### PR TITLE
Custom base URL for OpenAI API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+dist

--- a/src/api/AIService.ts
+++ b/src/api/AIService.ts
@@ -122,7 +122,7 @@ export class AIService {
     baseOpenAIApiUrl: string;
   }) {
     this.services.openai.updateApiKey(settings.openAIApiKey);
-    this.services.openai.updateBaseUrl(settings.baseOpenAIApiUrl);
+    this.services.openai.updateOpenAIBaseUrl(settings.baseOpenAIApiUrl);
     this.services.groq.updateApiKey(settings.groqAPIKey);
     this.services.openRouter.updateApiKey(settings.openRouterAPIKey);
     Object.values(this.services).forEach(service =>

--- a/src/api/AIService.ts
+++ b/src/api/AIService.ts
@@ -17,7 +17,7 @@ export class AIService {
     showgroqSetting: boolean;
     showlocalEndpointSetting: boolean;
     showopenRouterSetting: boolean;
-    baseOpenAIApiUrl: string;
+    baseOpenAIApiUrl?: string;
   };
 
   private constructor(settings: {
@@ -31,13 +31,13 @@ export class AIService {
     showgroqSetting: boolean;
     showlocalEndpointSetting: boolean;
     showopenRouterSetting: boolean;
-    baseOpenAIApiUrl: string;
+    baseOpenAIApiUrl?: string;
   }) {
     this.settings = settings;
     this.services = {
       openai: new UnifiedAIService(
         settings.openAIApiKey,
-        settings.baseOpenAIApiUrl,
+        settings.baseOpenAIApiUrl ?? 'https://api.openai.com/v1',
         'openai',
         { temperature: settings.temperature }
       ),
@@ -71,7 +71,7 @@ export class AIService {
       showgroqSetting: boolean;
       showlocalEndpointSetting: boolean;
       showopenRouterSetting: boolean;
-      baseOpenAIApiUrl: string;
+      baseOpenAIApiUrl?: string;
     },
     forceNewInstance: boolean = false
   ): Promise<AIService> {
@@ -101,7 +101,7 @@ export class AIService {
     apiEndpoint: string;
     localEndpoint?: string;
     temperature: number;
-    baseOpenAIApiUrl: string;
+    baseOpenAIApiUrl?: string;
   }) {
     this.updateApiKeysDebounced(settings);
   }
@@ -119,10 +119,10 @@ export class AIService {
     apiEndpoint: string;
     localEndpoint?: string;
     temperature: number;
-    baseOpenAIApiUrl: string;
+    baseOpenAIApiUrl?: string;
   }) {
     this.services.openai.updateApiKey(settings.openAIApiKey);
-    this.services.openai.updateOpenAIBaseUrl(settings.baseOpenAIApiUrl);
+    this.services.openai.updateOpenAIBaseUrl(settings.baseOpenAIApiUrl ?? 'https://api.openai.com/v1');
     this.services.groq.updateApiKey(settings.groqAPIKey);
     this.services.openRouter.updateApiKey(settings.openRouterAPIKey);
     Object.values(this.services).forEach(service =>

--- a/src/api/AIService.ts
+++ b/src/api/AIService.ts
@@ -17,7 +17,7 @@ export class AIService {
     showgroqSetting: boolean;
     showlocalEndpointSetting: boolean;
     showopenRouterSetting: boolean;
-    baseApiUrl: string;
+    baseOpenAIApiUrl: string;
   };
 
   private constructor(settings: {
@@ -31,13 +31,13 @@ export class AIService {
     showgroqSetting: boolean;
     showlocalEndpointSetting: boolean;
     showopenRouterSetting: boolean;
-    baseApiUrl: string;
+    baseOpenAIApiUrl: string;
   }) {
     this.settings = settings;
     this.services = {
       openai: new UnifiedAIService(
         settings.openAIApiKey,
-        settings.baseApiUrl,
+        settings.baseOpenAIApiUrl,
         'openai',
         { temperature: settings.temperature }
       ),
@@ -71,7 +71,7 @@ export class AIService {
       showgroqSetting: boolean;
       showlocalEndpointSetting: boolean;
       showopenRouterSetting: boolean;
-      baseApiUrl: string;
+      baseOpenAIApiUrl: string;
     },
     forceNewInstance: boolean = false
   ): Promise<AIService> {
@@ -101,7 +101,7 @@ export class AIService {
     apiEndpoint: string;
     localEndpoint?: string;
     temperature: number;
-    baseApiUrl: string;
+    baseOpenAIApiUrl: string;
   }) {
     this.updateApiKeysDebounced(settings);
   }
@@ -119,10 +119,10 @@ export class AIService {
     apiEndpoint: string;
     localEndpoint?: string;
     temperature: number;
-    baseApiUrl: string;
+    baseOpenAIApiUrl: string;
   }) {
     this.services.openai.updateApiKey(settings.openAIApiKey);
-    this.services.openai.updateBaseUrl(settings.baseApiUrl);
+    this.services.openai.updateBaseUrl(settings.baseOpenAIApiUrl);
     this.services.groq.updateApiKey(settings.groqAPIKey);
     this.services.openRouter.updateApiKey(settings.openRouterAPIKey);
     Object.values(this.services).forEach(service =>
@@ -235,10 +235,10 @@ export class AIService {
     return undefined;
   }
 
-  static async validateOpenAIApiKey(apiKey: string, baseApiUrl?: string): Promise<boolean> {
+  static async validateOpenAIApiKey(apiKey: string, baseOpenAIApiUrl?: string): Promise<boolean> {
     return UnifiedAIService.validateApiKey(
       apiKey,
-      baseApiUrl ?? 'https://api.openai.com/v1',
+      baseOpenAIApiUrl ?? 'https://api.openai.com/v1',
       'openai'
     );
   }

--- a/src/api/AIService.ts
+++ b/src/api/AIService.ts
@@ -17,6 +17,7 @@ export class AIService {
     showgroqSetting: boolean;
     showlocalEndpointSetting: boolean;
     showopenRouterSetting: boolean;
+    baseApiUrl: string;
   };
 
   private constructor(settings: {
@@ -30,12 +31,13 @@ export class AIService {
     showgroqSetting: boolean;
     showlocalEndpointSetting: boolean;
     showopenRouterSetting: boolean;
+    baseApiUrl: string;
   }) {
     this.settings = settings;
     this.services = {
       openai: new UnifiedAIService(
         settings.openAIApiKey,
-        'https://api.openai.com/v1',
+        settings.baseApiUrl,
         'openai',
         { temperature: settings.temperature }
       ),
@@ -69,6 +71,7 @@ export class AIService {
       showgroqSetting: boolean;
       showlocalEndpointSetting: boolean;
       showopenRouterSetting: boolean;
+      baseApiUrl: string;
     },
     forceNewInstance: boolean = false
   ): Promise<AIService> {
@@ -98,6 +101,7 @@ export class AIService {
     apiEndpoint: string;
     localEndpoint?: string;
     temperature: number;
+    baseApiUrl: string;
   }) {
     this.updateApiKeysDebounced(settings);
   }
@@ -115,8 +119,10 @@ export class AIService {
     apiEndpoint: string;
     localEndpoint?: string;
     temperature: number;
+    baseApiUrl: string;
   }) {
     this.services.openai.updateApiKey(settings.openAIApiKey);
+    this.services.openai.updateBaseUrl(settings.baseApiUrl);
     this.services.groq.updateApiKey(settings.groqAPIKey);
     this.services.openRouter.updateApiKey(settings.openRouterAPIKey);
     Object.values(this.services).forEach(service =>
@@ -229,10 +235,10 @@ export class AIService {
     return undefined;
   }
 
-  static async validateOpenAIApiKey(apiKey: string): Promise<boolean> {
+  static async validateOpenAIApiKey(apiKey: string, baseApiUrl?: string): Promise<boolean> {
     return UnifiedAIService.validateApiKey(
       apiKey,
-      'https://api.openai.com/v1',
+      baseApiUrl ?? 'https://api.openai.com/v1',
       'openai'
     );
   }
@@ -334,3 +340,4 @@ export class AIService {
     }
   }
 }
+

--- a/src/api/UnifiedAIService.ts
+++ b/src/api/UnifiedAIService.ts
@@ -27,6 +27,10 @@ export class UnifiedAIService implements AIServiceInterface {
     this.apiKey = apiKey;
   }
 
+  updateBaseUrl(baseUrl: string): void {
+    this.endpoint = baseUrl.endsWith('/v1') ? baseUrl : `${baseUrl}/v1`;
+  }
+
   async createChatCompletion(
     systemPrompt: string,
     userMessage: string,

--- a/src/api/UnifiedAIService.ts
+++ b/src/api/UnifiedAIService.ts
@@ -27,7 +27,7 @@ export class UnifiedAIService implements AIServiceInterface {
     this.apiKey = apiKey;
   }
 
-  updateBaseUrl(baseUrl: string): void {
+  updateOpenAIBaseUrl(baseUrl: string): void {
     this.endpoint = baseUrl.endsWith('/v1') ? baseUrl : `${baseUrl}/v1`;
   }
 

--- a/src/api/UnifiedAIService.ts
+++ b/src/api/UnifiedAIService.ts
@@ -28,6 +28,9 @@ export class UnifiedAIService implements AIServiceInterface {
   }
 
   updateOpenAIBaseUrl(baseUrl: string): void {
+    if (!baseUrl.startsWith('http://') && !baseUrl.startsWith('https://')) {
+      throw new Error('Invalid base URL. It must start with http:// or https://');
+    }
     this.endpoint = baseUrl.endsWith('/v1') ? baseUrl : `${baseUrl}/v1`;
   }
 

--- a/src/modules/brain/BrainModule.ts
+++ b/src/modules/brain/BrainModule.ts
@@ -100,7 +100,7 @@ export class BrainModule extends EventEmitter implements IGenerationModule {
       showgroqSetting,
       showlocalEndpointSetting,
       showopenRouterSetting,
-      baseApiUrl,
+      baseOpenAIApiUrl,
     } = this.settings;
     this._AIService = await AIService.getInstance({
       openAIApiKey,
@@ -113,7 +113,7 @@ export class BrainModule extends EventEmitter implements IGenerationModule {
       showgroqSetting,
       showlocalEndpointSetting,
       showopenRouterSetting,
-      baseApiUrl,
+      baseOpenAIApiUrl,
     });
   }
 
@@ -206,7 +206,7 @@ export class BrainModule extends EventEmitter implements IGenerationModule {
           showgroqSetting: this.settings.showgroqSetting,
           showlocalEndpointSetting: this.settings.showlocalEndpointSetting,
           showopenRouterSetting: this.settings.showopenRouterSetting,
-          baseApiUrl: this.settings.baseApiUrl,
+          baseOpenAIApiUrl: this.settings.baseOpenAIApiUrl,
         },
         true
       );

--- a/src/modules/brain/BrainModule.ts
+++ b/src/modules/brain/BrainModule.ts
@@ -100,6 +100,7 @@ export class BrainModule extends EventEmitter implements IGenerationModule {
       showgroqSetting,
       showlocalEndpointSetting,
       showopenRouterSetting,
+      baseApiUrl,
     } = this.settings;
     this._AIService = await AIService.getInstance({
       openAIApiKey,
@@ -112,6 +113,7 @@ export class BrainModule extends EventEmitter implements IGenerationModule {
       showgroqSetting,
       showlocalEndpointSetting,
       showopenRouterSetting,
+      baseApiUrl,
     });
   }
 
@@ -204,6 +206,7 @@ export class BrainModule extends EventEmitter implements IGenerationModule {
           showgroqSetting: this.settings.showgroqSetting,
           showlocalEndpointSetting: this.settings.showlocalEndpointSetting,
           showopenRouterSetting: this.settings.showopenRouterSetting,
+          baseApiUrl: this.settings.baseApiUrl,
         },
         true
       );

--- a/src/modules/brain/settings/BrainSettingTab.ts
+++ b/src/modules/brain/settings/BrainSettingTab.ts
@@ -46,7 +46,7 @@ export class BrainSettingTab extends PluginSettingTab {
       () => this.refreshTab()
     );
     endpointManager.renderEndpointSettings();
-    this.renderBaseApiUrlSetting();
+    this.renderbaseOpenAIApiUrlSetting();
     this.renderModelSettings();
     this.renderTemperatureSettings();
     this.renderPromptSettings();
@@ -60,21 +60,21 @@ export class BrainSettingTab extends PluginSettingTab {
       return false;
     }
   }
-  
-  private renderBaseApiUrlSetting(): void {
+
+  private renderbaseOpenAIApiUrlSetting(): void {
     new Setting(this.containerEl)
       .setName('OpenAI API Base URL')
       .setDesc('Set the base URL for OpenAI API calls. Leave blank to use the default.')
       .addText(text => text
         .setPlaceholder(BrainSettingTab.DEFAULT_API_URL)
-        .setValue(this.plugin.settings.baseApiUrl)
+        .setValue(this.plugin.settings.baseOpenAIApiUrl)
         .onChange(async (value) => {
           if (value && !this.isValidUrl(value)) {
             // Display an error message to the user
             new Notice('Invalid URL. Please enter a valid URL or leave blank for default.');
             return;
           }
-          this.plugin.settings.baseApiUrl = value || BrainSettingTab.DEFAULT_API_URL;
+          this.plugin.settings.baseOpenAIApiUrl = value || BrainSettingTab.DEFAULT_API_URL;
           await this.plugin.saveSettings();
         }));
   }

--- a/src/modules/brain/settings/BrainSettingTab.ts
+++ b/src/modules/brain/settings/BrainSettingTab.ts
@@ -44,9 +44,23 @@ export class BrainSettingTab extends PluginSettingTab {
       () => this.refreshTab()
     );
     endpointManager.renderEndpointSettings();
+    this.renderBaseApiUrlSetting();
     this.renderModelSettings();
     this.renderTemperatureSettings();
     this.renderPromptSettings();
+  }
+
+  private renderBaseApiUrlSetting(): void {
+    new Setting(this.containerEl)
+      .setName('OpenAI API Base URL')
+      .setDesc('Set the base URL for OpenAI API calls. Leave blank to use the default.')
+      .addText(text => text
+        .setPlaceholder('https://api.openai.com/v1')
+        .setValue(this.plugin.settings.baseApiUrl)
+        .onChange(async (value) => {
+          this.plugin.settings.baseApiUrl = value || 'https://api.openai.com/v1';
+          await this.plugin.saveSettings();
+        }));
   }
 
   private renderModelSettings(): void {

--- a/src/modules/brain/settings/BrainSettingTab.ts
+++ b/src/modules/brain/settings/BrainSettingTab.ts
@@ -46,7 +46,6 @@ export class BrainSettingTab extends PluginSettingTab {
       () => this.refreshTab()
     );
     endpointManager.renderEndpointSettings();
-    this.renderbaseOpenAIApiUrlSetting();
     this.renderModelSettings();
     this.renderTemperatureSettings();
     this.renderPromptSettings();
@@ -59,24 +58,6 @@ export class BrainSettingTab extends PluginSettingTab {
     } catch {
       return false;
     }
-  }
-
-  private renderbaseOpenAIApiUrlSetting(): void {
-    new Setting(this.containerEl)
-      .setName('OpenAI API Base URL')
-      .setDesc('Set the base URL for OpenAI API calls. Leave blank to use the default.')
-      .addText(text => text
-        .setPlaceholder(BrainSettingTab.DEFAULT_API_URL)
-        .setValue(this.plugin.settings.baseOpenAIApiUrl)
-        .onChange(async (value) => {
-          if (value && !this.isValidUrl(value)) {
-            // Display an error message to the user
-            new Notice('Invalid URL. Please enter a valid URL or leave blank for default.');
-            return;
-          }
-          this.plugin.settings.baseOpenAIApiUrl = value || BrainSettingTab.DEFAULT_API_URL;
-          await this.plugin.saveSettings();
-        }));
   }
 
   private renderModelSettings(): void {
@@ -105,3 +86,4 @@ export class BrainSettingTab extends PluginSettingTab {
     this.display();
   }
 }
+

--- a/src/modules/brain/settings/BrainSettings.ts
+++ b/src/modules/brain/settings/BrainSettings.ts
@@ -14,6 +14,7 @@ export interface BrainSettings {
   openRouterAPIKey: string;
   showopenRouterSetting: boolean;
   favoritedModels: string[];
+  baseApiUrl: string;
 }
 
 export const DEFAULT_BRAIN_SETTINGS: BrainSettings = {
@@ -67,4 +68,5 @@ Rules:
   openRouterAPIKey: '',
   showopenRouterSetting: true,
   favoritedModels: [],
+  baseApiUrl: 'https://api.openai.com/v1',
 };

--- a/src/modules/brain/settings/BrainSettings.ts
+++ b/src/modules/brain/settings/BrainSettings.ts
@@ -70,3 +70,4 @@ Rules:
   favoritedModels: [],
   baseOpenAIApiUrl: 'https://api.openai.com/v1',
 };
+

--- a/src/modules/brain/settings/BrainSettings.ts
+++ b/src/modules/brain/settings/BrainSettings.ts
@@ -14,7 +14,7 @@ export interface BrainSettings {
   openRouterAPIKey: string;
   showopenRouterSetting: boolean;
   favoritedModels: string[];
-  baseApiUrl: string;
+  baseOpenAIApiUrl: string;
 }
 
 export const DEFAULT_BRAIN_SETTINGS: BrainSettings = {
@@ -68,5 +68,5 @@ Rules:
   openRouterAPIKey: '',
   showopenRouterSetting: true,
   favoritedModels: [],
-  baseApiUrl: 'https://api.openai.com/v1',
+  baseOpenAIApiUrl: 'https://api.openai.com/v1',
 };

--- a/src/modules/brain/settings/EndpointManager.ts
+++ b/src/modules/brain/settings/EndpointManager.ts
@@ -100,14 +100,6 @@ export class EndpointManager {
       },
     ];
 
-    // Render baseOpenAIApiUrl setting
-    this.renderAPISetting({
-      name: 'OpenAI Base URL',
-      settingKey: 'baseOpenAIApiUrl',
-      validateFunction: () => Promise.resolve(true), // No validation needed for base URL
-      placeholder: 'https://api.openai.com/v1',
-    });
-
     apiProviders.forEach(provider => {
       if (
         this.plugin.settings[
@@ -117,6 +109,16 @@ export class EndpointManager {
         this.renderAPISetting(provider);
       }
     });
+
+    // Render baseOpenAIApiUrl setting only if OpenAI endpoint is enabled
+    if (this.plugin.settings.showopenAISetting) {
+      this.renderAPISetting({
+        name: 'OpenAI Base URL',
+        settingKey: 'baseOpenAIApiUrl',
+        validateFunction: () => Promise.resolve(true), // No validation needed for base URL
+        placeholder: 'https://api.openai.com/v1',
+      });
+    }
   }
 
   private renderAPISetting(provider: {
@@ -308,3 +310,4 @@ export class EndpointManager {
     return span;
   }
 }
+

--- a/src/modules/brain/settings/EndpointManager.ts
+++ b/src/modules/brain/settings/EndpointManager.ts
@@ -2,7 +2,7 @@ import { Setting, TextComponent, ToggleComponent } from 'obsidian';
 import { BrainModule } from '../BrainModule';
 import { AIService } from '../../../api/AIService';
 
-type ValidateFunction = (value: string, baseApiUrl?: string) => Promise<boolean>;
+type ValidateFunction = (value: string, baseOpenAIApiUrl?: string) => Promise<boolean>;
 
 interface APIProvider {
   name: string;
@@ -77,7 +77,7 @@ export class EndpointManager {
         name: 'OpenAI',
         settingKey: 'openAIApiKey',
         showSettingKey: 'showopenAISetting',
-        validateFunction: (apiKey: string, baseApiUrl?: string) => AIService.validateOpenAIApiKey(apiKey, baseApiUrl),
+        validateFunction: (apiKey: string, baseOpenAIApiUrl?: string) => AIService.validateOpenAIApiKey(apiKey, baseOpenAIApiUrl),
       },
       {
         name: 'Groq',
@@ -100,10 +100,10 @@ export class EndpointManager {
       },
     ];
 
-    // Render baseApiUrl setting
+    // Render baseOpenAIApiUrl setting
     this.renderAPISetting({
       name: 'OpenAI Base URL',
-      settingKey: 'baseApiUrl',
+      settingKey: 'baseOpenAIApiUrl',
       validateFunction: () => Promise.resolve(true), // No validation needed for base URL
       placeholder: 'https://api.openai.com/v1',
     });
@@ -122,7 +122,7 @@ export class EndpointManager {
   private renderAPISetting(provider: {
     name: string;
     settingKey: keyof BrainModule['settings'];
-    validateFunction: (value: string, baseApiUrl?: string) => Promise<boolean>;
+    validateFunction: (value: string, baseOpenAIApiUrl?: string) => Promise<boolean>;
     placeholder?: string;
   }): void {
     let apiSettingTextComponent: TextComponent;
@@ -241,7 +241,7 @@ export class EndpointManager {
       const validationPromise = (async () => {
         switch (provider.name) {
           case 'OpenAI':
-            return await AIService.validateOpenAIApiKey(value, this.plugin.settings.baseApiUrl);
+            return await AIService.validateOpenAIApiKey(value, this.plugin.settings.baseOpenAIApiUrl);
           case 'Groq':
             return await AIService.validateGroqAPIKey(value);
           case 'OpenRouter':
@@ -283,7 +283,7 @@ export class EndpointManager {
       showgroqSetting: this.plugin.settings.showgroqSetting,
       showlocalEndpointSetting: this.plugin.settings.showlocalEndpointSetting,
       showopenRouterSetting: this.plugin.settings.showopenRouterSetting,
-      baseApiUrl: this.plugin.settings.baseApiUrl,
+      baseOpenAIApiUrl: this.plugin.settings.baseOpenAIApiUrl,
     });
   }
 

--- a/src/modules/brain/settings/EndpointManager.ts
+++ b/src/modules/brain/settings/EndpointManager.ts
@@ -110,12 +110,10 @@ export class EndpointManager {
       }
     });
 
-    // Render baseOpenAIApiUrl setting only if OpenAI endpoint is enabled
     if (this.plugin.settings.showopenAISetting) {
-      this.renderAPISetting({
+      this.renderSimpleAPISetting({
         name: 'OpenAI Base URL',
         settingKey: 'baseOpenAIApiUrl',
-        validateFunction: () => Promise.resolve(true), // No validation needed for base URL
         placeholder: 'https://api.openai.com/v1',
       });
     }
@@ -128,8 +126,8 @@ export class EndpointManager {
     placeholder?: string;
   }): void {
     let apiSettingTextComponent: TextComponent;
-
-    new Setting(this.containerEl)
+  
+    const setting = new Setting(this.containerEl)
       .setName(
         `${provider.name} ${provider.name === 'Local' ? 'Endpoint' : provider.name === 'OpenAI Base URL' ? '' : 'API Key'}`
       )
@@ -151,7 +149,7 @@ export class EndpointManager {
               provider.settingKey
             );
           });
-
+  
         if (provider.name !== 'Local' && provider.name !== 'OpenAI Base URL') {
           text.inputEl.type = 'password';
           text.inputEl.addEventListener('focus', () => {
@@ -161,7 +159,7 @@ export class EndpointManager {
             text.inputEl.type = 'password';
           });
         }
-
+  
         this.validateSettingAndUpdateStatus(
           this.plugin.settings[provider.settingKey] as string,
           apiSettingTextComponent,
@@ -184,6 +182,24 @@ export class EndpointManager {
             provider.name === 'Local' ? 'Endpoint' : provider.name === 'OpenAI Base URL' ? 'Base URL' : 'API Key'
           } and Refresh AI Service`
         );
+      });
+  }
+
+  private renderSimpleAPISetting(provider: {
+    name: string;
+    settingKey: keyof BrainModule['settings'];
+    placeholder?: string;
+  }): void {
+    new Setting(this.containerEl)
+      .setName(provider.name)
+      .setDesc(`Enter your ${provider.name}`)
+      .addText(text => {
+        text
+          .setPlaceholder(provider.placeholder || 'URL')
+          .setValue(this.plugin.settings[provider.settingKey] as string)
+          .onChange((value: string) => {
+            this.saveImmediately(value, provider.settingKey);
+          });
       });
   }
 
@@ -250,8 +266,6 @@ export class EndpointManager {
             return await AIService.validateOpenRouterApiKey(value);
           case 'Local':
             return await AIService.validateLocalEndpoint(value);
-          case 'OpenAI Base URL':
-            return true; // No validation needed for base URL
           default:
             return false;
         }


### PR DESCRIPTION
This pull request introduces support for configuring a custom base URL for the OpenAI API. This allows users to specify an endpoint different from the default https://api.openai.com/v1. 
The primary motivation for this change is to enhance flexibility and support scenarios where the API might be hosted on a custom server or a different URL.

## Linked Issues
- resolve #59 
- resolve #16 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a setting for users to specify the base URL for OpenAI API calls, enhancing configurability.
  - Added a method to dynamically update the API endpoint based on user-defined settings.
  
- **Improvements**
  - Enhanced the `BrainModule` and `AIService` to support a customizable base API URL.
  - Updated settings management to include flexible validation for API URLs.

- **Chores**
  - Added a `.gitignore` file to keep the repository clean from unnecessary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->