### PR TITLE
fix(chat): four chat-error UX gaps + persistent provider disconnect

### DIFF
--- a/src/settings/ProvidersTabContent.ts
+++ b/src/settings/ProvidersTabContent.ts
@@ -175,6 +175,27 @@ async function refreshProviderList(
   }
 }
 
+// Optimistically flip the in-memory record for a provider row to the
+// disconnected state so a synchronous rerender reflects the click immediately.
+// The async clear + refreshProviderList still runs afterwards and will
+// reconcile against the canonical state.
+function optimisticDisconnectProviderRow(
+  state: TabState,
+  provider: string,
+): void {
+  for (const providerState of state.providers) {
+    if (providerState.record.provider !== provider) continue;
+    providerState.record = {
+      ...providerState.record,
+      hasAnyAuth: false,
+      hasStoredCredential: false,
+      source: "none",
+      credentialType: "none",
+      oauthExpiresAt: null,
+    };
+  }
+}
+
 // ─── Render ─────────────────────────────────────────────────────────────────
 
 function renderProvidersList(
@@ -334,6 +355,7 @@ function renderProviderRow(
     });
     disconnectBtn.disabled = state.actionRunning;
     disconnectBtn.addEventListener("click", async () => {
+      optimisticDisconnectProviderRow(state, record.provider);
       state.actionRunning = true;
       rerender();
       try {
@@ -345,6 +367,7 @@ function renderProviderRow(
         new Notice(
           `Failed to disconnect ${label}: ${error instanceof Error ? error.message : String(error)}`
         );
+        await refreshProviderList(state, plugin);
       } finally {
         state.actionRunning = false;
         rerender();
@@ -358,6 +381,7 @@ function renderProviderRow(
     });
     disconnectBtn.disabled = state.actionRunning;
     disconnectBtn.addEventListener("click", async () => {
+      optimisticDisconnectProviderRow(state, record.provider);
       state.actionRunning = true;
       rerender();
       try {
@@ -369,6 +393,7 @@ function renderProviderRow(
         new Notice(
           `Failed to disconnect ${label}: ${error instanceof Error ? error.message : String(error)}`
         );
+        await refreshProviderList(state, plugin);
       } finally {
         state.actionRunning = false;
         rerender();

--- a/src/settings/ProvidersTabContent.ts
+++ b/src/settings/ProvidersTabContent.ts
@@ -196,6 +196,31 @@ function optimisticDisconnectProviderRow(
   }
 }
 
+async function performProviderDisconnect(
+  state: TabState,
+  plugin: SystemSculptSettingTab["plugin"],
+  provider: string,
+  label: string,
+  rerender: () => void,
+): Promise<void> {
+  optimisticDisconnectProviderRow(state, provider);
+  state.actionRunning = true;
+  rerender();
+  try {
+    const { clearStudioPiProviderAuth } = await loadStudioPiAuthStorageModule();
+    await clearStudioPiProviderAuth(provider, { plugin });
+    new Notice(`Disconnected ${label}.`);
+  } catch (error) {
+    new Notice(
+      `Failed to disconnect ${label}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    await refreshProviderList(state, plugin);
+    state.actionRunning = false;
+    rerender();
+  }
+}
+
 // ─── Render ─────────────────────────────────────────────────────────────────
 
 function renderProvidersList(
@@ -354,50 +379,17 @@ function renderProviderRow(
       text: "Disconnect",
     });
     disconnectBtn.disabled = state.actionRunning;
-    disconnectBtn.addEventListener("click", async () => {
-      optimisticDisconnectProviderRow(state, record.provider);
-      state.actionRunning = true;
-      rerender();
-      try {
-        const { clearStudioPiProviderAuth } = await loadStudioPiAuthStorageModule();
-        await clearStudioPiProviderAuth(record.provider, { plugin });
-        new Notice(`Disconnected ${label}.`);
-        await refreshProviderList(state, plugin);
-      } catch (error) {
-        new Notice(
-          `Failed to disconnect ${label}: ${error instanceof Error ? error.message : String(error)}`
-        );
-        await refreshProviderList(state, plugin);
-      } finally {
-        state.actionRunning = false;
-        rerender();
-      }
+    disconnectBtn.addEventListener("click", () => {
+      void performProviderDisconnect(state, plugin, record.provider, label, rerender);
     });
   } else if (connected) {
-    // Disconnect button
     const disconnectBtn = actions.createEl("button", {
       cls: "ss-provider-row__btn ss-provider-row__btn--disconnect",
       text: "Disconnect",
     });
     disconnectBtn.disabled = state.actionRunning;
-    disconnectBtn.addEventListener("click", async () => {
-      optimisticDisconnectProviderRow(state, record.provider);
-      state.actionRunning = true;
-      rerender();
-      try {
-        const { clearStudioPiProviderAuth } = await loadStudioPiAuthStorageModule();
-        await clearStudioPiProviderAuth(record.provider, { plugin });
-        new Notice(`Disconnected ${label}.`);
-        await refreshProviderList(state, plugin);
-      } catch (error) {
-        new Notice(
-          `Failed to disconnect ${label}: ${error instanceof Error ? error.message : String(error)}`
-        );
-        await refreshProviderList(state, plugin);
-      } finally {
-        state.actionRunning = false;
-        rerender();
-      }
+    disconnectBtn.addEventListener("click", () => {
+      void performProviderDisconnect(state, plugin, record.provider, label, rerender);
     });
   } else {
     // Connect button (toggle expand)

--- a/src/studio/piAuth/StudioPiAuthStorage.ts
+++ b/src/studio/piAuth/StudioPiAuthStorage.ts
@@ -13,6 +13,7 @@ import {
   withPiDesktopFetchShim,
 } from "../../services/pi/PiSdkDesktopSupport";
 import type { PiAuthStorageInstance } from "../../services/pi/PiSdkAuthStorage";
+import { resolvePiAuthPath } from "../../services/pi/PiSdkStoragePaths";
 import type {
   StudioPiAuthCredentialType,
   StudioPiAuthState,
@@ -340,7 +341,6 @@ export async function loginStudioPiProviderOAuth(
   try {
     const credential = storage.get(providerId);
     if (credential) {
-      const { resolvePiAuthPath } = await import("../../services/pi/PiSdkStoragePaths");
       const authPath = resolvePiAuthPath(options.plugin);
       if (authPath) {
         const fs = require("fs");
@@ -395,18 +395,58 @@ export async function clearStudioPiProviderAuth(
   const provider = normalizeStudioPiProviderHint(providerHint);
   if (!provider) throw new Error("Select a valid provider before clearing credentials.");
   await clearPluginStoredApiKey(provider, context.plugin);
+
   const storage = tryGetAuthStorage(context);
-  if (!storage) {
-    return;
+  if (storage) {
+    try {
+      storage.remove(provider);
+    } catch (err) {
+      console.warn(
+        `[StudioPiAuthStorage] SDK storage.remove failed for ${provider}; falling back to direct auth.json rewrite.`,
+        err,
+      );
+    }
   }
+
+  // The SDK's FileAuthStorageBackend uses proper-lockfile, which can fail
+  // silently in Obsidian's Electron renderer — and the in-memory fallback in
+  // createBundledPiAuthStorage explicitly sacrifices write-back. Either path
+  // leaves auth.json untouched, so a fresh refreshProviderList() re-reads the
+  // old credential and the UI pops back to "Disconnect". Rewriting auth.json
+  // directly is the only way to guarantee the credential is actually gone.
+  rewriteAuthJsonWithoutProvider(provider, context.plugin);
+}
+
+function rewriteAuthJsonWithoutProvider(
+  provider: string,
+  plugin?: SystemSculptPlugin | null,
+): void {
+  if (!Platform.isDesktopApp) return;
+  const authPath = resolvePiAuthPath(plugin);
+  if (!authPath) return;
   try {
-    storage.remove(provider);
+    const fs = require("fs");
+    if (!fs.existsSync(authPath)) return;
+    const rawContent = fs.readFileSync(authPath, "utf-8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawContent);
+    } catch {
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
+    const data = parsed as Record<string, unknown>;
+    if (!(provider in data)) return;
+    delete data[provider];
+    fs.writeFileSync(authPath, JSON.stringify(data, null, 2), "utf-8");
+    try {
+      fs.chmodSync(authPath, 0o600);
+    } catch {
+      // chmod is best-effort — some filesystems (e.g. exFAT) reject mode changes.
+    }
   } catch (err) {
-    // Plugin-settings fallback is already cleared above. Log a warning so the
-    // discrepancy is visible: resolveProviderApiKey prefers Pi storage, so a
-    // stale entry there could shadow the cleared plugin-settings value.
     console.warn(
-      `[StudioPiAuthStorage] Failed to remove ${provider} from Pi auth storage; plugin-settings entry was cleared but Pi storage may retain stale credentials.`,
+      `[StudioPiAuthStorage] Direct fs rewrite of auth.json failed for ${provider}.`,
       err,
     );
   }

--- a/src/studio/piAuth/StudioPiAuthStorage.ts
+++ b/src/studio/piAuth/StudioPiAuthStorage.ts
@@ -334,35 +334,23 @@ export async function loginStudioPiProviderOAuth(
     });
   });
 
-  // After successful OAuth login, ensure the credential is persisted to auth.json.
-  // The SDK's persistProviderChange uses proper-lockfile which can silently fail
-  // in Electron. As a safety net, read the credential from the in-memory storage
-  // and write auth.json directly if the SDK's persist was lost.
+  // The SDK's proper-lockfile-backed persist can fail silently in Electron;
+  // mirror the credential to auth.json directly so login state survives a
+  // restart even when the SDK's write was lost.
   try {
     const credential = storage.get(providerId);
     if (credential) {
-      const authPath = resolvePiAuthPath(options.plugin);
-      if (authPath) {
-        const fs = require("fs");
-        const path = require("path");
-        const dir = path.dirname(authPath);
-        if (!fs.existsSync(dir)) {
-          fs.mkdirSync(dir, { recursive: true });
-        }
-        let existing: Record<string, unknown> = {};
-        try {
-          if (fs.existsSync(authPath)) {
-            existing = JSON.parse(fs.readFileSync(authPath, "utf-8"));
-          }
-        } catch {
-          // Corrupt auth.json — start fresh so the new credential is not lost.
-        }
-        existing[providerId] = credential;
-        fs.writeFileSync(authPath, JSON.stringify(existing, null, 2), "utf-8");
-      }
+      mutateAuthJsonFile(
+        options.plugin,
+        (data) => {
+          data[providerId] = credential;
+          return data;
+        },
+        { ensureDir: true, logLabel: `login ${providerId}` },
+      );
     }
   } catch {
-    // Best-effort — the login itself succeeded even if disk persist fails.
+    // Best-effort — login itself succeeded even if the disk mirror failed.
   }
 }
 
@@ -408,37 +396,56 @@ export async function clearStudioPiProviderAuth(
     }
   }
 
-  // The SDK's FileAuthStorageBackend uses proper-lockfile, which can fail
-  // silently in Obsidian's Electron renderer — and the in-memory fallback in
-  // createBundledPiAuthStorage explicitly sacrifices write-back. Either path
-  // leaves auth.json untouched, so a fresh refreshProviderList() re-reads the
-  // old credential and the UI pops back to "Disconnect". Rewriting auth.json
-  // directly is the only way to guarantee the credential is actually gone.
-  rewriteAuthJsonWithoutProvider(provider, context.plugin);
+  // The SDK's proper-lockfile path silently no-ops writes in Electron's
+  // renderer (and the inMemory fallback explicitly sacrifices write-back), so
+  // refreshProviderList would read the stale credential right back. Rewrite
+  // auth.json directly to guarantee the credential is actually gone.
+  mutateAuthJsonFile(
+    context.plugin,
+    (data) => {
+      if (!(provider in data)) return null;
+      delete data[provider];
+      return data;
+    },
+    { logLabel: `clear ${provider}` },
+  );
 }
 
-function rewriteAuthJsonWithoutProvider(
-  provider: string,
-  plugin?: SystemSculptPlugin | null,
+function mutateAuthJsonFile(
+  plugin: SystemSculptPlugin | null | undefined,
+  mutator: (data: Record<string, unknown>) => Record<string, unknown> | null,
+  options: { ensureDir?: boolean; logLabel: string },
 ): void {
   if (!Platform.isDesktopApp) return;
   const authPath = resolvePiAuthPath(plugin);
   if (!authPath) return;
   try {
     const fs = require("fs");
-    if (!fs.existsSync(authPath)) return;
-    const rawContent = fs.readFileSync(authPath, "utf-8");
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(rawContent);
-    } catch {
-      return;
+    if (options.ensureDir) {
+      const path = require("path");
+      const dir = path.dirname(authPath);
+      try {
+        fs.mkdirSync(dir, { recursive: true });
+      } catch {
+        // Directory already exists or cannot be created — let readFile/writeFile error surface below.
+      }
     }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
-    const data = parsed as Record<string, unknown>;
-    if (!(provider in data)) return;
-    delete data[provider];
-    fs.writeFileSync(authPath, JSON.stringify(data, null, 2), "utf-8");
+    let existing: Record<string, unknown> = {};
+    try {
+      const rawContent = fs.readFileSync(authPath, "utf-8");
+      const parsed = JSON.parse(rawContent);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        existing = parsed as Record<string, unknown>;
+      }
+    } catch (err: any) {
+      if (err?.code !== "ENOENT") {
+        // Corrupt JSON or read failure — start from an empty object so the
+        // mutator can still write a fresh file rather than losing all state.
+      }
+    }
+    const next = mutator(existing);
+    if (!next) return;
+    fs.writeFileSync(authPath, JSON.stringify(next, null, 2), "utf-8");
     try {
       fs.chmodSync(authPath, 0o600);
     } catch {
@@ -446,7 +453,7 @@ function rewriteAuthJsonWithoutProvider(
     }
   } catch (err) {
     console.warn(
-      `[StudioPiAuthStorage] Direct fs rewrite of auth.json failed for ${provider}.`,
+      `[StudioPiAuthStorage] Direct fs auth.json mutate failed (${options.logLabel}).`,
       err,
     );
   }

--- a/src/studio/piAuth/__tests__/studio-pi-auth-storage-fetch-shim.test.ts
+++ b/src/studio/piAuth/__tests__/studio-pi-auth-storage-fetch-shim.test.ts
@@ -6,6 +6,12 @@ describe("StudioPiAuthStorage fetch shim integration", () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    // Ensure any previous test's doMock calls do not bleed into this one.
+    // jest.resetModules() clears the module cache but not the doMock registry.
+    jest.dontMock("fs");
+    jest.dontMock("../../../services/pi/PiSdkStoragePaths");
+    jest.dontMock("../../../services/pi/PiSdkDesktopSupport");
+    jest.dontMock("../../../services/pi/PiSdkAuthStorage");
     Object.defineProperty(Platform, "isDesktopApp", {
       configurable: true,
       value: true,
@@ -259,6 +265,109 @@ describe("StudioPiAuthStorage fetch shim integration", () => {
     });
 
     await expect(resolveStudioPiProviderApiKey!("openrouter", { plugin })).resolves.toBeNull();
+  });
+
+  it("rewrites auth.json directly when disconnecting to bypass proper-lockfile silent writes", async () => {
+    const initialAuthJson = {
+      "openai-codex": {
+        type: "oauth",
+        tokens: { access: "tok-abc", refresh: "tok-xyz" },
+        expires: 1700000000000,
+      },
+      anthropic: {
+        type: "oauth",
+        tokens: { access: "claude-tok" },
+      },
+    };
+
+    const fsState = {
+      content: JSON.stringify(initialAuthJson, null, 2),
+      writes: [] as Array<{ path: string; content: string }>,
+    };
+
+    jest.doMock("fs", () => ({
+      existsSync: jest.fn((_path: string) => true),
+      readFileSync: jest.fn((_path: string, _encoding: string) => fsState.content),
+      writeFileSync: jest.fn((path: string, content: string) => {
+        fsState.writes.push({ path, content });
+        fsState.content = content;
+      }),
+      chmodSync: jest.fn(),
+    }));
+
+    jest.doMock("../../../services/pi/PiSdkStoragePaths", () => ({
+      resolvePiAuthPath: jest.fn(() => "/fake/vault/.systemsculpt/pi-agent/auth.json"),
+    }));
+
+    const storageRemove = jest.fn(() => {
+      // Simulate the SDK's silent-no-op: remove returns cleanly but nothing is
+      // written to disk, mirroring the proper-lockfile failure path in Electron.
+    });
+    jest.doMock("../../../services/pi/PiSdkDesktopSupport", () => ({
+      createPiAuthStorage: jest.fn(() => ({ remove: storageRemove })),
+      withPiDesktopFetchShim: jest.fn(async (callback: () => Promise<unknown>) => await callback()),
+    }));
+
+    let clearStudioPiProviderAuth: typeof import("../StudioPiAuthStorage").clearStudioPiProviderAuth;
+    jest.isolateModules(() => {
+      ({ clearStudioPiProviderAuth } = require("../StudioPiAuthStorage"));
+    });
+
+    const plugin = {
+      settings: { customProviders: [] },
+      getSettingsManager: () => ({
+        updateSettings: jest.fn(async () => {}),
+      }),
+    } as any;
+
+    await clearStudioPiProviderAuth!("openai-codex", { plugin });
+
+    expect(storageRemove).toHaveBeenCalledWith("openai-codex");
+    expect(fsState.writes).toHaveLength(1);
+    const [write] = fsState.writes;
+    expect(write.path).toBe("/fake/vault/.systemsculpt/pi-agent/auth.json");
+    const parsed = JSON.parse(write.content);
+    expect(parsed).not.toHaveProperty("openai-codex");
+    expect(parsed).toHaveProperty("anthropic");
+  });
+
+  it("skips direct fs rewrite when the provider is already absent from auth.json", async () => {
+    const fsState = {
+      content: JSON.stringify({ anthropic: { type: "oauth" } }, null, 2),
+      writes: [] as Array<{ path: string; content: string }>,
+    };
+
+    jest.doMock("fs", () => ({
+      existsSync: jest.fn(() => true),
+      readFileSync: jest.fn(() => fsState.content),
+      writeFileSync: jest.fn((path: string, content: string) => {
+        fsState.writes.push({ path, content });
+      }),
+      chmodSync: jest.fn(),
+    }));
+
+    jest.doMock("../../../services/pi/PiSdkStoragePaths", () => ({
+      resolvePiAuthPath: jest.fn(() => "/fake/vault/.systemsculpt/pi-agent/auth.json"),
+    }));
+
+    jest.doMock("../../../services/pi/PiSdkDesktopSupport", () => ({
+      createPiAuthStorage: jest.fn(() => ({ remove: jest.fn() })),
+      withPiDesktopFetchShim: jest.fn(async (callback: () => Promise<unknown>) => await callback()),
+    }));
+
+    let clearStudioPiProviderAuth: typeof import("../StudioPiAuthStorage").clearStudioPiProviderAuth;
+    jest.isolateModules(() => {
+      ({ clearStudioPiProviderAuth } = require("../StudioPiAuthStorage"));
+    });
+
+    await clearStudioPiProviderAuth!("openai-codex", {
+      plugin: {
+        settings: { customProviders: [] },
+        getSettingsManager: () => ({ updateSettings: jest.fn(async () => {}) }),
+      } as any,
+    });
+
+    expect(fsState.writes).toHaveLength(0);
   });
 
   it("uses plugin-stored API keys in inventory records when auth storage is unavailable", async () => {

--- a/src/studio/piAuth/__tests__/studio-pi-auth-storage-fetch-shim.test.ts
+++ b/src/studio/piAuth/__tests__/studio-pi-auth-storage-fetch-shim.test.ts
@@ -6,8 +6,8 @@ describe("StudioPiAuthStorage fetch shim integration", () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
-    // Ensure any previous test's doMock calls do not bleed into this one.
-    // jest.resetModules() clears the module cache but not the doMock registry.
+    // jest.resetModules() clears the cache but not the doMock registry, so
+    // un-register module mocks each test or fs/path stubs leak.
     jest.dontMock("fs");
     jest.dontMock("../../../services/pi/PiSdkStoragePaths");
     jest.dontMock("../../../services/pi/PiSdkDesktopSupport");

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -25,6 +25,7 @@ import type { ChatExportResult } from "./export/ChatExportTypes";
 import { removeGroupIfEmpty } from "./utils/MessageGrouping";
 import { classifyQuotaExceededError } from "./utils/quotaError";
 import { classifyStreamError } from "./utils/streamError";
+import { ChatErrorModal } from "./modals/ChatErrorModal";
 import type { ToolCall } from "../../types/toolCalls";
 import { tryCopyToClipboard } from "../../utils/clipboard";
 import { resolveAbsoluteVaultPath } from "../../utils/vaultPathUtils";
@@ -551,18 +552,24 @@ export class ChatView extends ItemView {
         return;
       }
 
-      new Notice(
-        "Usage quota is exhausted for your SystemSculpt account. Add credits or wait for the next reset.",
-        10000
-      );
+      await this.resetFailedAssistantTurn();
+      if (!automationRequestActive) {
+        new ChatErrorModal({
+          app: this.app,
+          title: "Usage limit reached",
+          icon: "alert-octagon",
+          message:
+            "Usage quota is exhausted for your SystemSculpt account. Add credits or wait for the next reset to continue using this provider.",
+          primaryActionLabel: "Open Account",
+          onPrimaryAction: () => this.openSetupTab("account"),
+        }).open();
+      }
+      return;
     }
 
-    const shouldRecoverFromQuotaBySwitching =
-      !!quotaClassification && !quotaClassification.isTransientRateLimit;
-    
     if (
       error instanceof SystemSculptError &&
-      (error.code === "MODEL_UNAVAILABLE" || error.code === "MODEL_REQUEST_ERROR" || shouldRecoverFromQuotaBySwitching)
+      (error.code === "MODEL_UNAVAILABLE" || error.code === "MODEL_REQUEST_ERROR")
     ) {
       const isManagedSelection = this.isManagedSelectedModel();
 
@@ -577,21 +584,73 @@ export class ChatView extends ItemView {
       }
 
       await this.resetFailedAssistantTurn();
-      new Notice(
-        isManagedSelection
-          ? "SystemSculpt could not complete this request right now. Please try again in a moment or check Account for license and account status."
-          : "The selected Pi model could not complete this request right now. Please try again in a moment or check Providers to confirm the selected model and provider are configured.",
-        10000
-      );
+      if (!automationRequestActive) {
+        new ChatErrorModal({
+          app: this.app,
+          title: isManagedSelection ? "SystemSculpt is unavailable" : "Selected model is unavailable",
+          icon: "alert-triangle",
+          message: isManagedSelection
+            ? "SystemSculpt could not complete this request right now. Try again in a moment, or check Account for license and account status."
+            : "The selected Pi model could not complete this request right now. Try again in a moment, or check Providers to confirm the selected model and provider are configured.",
+          primaryActionLabel: isManagedSelection ? "Open Account" : "Open Providers",
+          onPrimaryAction: () =>
+            this.openSetupTab(isManagedSelection ? "account" : "providers"),
+        }).open();
+      }
     } else {
       // Catch-all: classify the error and always show feedback + clean up.
       await this.resetFailedAssistantTurn();
 
       if (!automationRequestActive) {
         const classification = classifyStreamError(error);
-        const duration = classification.kind === "rate_limit" ? 12000 : 10000;
-        new Notice(classification.userMessage, duration);
+        // Transient/auto-recovering categories stay as small Notices so they
+        // don't interrupt the user. Everything else surfaces as a modal so the
+        // user can read the message at their own pace and dismiss it.
+        if (classification.kind === "rate_limit" || classification.kind === "network") {
+          const duration = classification.kind === "rate_limit" ? 12000 : 10000;
+          new Notice(classification.userMessage, duration);
+        } else {
+          new ChatErrorModal({
+            app: this.app,
+            title: this.titleForStreamErrorKind(classification.kind),
+            icon: this.iconForStreamErrorKind(classification.kind),
+            message: classification.userMessage,
+            primaryActionLabel: classification.kind === "auth" ? "Open Providers" : undefined,
+            onPrimaryAction:
+              classification.kind === "auth"
+                ? () => this.openSetupTab("providers")
+                : undefined,
+          }).open();
+        }
       }
+    }
+  }
+
+  private titleForStreamErrorKind(kind: string): string {
+    switch (kind) {
+      case "auth":
+        return "Authentication required";
+      case "model_not_found":
+        return "Model not available";
+      case "server":
+        return "Provider error";
+      case "unknown":
+      default:
+        return "Chat request failed";
+    }
+  }
+
+  private iconForStreamErrorKind(kind: string): string {
+    switch (kind) {
+      case "auth":
+        return "key-round";
+      case "model_not_found":
+        return "help-circle";
+      case "server":
+        return "server-crash";
+      case "unknown":
+      default:
+        return "alert-triangle";
     }
   }
 
@@ -787,6 +846,14 @@ export class ChatView extends ItemView {
     if (!this.inputHandler) {
       return;
     }
+    // Prefer the raw text the user actually typed, captured at submit time.
+    // It survives removal of the failed message from this.messages and isn't
+    // affected by any later normalization or trimming.
+    const snapshot = this.inputHandler.consumeSubmittedInputSnapshot?.();
+    if (snapshot) {
+      this.inputHandler.setInputText(snapshot.rawText);
+      return;
+    }
     const lastUserMessage = [...this.messages].reverse().find((msg) => msg.role === "user");
     if (!lastUserMessage) {
       return;
@@ -803,9 +870,46 @@ export class ChatView extends ItemView {
     }
   }
 
-  private async resetFailedAssistantTurn(): Promise<void> {
+  private removeUserMessageDomById(messageId: string): void {
+    if (!this.chatContainer) return;
+    const node = this.chatContainer.querySelector(
+      `.systemsculpt-message[data-message-id="${CSS.escape(messageId)}"]`,
+    ) as HTMLElement | null;
+    if (!node) return;
+    const parentGroup = node.parentElement as HTMLElement | null;
+    node.remove();
+    if (parentGroup) {
+      removeGroupIfEmpty(parentGroup);
+    }
+  }
+
+  // Cleanup hook for the failed-submission path. Pulls the matching user
+  // message out of this.messages + DOM, runs the existing assistant-side
+  // cleanup, and restores the original input text via the InputHandler
+  // snapshot so the user can resend without having to retype. Returns true
+  // when a snapshot was applied so callers can skip the legacy restore path.
+  public async removeFailedSubmissionTurn(): Promise<boolean> {
+    const snapshot = this.inputHandler?.consumeSubmittedInputSnapshot?.() ?? null;
+    if (snapshot) {
+      const idx = this.messages.findIndex((msg) => msg.message_id === snapshot.messageId);
+      if (idx >= 0) {
+        this.messages.splice(idx, 1);
+      }
+      this.removeUserMessageDomById(snapshot.messageId);
+      this.inputHandler?.setInputText(snapshot.rawText);
+    }
     this.removeLastAssistantMessageFromDom();
-    await this.restoreLastUserMessageToComposer();
+    return Boolean(snapshot);
+  }
+
+  private async resetFailedAssistantTurn(): Promise<void> {
+    const restored = await this.removeFailedSubmissionTurn();
+    if (!restored) {
+      // No snapshot available (legacy paths) — fall back to reading the
+      // last user message out of this.messages so we don't regress the
+      // restore behavior for callers that pre-date the snapshot field.
+      await this.restoreLastUserMessageToComposer();
+    }
   }
 
   public generateMessageId(): string {

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -22,9 +22,9 @@ import { AGENT_PRESET, GENERAL_USE_PRESET } from "../../constants/prompts";
 import { ChatExportService } from "./export/ChatExportService";
 import type { ChatExportOptions } from "../../types/chatExport";
 import type { ChatExportResult } from "./export/ChatExportTypes";
-import { removeGroupIfEmpty } from "./utils/MessageGrouping";
+import { removeMessageElement } from "./utils/MessageGrouping";
 import { classifyQuotaExceededError } from "./utils/quotaError";
-import { classifyStreamError } from "./utils/streamError";
+import { classifyStreamError, type StreamErrorKind } from "./utils/streamError";
 import { ChatErrorModal } from "./modals/ChatErrorModal";
 import type { ToolCall } from "../../types/toolCalls";
 import { tryCopyToClipboard } from "../../utils/clipboard";
@@ -603,16 +603,13 @@ export class ChatView extends ItemView {
 
       if (!automationRequestActive) {
         const classification = classifyStreamError(error);
-        // Transient categories (short rate limits, network blips, brief
-        // server outages) stay as small Notices so they don't interrupt the
-        // user. Hard limits / auth / unknown / model_not_found surface as a
-        // modal so the user can read at their own pace.
         if (classification.transient) {
           const duration = classification.kind === "rate_limit" ? 12000 : 10000;
           new Notice(classification.userMessage, duration);
         } else {
           const isHardRateLimit = classification.kind === "rate_limit";
           const isAuth = classification.kind === "auth";
+          const wantsProvidersAction = isAuth || isHardRateLimit;
           new ChatErrorModal({
             app: this.app,
             title: isHardRateLimit
@@ -622,22 +619,17 @@ export class ChatView extends ItemView {
               ? "alert-octagon"
               : this.iconForStreamErrorKind(classification.kind),
             message: classification.userMessage,
-            primaryActionLabel: isAuth
-              ? "Open Providers"
-              : isHardRateLimit
-                ? "Open Providers"
-                : undefined,
-            onPrimaryAction:
-              isAuth || isHardRateLimit
-                ? () => this.openSetupTab("providers")
-                : undefined,
+            primaryActionLabel: wantsProvidersAction ? "Open Providers" : undefined,
+            onPrimaryAction: wantsProvidersAction
+              ? () => this.openSetupTab("providers")
+              : undefined,
           }).open();
         }
       }
     }
   }
 
-  private titleForStreamErrorKind(kind: string): string {
+  private titleForStreamErrorKind(kind: StreamErrorKind): string {
     switch (kind) {
       case "auth":
         return "Authentication required";
@@ -645,13 +637,15 @@ export class ChatView extends ItemView {
         return "Model not available";
       case "server":
         return "Provider error";
+      case "rate_limit":
+      case "network":
       case "unknown":
       default:
         return "Chat request failed";
     }
   }
 
-  private iconForStreamErrorKind(kind: string): string {
+  private iconForStreamErrorKind(kind: StreamErrorKind): string {
     switch (kind) {
       case "auth":
         return "key-round";
@@ -659,6 +653,8 @@ export class ChatView extends ItemView {
         return "help-circle";
       case "server":
         return "server-crash";
+      case "rate_limit":
+      case "network":
       case "unknown":
       default:
         return "alert-triangle";
@@ -844,25 +840,11 @@ export class ChatView extends ItemView {
     }
     const lastGroup = this.chatContainer.querySelector(':scope > .systemsculpt-message-group:last-of-type') as HTMLElement | null;
     const lastMessage = lastGroup?.querySelector('.systemsculpt-message:last-of-type') as HTMLElement | null;
-    if (lastMessage) {
-      const parentGroup = lastMessage.parentElement as HTMLElement | null;
-      lastMessage.remove();
-      if (parentGroup) {
-        removeGroupIfEmpty(parentGroup);
-      }
-    }
+    removeMessageElement(lastMessage);
   }
 
   private async restoreLastUserMessageToComposer(): Promise<void> {
     if (!this.inputHandler) {
-      return;
-    }
-    // Prefer the raw text the user actually typed, captured at submit time.
-    // It survives removal of the failed message from this.messages and isn't
-    // affected by any later normalization or trimming.
-    const snapshot = this.inputHandler.consumeSubmittedInputSnapshot?.();
-    if (snapshot) {
-      this.inputHandler.setInputText(snapshot.rawText);
       return;
     }
     const lastUserMessage = [...this.messages].reverse().find((msg) => msg.role === "user");
@@ -886,19 +868,9 @@ export class ChatView extends ItemView {
     const node = this.chatContainer.querySelector(
       `.systemsculpt-message[data-message-id="${CSS.escape(messageId)}"]`,
     ) as HTMLElement | null;
-    if (!node) return;
-    const parentGroup = node.parentElement as HTMLElement | null;
-    node.remove();
-    if (parentGroup) {
-      removeGroupIfEmpty(parentGroup);
-    }
+    removeMessageElement(node);
   }
 
-  // Cleanup hook for the failed-submission path. Pulls the matching user
-  // message out of this.messages + DOM, runs the existing assistant-side
-  // cleanup, and restores the original input text via the InputHandler
-  // snapshot so the user can resend without having to retype. Returns true
-  // when a snapshot was applied so callers can skip the legacy restore path.
   public async removeFailedSubmissionTurn(): Promise<boolean> {
     const snapshot = this.inputHandler?.consumeSubmittedInputSnapshot?.() ?? null;
     if (snapshot) {
@@ -916,9 +888,6 @@ export class ChatView extends ItemView {
   private async resetFailedAssistantTurn(): Promise<void> {
     const restored = await this.removeFailedSubmissionTurn();
     if (!restored) {
-      // No snapshot available (legacy paths) — fall back to reading the
-      // last user message out of this.messages so we don't regress the
-      // restore behavior for callers that pre-date the snapshot field.
       await this.restoreLastUserMessageToComposer();
     }
   }

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -603,21 +603,32 @@ export class ChatView extends ItemView {
 
       if (!automationRequestActive) {
         const classification = classifyStreamError(error);
-        // Transient/auto-recovering categories stay as small Notices so they
-        // don't interrupt the user. Everything else surfaces as a modal so the
-        // user can read the message at their own pace and dismiss it.
-        if (classification.kind === "rate_limit" || classification.kind === "network") {
+        // Transient categories (short rate limits, network blips, brief
+        // server outages) stay as small Notices so they don't interrupt the
+        // user. Hard limits / auth / unknown / model_not_found surface as a
+        // modal so the user can read at their own pace.
+        if (classification.transient) {
           const duration = classification.kind === "rate_limit" ? 12000 : 10000;
           new Notice(classification.userMessage, duration);
         } else {
+          const isHardRateLimit = classification.kind === "rate_limit";
+          const isAuth = classification.kind === "auth";
           new ChatErrorModal({
             app: this.app,
-            title: this.titleForStreamErrorKind(classification.kind),
-            icon: this.iconForStreamErrorKind(classification.kind),
+            title: isHardRateLimit
+              ? "Provider usage limit reached"
+              : this.titleForStreamErrorKind(classification.kind),
+            icon: isHardRateLimit
+              ? "alert-octagon"
+              : this.iconForStreamErrorKind(classification.kind),
             message: classification.userMessage,
-            primaryActionLabel: classification.kind === "auth" ? "Open Providers" : undefined,
+            primaryActionLabel: isAuth
+              ? "Open Providers"
+              : isHardRateLimit
+                ? "Open Providers"
+                : undefined,
             onPrimaryAction:
-              classification.kind === "auth"
+              isAuth || isHardRateLimit
                 ? () => this.openSetupTab("providers")
                 : undefined,
           }).open();

--- a/src/views/chatview/InputHandler.ts
+++ b/src/views/chatview/InputHandler.ts
@@ -121,8 +121,6 @@ export class InputHandler extends Component {
   private getChatTitle: () => string;
   private addFileToContext: (file: TFile) => Promise<void>;
   private pendingLargeTextContent: string | null = null;
-  // Captured at submit time so failed submissions can restore the exact text the
-  // user typed, independent of this.messages cleanup.
   private submittedInputSnapshot: { messageId: string; rawText: string } | null = null;
   private settingsButton: ButtonComponent;
   private attachButton: ButtonComponent;
@@ -803,7 +801,7 @@ export class InputHandler extends Component {
 
     const includeContextFiles = overrides?.includeContextFiles ?? true;
 
-    const submittedRawText = this.input.value;
+    const submittedRawText = messageText;
 
     try {
       await this.turnLifecycle.runTurn(async (signal) => {
@@ -822,7 +820,6 @@ export class InputHandler extends Component {
 
         await this.runHostedAgentTurnLoop(signal, includeContextFiles);
         void this.chatView.refreshCreditsBalance();
-        this.submittedInputSnapshot = null;
       });
     } catch (err) {
       // StreamingController already forwards errors into ChatView.handleError via onError.
@@ -847,6 +844,7 @@ export class InputHandler extends Component {
         throw new Error(String(err ?? "Unknown chat turn failure"));
       }
     } finally {
+      this.submittedInputSnapshot = null;
       if (overrides?.focusAfterSend !== false) {
         this.focus();
       }
@@ -1537,8 +1535,6 @@ export class InputHandler extends Component {
     }
   }
 
-  // Snapshot accessor for the failure path. Returns and clears the captured
-  // raw text + message_id, so retries don't see a stale snapshot.
   public consumeSubmittedInputSnapshot(): { messageId: string; rawText: string } | null {
     const snapshot = this.submittedInputSnapshot;
     this.submittedInputSnapshot = null;

--- a/src/views/chatview/InputHandler.ts
+++ b/src/views/chatview/InputHandler.ts
@@ -121,6 +121,9 @@ export class InputHandler extends Component {
   private getChatTitle: () => string;
   private addFileToContext: (file: TFile) => Promise<void>;
   private pendingLargeTextContent: string | null = null;
+  // Captured at submit time so failed submissions can restore the exact text the
+  // user typed, independent of this.messages cleanup.
+  private submittedInputSnapshot: { messageId: string; rawText: string } | null = null;
   private settingsButton: ButtonComponent;
   private attachButton: ButtonComponent;
   private micButton: ButtonComponent;
@@ -800,20 +803,26 @@ export class InputHandler extends Component {
 
     const includeContextFiles = overrides?.includeContextFiles ?? true;
 
+    const submittedRawText = this.input.value;
+
     try {
       await this.turnLifecycle.runTurn(async (signal) => {
         this.input.value = "";
         this.adjustInputHeight();
 
+        const messageId = this.generateMessageId();
+        this.submittedInputSnapshot = { messageId, rawText: submittedRawText };
+
         const userMessage: ChatMessage = {
           role: "user",
           content: messageText,
-          message_id: this.generateMessageId(),
+          message_id: messageId,
         } as any;
         await this.onMessageSubmit(userMessage);
 
         await this.runHostedAgentTurnLoop(signal, includeContextFiles);
         void this.chatView.refreshCreditsBalance();
+        this.submittedInputSnapshot = null;
       });
     } catch (err) {
       // StreamingController already forwards errors into ChatView.handleError via onError.
@@ -1526,6 +1535,14 @@ export class InputHandler extends Component {
     if (shouldFocus) {
       this.focus();
     }
+  }
+
+  // Snapshot accessor for the failure path. Returns and clears the captured
+  // raw text + message_id, so retries don't see a stale snapshot.
+  public consumeSubmittedInputSnapshot(): { messageId: string; rawText: string } | null {
+    const snapshot = this.submittedInputSnapshot;
+    this.submittedInputSnapshot = null;
+    return snapshot;
   }
 
   /**

--- a/src/views/chatview/controllers/StreamingController.ts
+++ b/src/views/chatview/controllers/StreamingController.ts
@@ -220,10 +220,8 @@ export class StreamingController extends Component {
         });
       } catch {}
 
-      // Always rethrow as a SystemSculptError so upstream catch blocks (and
-      // their `instanceof SystemSculptError` guards) recognize that this
-      // error has already been forwarded to ChatView.handleError, and do
-      // NOT call handleError a second time.
+      // Rethrow wrapped so upstream `instanceof SystemSculptError` guards know
+      // onError already fired and do not double-forward into handleError.
       const wrapped =
         err instanceof SystemSculptError
           ? err

--- a/src/views/chatview/controllers/StreamingController.ts
+++ b/src/views/chatview/controllers/StreamingController.ts
@@ -220,15 +220,24 @@ export class StreamingController extends Component {
         });
       } catch {}
 
+      // Always rethrow as a SystemSculptError so upstream catch blocks (and
+      // their `instanceof SystemSculptError` guards) recognize that this
+      // error has already been forwarded to ChatView.handleError, and do
+      // NOT call handleError a second time.
+      const wrapped =
+        err instanceof SystemSculptError
+          ? err
+          : new SystemSculptError(
+              err?.message || err?.toString?.() || "Unknown streaming error",
+              ERROR_CODES.STREAM_ERROR,
+              500,
+              { cause: err },
+            );
+
       if (onError) {
-        if (err instanceof SystemSculptError) {
-          onError(err);
-        } else {
-          const errorMessage = err?.message || err?.toString?.() || "Unknown streaming error";
-          onError(new SystemSculptError(errorMessage, ERROR_CODES.STREAM_ERROR, 500, { cause: err }));
-        }
+        onError(wrapped);
       }
-      throw err;
+      throw wrapped;
     } finally {
       if (ownsTracker) {
         metricsTracker.stop();

--- a/src/views/chatview/messageHandling.ts
+++ b/src/views/chatview/messageHandling.ts
@@ -1,7 +1,7 @@
 import { ChatView } from "./ChatView";
 import { ChatRole, MultiPartContent, ChatMessage, MessagePart, UrlCitation } from "../../types";
 import { ButtonComponent, Notice } from "obsidian";
-import { appendMessageToGroupedContainer, removeGroupIfEmpty } from "./utils/MessageGrouping";
+import { appendMessageToGroupedContainer, removeMessageElement } from "./utils/MessageGrouping";
 // Tool call rendering is fully status-driven from PI tool events.
 
 export const messageHandling = {
@@ -251,12 +251,7 @@ export const messageHandling = {
         chatView.messages.splice(index, 1);
         chatView.clearPiSessionState({ save: false });
         await chatView.saveChat();
-
-        const parentGroup = messageEl.parentElement as HTMLElement | null;
-        messageEl.remove();
-        if (parentGroup) {
-          removeGroupIfEmpty(parentGroup);
-        }
+        removeMessageElement(messageEl);
       }
     };
     

--- a/src/views/chatview/modals/ChatErrorModal.ts
+++ b/src/views/chatview/modals/ChatErrorModal.ts
@@ -13,9 +13,6 @@ export interface ChatErrorModalOptions {
   onPrimaryAction?: () => void | Promise<void>;
 }
 
-// Prominent dismissable modal for chat errors that the user needs to read at
-// their own pace (quota exhaustion, auth failure, model unavailable, etc).
-// Replaces transient Notices for any error that is too important to flash by.
 export class ChatErrorModal extends StandardModal {
   private readonly options: ChatErrorModalOptions;
 
@@ -50,7 +47,9 @@ export class ChatErrorModal extends StandardModal {
           this.close();
           try {
             await this.options.onPrimaryAction!();
-          } catch {}
+          } catch (err) {
+            console.warn("[ChatErrorModal] primary action failed", err);
+          }
         },
         true,
       );

--- a/src/views/chatview/modals/ChatErrorModal.ts
+++ b/src/views/chatview/modals/ChatErrorModal.ts
@@ -1,0 +1,65 @@
+import type { App } from "obsidian";
+import { setIcon } from "obsidian";
+import { StandardModal } from "../../../core/ui/modals/standard/StandardModal";
+
+export interface ChatErrorModalOptions {
+  app: App;
+  title: string;
+  message: string;
+  description?: string;
+  icon?: string;
+  primaryActionLabel?: string;
+  secondaryActionLabel?: string;
+  onPrimaryAction?: () => void | Promise<void>;
+}
+
+// Prominent dismissable modal for chat errors that the user needs to read at
+// their own pace (quota exhaustion, auth failure, model unavailable, etc).
+// Replaces transient Notices for any error that is too important to flash by.
+export class ChatErrorModal extends StandardModal {
+  private readonly options: ChatErrorModalOptions;
+
+  constructor(options: ChatErrorModalOptions) {
+    super(options.app);
+    this.options = options;
+  }
+
+  onOpen(): void {
+    super.onOpen();
+    this.setSize("medium");
+    this.modalEl.addClass("ss-chat-error-modal");
+
+    this.addTitle(this.options.title, this.options.description);
+
+    const body = this.contentEl.createDiv({ cls: "ss-chat-error-modal__body" });
+
+    if (this.options.icon) {
+      const iconWrap = body.createDiv({ cls: "ss-chat-error-modal__icon" });
+      setIcon(iconWrap, this.options.icon);
+    }
+
+    body.createDiv({
+      cls: "ss-chat-error-modal__message",
+      text: this.options.message,
+    });
+
+    if (this.options.onPrimaryAction && this.options.primaryActionLabel) {
+      this.addActionButton(
+        this.options.primaryActionLabel,
+        async () => {
+          this.close();
+          try {
+            await this.options.onPrimaryAction!();
+          } catch {}
+        },
+        true,
+      );
+    }
+
+    this.addActionButton(
+      this.options.secondaryActionLabel ?? "Dismiss",
+      () => this.close(),
+      !this.options.onPrimaryAction,
+    );
+  }
+}

--- a/src/views/chatview/utils/MessageGrouping.ts
+++ b/src/views/chatview/utils/MessageGrouping.ts
@@ -85,3 +85,12 @@ export function removeGroupIfEmpty(groupEl: HTMLElement): void {
     groupEl.remove();
   }
 }
+
+export function removeMessageElement(messageEl: HTMLElement | null): void {
+  if (!messageEl) return;
+  const parentGroup = messageEl.parentElement as HTMLElement | null;
+  messageEl.remove();
+  if (parentGroup) {
+    removeGroupIfEmpty(parentGroup);
+  }
+}

--- a/src/views/chatview/utils/__tests__/streamError.test.ts
+++ b/src/views/chatview/utils/__tests__/streamError.test.ts
@@ -3,42 +3,58 @@ import { SystemSculptError, ERROR_CODES } from "../../../../utils/errors";
 
 describe("classifyStreamError", () => {
   describe("rate limit detection", () => {
-    it("detects ChatGPT usage limit with retry timing", () => {
+    it("detects ChatGPT usage limit with retry timing as a hard (non-transient) limit", () => {
       const result = classifyStreamError(
         "You have hit your ChatGPT usage limit (free plan). Try again in ~320 min.",
       );
       expect(result.kind).toBe("rate_limit");
       expect(result.retryAfterSeconds).toBe(320 * 60);
-      expect(result.userMessage).toContain("rate limit");
-      expect(result.userMessage).toContain("~5h");
+      expect(result.transient).toBe(false);
+      // Hard limits keep the original upstream message verbatim so the user
+      // sees the exact retry hint the provider returned.
+      expect(result.userMessage).toContain("ChatGPT usage limit");
+      expect(result.userMessage).toContain("~320 min");
     });
 
-    it("detects generic rate limit", () => {
+    it("detects generic rate limit as transient", () => {
       const result = classifyStreamError("Rate limit exceeded");
       expect(result.kind).toBe("rate_limit");
+      expect(result.transient).toBe(true);
     });
 
-    it("detects 429 status", () => {
+    it("detects 429 status as transient", () => {
       const result = classifyStreamError("HTTP 429 Too Many Requests");
       expect(result.kind).toBe("rate_limit");
+      expect(result.transient).toBe(true);
     });
 
-    it("detects quota exceeded", () => {
+    it("detects quota exceeded as transient (no hard markers, no long retry)", () => {
       const result = classifyStreamError("Quota exceeded for this model");
       expect(result.kind).toBe("rate_limit");
+      expect(result.transient).toBe(true);
     });
 
-    it("parses retry time in seconds", () => {
+    it("parses short retry time in seconds as transient", () => {
       const result = classifyStreamError("Rate limited. Try again in 30 seconds.");
       expect(result.kind).toBe("rate_limit");
       expect(result.retryAfterSeconds).toBe(30);
+      expect(result.transient).toBe(true);
       expect(result.userMessage).toContain("~30s");
     });
 
-    it("parses retry time in hours", () => {
+    it("parses retry time in hours as a hard limit", () => {
       const result = classifyStreamError("Usage limit. Try again in ~2 hours.");
       expect(result.retryAfterSeconds).toBe(7200);
-      expect(result.userMessage).toContain("~2h");
+      expect(result.transient).toBe(false);
+      // Original message preserved when it already contains the wait hint.
+      expect(result.userMessage).toContain("Usage limit");
+      expect(result.userMessage).toContain("2 hours");
+    });
+
+    it("flags free-plan exhaustion as a hard limit even with a short delay", () => {
+      const result = classifyStreamError("Free plan capacity reached.");
+      expect(result.kind).toBe("rate_limit");
+      expect(result.transient).toBe(false);
     });
   });
 

--- a/src/views/chatview/utils/streamError.ts
+++ b/src/views/chatview/utils/streamError.ts
@@ -14,7 +14,38 @@ export type StreamErrorClassification = {
   userMessage: string;
   /** Retry delay in seconds, if parseable from the error. */
   retryAfterSeconds: number;
+  /**
+   * True when the error is expected to clear on its own quickly — short
+   * provider rate limits, transient network blips. False when the user needs
+   * to take action (hard usage caps, multi-hour cooldowns, plan exhaustion).
+   * UI surfaces use this to choose Notice vs. modal.
+   */
+  transient: boolean;
 };
+
+const HARD_RATE_LIMIT_MARKERS = [
+  "usage limit",
+  "free plan",
+  "free tier",
+  "monthly limit",
+  "daily limit",
+  "exhausted",
+  "out of credits",
+  "billing",
+  "subscription",
+  "upgrade",
+];
+
+// Anything longer than this is treated as a hard limit the user has to deal
+// with manually, not a transient cooldown to wait out.
+const TRANSIENT_RATE_LIMIT_THRESHOLD_SECONDS = 60;
+
+function isHardRateLimit(combined: string, retryAfterSeconds: number): boolean {
+  if (retryAfterSeconds > TRANSIENT_RATE_LIMIT_THRESHOLD_SECONDS) {
+    return true;
+  }
+  return HARD_RATE_LIMIT_MARKERS.some((marker) => combined.includes(marker));
+}
 
 function includesAny(haystack: string, needles: string[]): boolean {
   return needles.some((needle) => haystack.includes(needle));
@@ -65,20 +96,51 @@ export function classifyStreamError(
 
   const retryAfterSeconds = parseRetryDelay(combined);
 
-  // Short-circuit on structured error codes when available.
-  if (code === ERROR_CODES.RATE_LIMIT_ERROR) {
+  const buildRateLimit = (): StreamErrorClassification => {
+    const hard = isHardRateLimit(combined, retryAfterSeconds);
     const wait = formatWaitTime(retryAfterSeconds);
     const suffix = wait ? ` Try again in ${wait}.` : " Please try again later.";
-    return { kind: "rate_limit", userMessage: `Provider rate limit reached.${suffix}`, retryAfterSeconds };
+    const messageHasRetryHint = /try again|retry|wait/i.test(message);
+    const userMessage = hard
+      ? messageHasRetryHint
+        ? message
+        : `${message || "Provider usage limit reached."}${suffix}`
+      : `Provider rate limit reached.${suffix}`;
+    return {
+      kind: "rate_limit",
+      userMessage,
+      retryAfterSeconds,
+      transient: !hard,
+    };
+  };
+
+  // Short-circuit on structured error codes when available.
+  if (code === ERROR_CODES.RATE_LIMIT_ERROR) {
+    return buildRateLimit();
   }
   if (code === ERROR_CODES.NETWORK_ERROR) {
-    return { kind: "network", userMessage: "Could not reach the provider. Check your internet connection and try again.", retryAfterSeconds: 0 };
+    return {
+      kind: "network",
+      userMessage: "Could not reach the provider. Check your internet connection and try again.",
+      retryAfterSeconds: 0,
+      transient: true,
+    };
   }
   if (code === ERROR_CODES.SERVICE_UNAVAILABLE) {
-    return { kind: "server", userMessage: "The provider is temporarily unavailable. Please try again in a moment.", retryAfterSeconds: 0 };
+    return {
+      kind: "server",
+      userMessage: "The provider is temporarily unavailable. Please try again in a moment.",
+      retryAfterSeconds: 0,
+      transient: true,
+    };
   }
   if (code === ERROR_CODES.MODEL_UNAVAILABLE) {
-    return { kind: "model_not_found", userMessage: "The selected model is not available. Try switching to a different model.", retryAfterSeconds: 0 };
+    return {
+      kind: "model_not_found",
+      userMessage: "The selected model is not available. Try switching to a different model.",
+      retryAfterSeconds: 0,
+      transient: false,
+    };
   }
 
   if (
@@ -94,9 +156,7 @@ export function classifyStreamError(
       "capacity",
     ])
   ) {
-    const wait = formatWaitTime(retryAfterSeconds);
-    const suffix = wait ? ` Try again in ${wait}.` : " Please try again later.";
-    return { kind: "rate_limit", userMessage: `Provider rate limit reached.${suffix}`, retryAfterSeconds };
+    return buildRateLimit();
   }
 
   if (isAuthFailureMessage(combined)) {
@@ -104,6 +164,7 @@ export function classifyStreamError(
       kind: "auth",
       userMessage: "Authentication failed for this provider. Check Settings \u2192 Providers to reconnect.",
       retryAfterSeconds: 0,
+      transient: false,
     };
   }
 
@@ -122,6 +183,7 @@ export function classifyStreamError(
       kind: "model_not_found",
       userMessage: "The selected model is not available. Try switching to a different model.",
       retryAfterSeconds: 0,
+      transient: false,
     };
   }
 
@@ -140,6 +202,7 @@ export function classifyStreamError(
       kind: "server",
       userMessage: "The provider is temporarily unavailable. Please try again in a moment.",
       retryAfterSeconds: 0,
+      transient: true,
     };
   }
 
@@ -159,6 +222,7 @@ export function classifyStreamError(
       kind: "network",
       userMessage: "Could not reach the provider. Check your internet connection and try again.",
       retryAfterSeconds: 0,
+      transient: true,
     };
   }
 
@@ -167,5 +231,6 @@ export function classifyStreamError(
     kind: "unknown",
     userMessage: trimmed || "An unexpected error occurred. Please try again.",
     retryAfterSeconds: 0,
+    transient: false,
   };
 }


### PR DESCRIPTION
## Summary

Five tightly-related fixes for chat error and provider-disconnect UX:

1. **Provider disconnect now actually persists.** The Pi SDK's `AuthStorage` writes through `proper-lockfile`, which silently no-ops in Obsidian's Electron renderer when the initial `reload()` set `loadError`. Result: `storage.remove(provider)` returned cleanly but `auth.json` was untouched, so the next refresh re-read the stale credential and the UI flipped right back to "Disconnect". Fix: `mutateAuthJsonFile()` rewrites `auth.json` directly via `fs.writeFileSync`, bypassing the SDK's lockfile path. Both the post-OAuth-login persist path and the disconnect rewrite path now share the helper, and the login path picks up `chmodSync 0o600` for free.

2. **Provider disconnect now updates the row immediately.** Optimistically flips the in-memory `state.providers[i].record` to a disconnected shape and rerenders before the async `clearStudioPiProviderAuth` + `refreshProviderList` chain runs. Reconciles against canonical state in the catch path.

3. **Hard usage limits / auth / model-not-found / unknown errors surface as a `ChatErrorModal`** that the user can read at their own pace, instead of a 5-second `Notice`. Transient categories (short rate limits, network blips, brief server outages) stay as Notices so they don't interrupt a working session.

4. **Failed user messages no longer orphan in the chat container.** `removeFailedSubmissionTurn()` pulls the matching user message out of `this.messages` + DOM, runs the existing assistant-side cleanup, and restores the original input text via an `InputHandler.submittedInputSnapshot` captured at submit time.

5. **`StreamingController` rethrows the wrapped `SystemSculptError`** instead of the unwrapped original, so upstream `instanceof SystemSculptError` guards correctly recognize that `onError` already fired and don't double-forward into `handleError` (the previous behavior produced two stacked Notices for one rate-limit event).

Stream error classification grew a `transient: boolean` field with a 60s retry-after threshold + hard-limit keyword markers (`usage limit`, `free plan`, `billing`, `subscription`, `upgrade`, etc.) so the UI can route hard vs transient correctly.

## Code review fixes (post-simplify pass)

A second pass found and fixed:

- **Latent pasted-text bug**: `submittedRawText` was capturing `this.input.value` BEFORE the placeholder expansion ran on `messageText`, so a failed paste would restore the literal `[PASTED TEXT - N LINES]` string. Now captures `messageText`. Snapshot also moved into `finally` to prevent leak across cancelled turns.
- **Dead code**: snapshot-consume branch in `restoreLastUserMessageToComposer` was unreachable (caller already drained the snapshot).
- **Duplication**: extracted `mutateAuthJsonFile` (auth.json read-modify-write), `removeMessageElement` (3 call sites doing the same `el.remove() + removeGroupIfEmpty(parent)` ritual), and `performProviderDisconnect` (two byte-identical 19-line click handlers).
- **Typing**: `titleForStreamErrorKind` / `iconForStreamErrorKind` now take `StreamErrorKind` (exhaustive).
- **Defensive**: `ChatErrorModal` logs primary-action errors instead of swallowing.

## Test plan

- [ ] **Disconnect a provider in Settings → Providers → confirm row flips to "Connect" and stays there (this is the bug that started this PR — please verify the in-Obsidian behavior, not just CI).**
- [ ] Trigger a usage-limit / auth / quota error in chat (e.g. exhaust a free-plan ChatGPT session) → confirm a `ChatErrorModal` appears, not a Notice, and exactly one (no doubles).
- [ ] Submit a chat message that fails (e.g. while disconnected from the provider) → confirm the failed user message is removed from the chat container AND the input box has the original text restored. For pasted large text: confirm the input box has the expanded paste content.
- [ ] Verify CI: `tsc`, bundle, script-tests, jest (`npm run check:plugin:fast`).
- [ ] Targeted suites: `studio-pi-auth-storage-fetch-shim.test.ts` (added 2 new tests for the direct fs path + leak isolation), `settings-providers-tab.test.ts`, `streamError.test.ts`.
