### PR TITLE
Fix Studio selection halo and release surface checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Desktop validation is attach-only to an already-open Obsidian vault. Keep live s
 ```bash
 npm run check:release:windows         # build + Windows 11 clean install + Windows baselines
 npm run check:release:native          # required native release matrix
+npm run check:release-surfaces -- --version <version> --require-notes
 npm run release:plugin                  # auto bump (major/minor/patch from commits)
 npm run release:plugin -- --dry-run    # preview next version + notes only
 npm run release:plugin -- --bump patch # force a specific bump
@@ -117,6 +118,7 @@ Use `npm run check:release:windows` when you want the fast Windows-only release 
 
 The old tag-triggered GitHub Actions release workflow is retired. Treat `npm run release:plugin` as the canonical publish path for this repo.
 That release path now packages the standard Obsidian plugin artifact set only: `manifest.json`, `main.js`, and `styles.css`.
+Before release, `npm run check:release-surfaces -- --version <version> --require-notes` verifies the exact version surfaces and release notes file. After a production build, add `--check-artifacts` to verify the release asset set too.
 Desktop validation is now bridge-based and no-focus by default; the old renderer-driving desktop lane is retired.
 When multiple synced desktop vaults exist, use `--vault-name <vault-name>` or `--vault-path <absolute-path>` to pin one explicitly. Otherwise the desktop runner prefers the latest live bridge target automatically.
 

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "test:leaks": "node scripts/jest.mjs --config jest.config.cjs --maxWorkers=1 --openHandlesTimeout=200 --passWithNoTests",
     "test:embeddings": "node scripts/jest.mjs --config jest.embeddings.config.cjs --passWithNoTests",
     "test:embeddings:serial": "node scripts/jest.mjs --config jest.embeddings.config.cjs --runInBand --passWithNoTests",
-    "test:release-script": "node --test scripts/release-plugin.test.mjs",
+    "test:release-script": "node --test scripts/release-plugin.test.mjs scripts/check-release-surfaces.test.mjs",
+    "check:release-surfaces": "node scripts/check-release-surfaces.mjs",
     "release:plugin": "node scripts/release-plugin.mjs"
   },
   "ts-node": {

--- a/scripts/check-release-surfaces.mjs
+++ b/scripts/check-release-surfaces.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  inspectPluginArtifacts,
+  REQUIRED_PLUGIN_ARTIFACTS,
+} from "./plugin-artifacts.mjs";
+
+export const REQUIRED_RELEASE_SOURCE_FILES = [
+  "README.md",
+  "LICENSE",
+  "manifest.json",
+  "package.json",
+  "package-lock.json",
+  "versions.json",
+];
+
+export const REQUIRED_VERSION_FILES = [
+  "manifest.json",
+  "package.json",
+  "package-lock.json",
+  "versions.json",
+  "README.md",
+];
+
+export const REQUIRED_GITIGNORE_PATTERNS = [
+  "main.js",
+  "styles.css",
+  "artifacts/",
+  ".env",
+  ".env.*",
+  "config.json",
+];
+
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function readJson(root, relativePath, problems) {
+  const filePath = path.join(root, relativePath);
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(readText(filePath));
+  } catch (error) {
+    problems.push(`${relativePath} is not valid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function hasLine(text, expectedLine) {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .includes(expectedLine);
+}
+
+function resolveNotesFile(root, version, notesFile, requireNotes) {
+  if (notesFile) {
+    return path.resolve(root, notesFile);
+  }
+  if (requireNotes) {
+    return path.join(root, "docs", "release-notes", `${version}.md`);
+  }
+  return "";
+}
+
+export function inspectReleaseSurfaces({
+  root = process.cwd(),
+  version = "",
+  notesFile = "",
+  requireNotes = false,
+  checkArtifacts = false,
+} = {}) {
+  const resolvedRoot = path.resolve(root);
+  const problems = [];
+  const warnings = [];
+
+  for (const relativePath of REQUIRED_RELEASE_SOURCE_FILES) {
+    if (!fs.existsSync(path.join(resolvedRoot, relativePath))) {
+      problems.push(`Required release source file is missing: ${relativePath}`);
+    }
+  }
+
+  const manifest = readJson(resolvedRoot, "manifest.json", problems);
+  const pkg = readJson(resolvedRoot, "package.json", problems);
+  const lockfile = readJson(resolvedRoot, "package-lock.json", problems);
+  const versions = readJson(resolvedRoot, "versions.json", problems);
+  const targetVersion = version || manifest?.version || "";
+
+  if (!SEMVER_PATTERN.test(targetVersion)) {
+    problems.push(`Target version must be semver x.y.z: ${targetVersion || "(empty)"}`);
+  }
+
+  if (manifest) {
+    if (manifest.version !== targetVersion) {
+      problems.push(`manifest.json version is ${manifest.version}; expected ${targetVersion}`);
+    }
+    if (!manifest.minAppVersion) {
+      problems.push("manifest.json is missing minAppVersion");
+    }
+  }
+
+  if (pkg?.version !== targetVersion) {
+    problems.push(`package.json version is ${pkg?.version || "(missing)"}; expected ${targetVersion}`);
+  }
+
+  if (lockfile) {
+    if (lockfile.version !== targetVersion) {
+      problems.push(`package-lock.json root version is ${lockfile.version || "(missing)"}; expected ${targetVersion}`);
+    }
+    if (lockfile.packages?.[""]?.version !== targetVersion) {
+      problems.push(
+        `package-lock.json packages[""].version is ${lockfile.packages?.[""]?.version || "(missing)"}; expected ${targetVersion}`
+      );
+    }
+  }
+
+  if (versions && manifest?.minAppVersion) {
+    if (versions[targetVersion] !== manifest.minAppVersion) {
+      problems.push(
+        `versions.json entry for ${targetVersion} is ${versions[targetVersion] || "(missing)"}; expected ${manifest.minAppVersion}`
+      );
+    }
+  }
+
+  const readmePath = path.join(resolvedRoot, "README.md");
+  if (fs.existsSync(readmePath)) {
+    const readme = readText(readmePath);
+    const pluginVersionMatch = readme.match(/- Plugin version:\s*`([^`]+)`/);
+    if (!pluginVersionMatch) {
+      problems.push("README.md is missing '- Plugin version: `<version>`'");
+    } else if (pluginVersionMatch[1] !== targetVersion) {
+      problems.push(`README.md plugin version is ${pluginVersionMatch[1]}; expected ${targetVersion}`);
+    }
+
+    const badgeVersions = [...readme.matchAll(/img\.shields\.io\/badge\/version-(\d+\.\d+\.\d+)-blue\.svg/g)]
+      .map((match) => match[1]);
+    for (const badgeVersion of badgeVersions) {
+      if (badgeVersion !== targetVersion) {
+        problems.push(`README.md version badge is ${badgeVersion}; expected ${targetVersion}`);
+      }
+    }
+
+    if (manifest?.minAppVersion) {
+      const minAppVersionLine = `- Minimum Obsidian version: \`${manifest.minAppVersion}\``;
+      if (!hasLine(readme, minAppVersionLine)) {
+        problems.push(`README.md is missing '${minAppVersionLine}'`);
+      }
+    }
+  }
+
+  const notesPath = resolveNotesFile(resolvedRoot, targetVersion, notesFile, requireNotes);
+  if (notesPath) {
+    if (!fs.existsSync(notesPath)) {
+      problems.push(`Release notes file is missing: ${path.relative(resolvedRoot, notesPath)}`);
+    } else {
+      const notes = readText(notesPath);
+      if (!notes.includes(`SystemSculpt ${targetVersion}`)) {
+        problems.push(`Release notes do not mention 'SystemSculpt ${targetVersion}'`);
+      }
+    }
+  }
+
+  const gitignorePath = path.join(resolvedRoot, ".gitignore");
+  if (fs.existsSync(gitignorePath)) {
+    const gitignore = readText(gitignorePath);
+    for (const pattern of REQUIRED_GITIGNORE_PATTERNS) {
+      if (!hasLine(gitignore, pattern)) {
+        problems.push(`.gitignore is missing required release-safety pattern: ${pattern}`);
+      }
+    }
+  } else {
+    problems.push(".gitignore is missing");
+  }
+
+  if (checkArtifacts) {
+    const artifactInspection = inspectPluginArtifacts({ root: resolvedRoot });
+    for (const problem of artifactInspection.problems) {
+      problems.push(problem);
+    }
+  } else {
+    warnings.push(`Release artifacts not checked; pass --check-artifacts after build to verify ${REQUIRED_PLUGIN_ARTIFACTS.join(", ")}`);
+  }
+
+  return {
+    ok: problems.length === 0,
+    root: resolvedRoot,
+    targetVersion,
+    notesPath: notesPath ? path.relative(resolvedRoot, notesPath) : "",
+    requiredReleaseSourceFiles: REQUIRED_RELEASE_SOURCE_FILES,
+    requiredVersionFiles: REQUIRED_VERSION_FILES,
+    requiredReleaseArtifacts: REQUIRED_PLUGIN_ARTIFACTS,
+    problems,
+    warnings,
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    version: "",
+    notesFile: "",
+    requireNotes: false,
+    checkArtifacts: false,
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--version") {
+      options.version = argv[index + 1] || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--notes-file") {
+      options.notesFile = argv[index + 1] || "";
+      index += 1;
+      continue;
+    }
+    if (arg === "--require-notes") {
+      options.requireNotes = true;
+      continue;
+    }
+    if (arg === "--check-artifacts") {
+      options.checkArtifacts = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function printHumanReport(result) {
+  if (result.ok) {
+    console.log(`[release-surfaces] OK for ${result.targetVersion}`);
+  } else {
+    console.error(`[release-surfaces] ERROR for ${result.targetVersion || "(unknown version)"}`);
+    for (const problem of result.problems) {
+      console.error(`[release-surfaces] - ${problem}`);
+    }
+  }
+
+  for (const warning of result.warnings) {
+    console.warn(`[release-surfaces] warning: ${warning}`);
+  }
+}
+
+const isDirectExecution = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url
+  : false;
+
+if (isDirectExecution) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const result = inspectReleaseSurfaces(options);
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      printHumanReport(result);
+    }
+    process.exit(result.ok ? 0 : 1);
+  } catch (error) {
+    console.error(`[release-surfaces] ERROR: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}

--- a/scripts/check-release-surfaces.test.mjs
+++ b/scripts/check-release-surfaces.test.mjs
@@ -1,0 +1,171 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  inspectReleaseSurfaces,
+  REQUIRED_RELEASE_SOURCE_FILES,
+  REQUIRED_VERSION_FILES,
+} from "./check-release-surfaces.mjs";
+
+function createReleaseRoot(version = "9.9.9") {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "systemsculpt-release-surfaces-"));
+  fs.mkdirSync(path.join(root, "docs", "release-notes"), { recursive: true });
+
+  fs.writeFileSync(path.join(root, "LICENSE"), "MIT\n", "utf8");
+  fs.writeFileSync(
+    path.join(root, "manifest.json"),
+    JSON.stringify({
+      id: "systemsculpt-ai",
+      name: "SystemSculpt AI",
+      version,
+      minAppVersion: "1.4.0",
+    }, null, 2),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "obsidian-systemsculpt-ai", version }, null, 2),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(root, "package-lock.json"),
+    JSON.stringify({
+      name: "obsidian-systemsculpt-ai",
+      version,
+      packages: {
+        "": {
+          name: "obsidian-systemsculpt-ai",
+          version,
+        },
+      },
+    }, null, 2),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(root, "versions.json"),
+    JSON.stringify({ [version]: "1.4.0" }, null, 2),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(root, "README.md"),
+    [
+      `- Plugin version: \`${version}\``,
+      "- Minimum Obsidian version: `1.4.0`",
+      `![Version](https://img.shields.io/badge/version-${version}-blue.svg)`,
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(root, "docs", "release-notes", `${version}.md`),
+    `# SystemSculpt ${version}\n\n## What's New\n\nA small release.\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(root, ".gitignore"),
+    [
+      "main.js",
+      "styles.css",
+      "artifacts/",
+      ".env",
+      ".env.*",
+      "config.json",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+
+  return root;
+}
+
+test("release surface constants name the exact required source and version files", () => {
+  assert.deepEqual(REQUIRED_RELEASE_SOURCE_FILES, [
+    "README.md",
+    "LICENSE",
+    "manifest.json",
+    "package.json",
+    "package-lock.json",
+    "versions.json",
+  ]);
+  assert.deepEqual(REQUIRED_VERSION_FILES, [
+    "manifest.json",
+    "package.json",
+    "package-lock.json",
+    "versions.json",
+    "README.md",
+  ]);
+});
+
+test("inspectReleaseSurfaces accepts synchronized metadata and release notes", () => {
+  const root = createReleaseRoot("9.9.9");
+  const result = inspectReleaseSurfaces({
+    root,
+    version: "9.9.9",
+    requireNotes: true,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.targetVersion, "9.9.9");
+  assert.equal(result.notesPath, path.join("docs", "release-notes", "9.9.9.md"));
+  assert.deepEqual(result.problems, []);
+});
+
+test("inspectReleaseSurfaces rejects drift across version-bearing files", () => {
+  const root = createReleaseRoot("9.9.9");
+  fs.writeFileSync(
+    path.join(root, "package-lock.json"),
+    JSON.stringify({
+      name: "obsidian-systemsculpt-ai",
+      version: "9.9.8",
+      packages: {
+        "": {
+          name: "obsidian-systemsculpt-ai",
+          version: "9.9.8",
+        },
+      },
+    }, null, 2),
+    "utf8"
+  );
+
+  const result = inspectReleaseSurfaces({
+    root,
+    version: "9.9.9",
+    requireNotes: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.problems.join("\n"), /package-lock\.json root version is 9\.9\.8/);
+  assert.match(result.problems.join("\n"), /packages\[""\]\.version is 9\.9\.8/);
+});
+
+test("inspectReleaseSurfaces requires the public release notes file when requested", () => {
+  const root = createReleaseRoot("9.9.9");
+  fs.rmSync(path.join(root, "docs", "release-notes", "9.9.9.md"));
+
+  const result = inspectReleaseSurfaces({
+    root,
+    version: "9.9.9",
+    requireNotes: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.problems.join("\n"), /Release notes file is missing/);
+});
+
+test("inspectReleaseSurfaces reports missing JSON files once", () => {
+  const root = createReleaseRoot("9.9.9");
+  fs.rmSync(path.join(root, "manifest.json"));
+
+  const result = inspectReleaseSurfaces({
+    root,
+    version: "9.9.9",
+    requireNotes: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.problems.join("\n"), /Required release source file is missing: manifest\.json/);
+  assert.doesNotMatch(result.problems.join("\n"), /manifest\.json is not valid JSON/);
+});

--- a/scripts/release-plugin.mjs
+++ b/scripts/release-plugin.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { assertProductionPluginArtifacts } from "./plugin-artifacts.mjs";
+import { inspectReleaseSurfaces } from "./check-release-surfaces.mjs";
 
 const cwd = process.cwd();
 const args = process.argv.slice(2);
@@ -939,6 +940,73 @@ function ensureTagDoesNotExist(version) {
   }
 }
 
+function toRepoRelativePath(filePath, root = cwd) {
+  return path.relative(root, path.resolve(root, filePath)).split(path.sep).join("/");
+}
+
+function expectedReleaseNotesPath(version) {
+  return `docs/release-notes/${version}.md`;
+}
+
+function validateAuthoredReleaseNotesFile({
+  notesFile,
+  dryRun = false,
+  version,
+  root = cwd,
+} = {}) {
+  const expectedPath = expectedReleaseNotesPath(version);
+  if (!notesFile) {
+    return {
+      ok: Boolean(dryRun),
+      expectedPath,
+      relativePath: "",
+      problem: dryRun
+        ? ""
+        : `Real releases require authored public notes: --notes-file ${expectedPath}`,
+    };
+  }
+
+  const relativePath = toRepoRelativePath(notesFile, root);
+  if (dryRun) {
+    return {
+      ok: true,
+      expectedPath,
+      relativePath,
+      problem: "",
+    };
+  }
+
+  if (relativePath !== expectedPath) {
+    return {
+      ok: false,
+      expectedPath,
+      relativePath,
+      problem: `Release notes file must be ${expectedPath}; got ${relativePath}`,
+    };
+  }
+
+  return {
+    ok: true,
+    expectedPath,
+    relativePath,
+    problem: "",
+  };
+}
+
+function ensureAuthoredReleaseNotesFile(options, version) {
+  const validation = validateAuthoredReleaseNotesFile({
+    notesFile: options.notesFile,
+    dryRun: options.dryRun,
+    version,
+  });
+
+  if (!validation.ok) {
+    fail(validation.problem);
+  }
+
+  return validation;
+}
+
 function ensureGitHubCliReady() {
   return resolveGitHubReleaseAuthStrategy();
 }
@@ -1142,6 +1210,7 @@ function main() {
     githubAuthStrategyName: githubAuthStrategy.name,
   });
 
+  ensureAuthoredReleaseNotesFile(options, newVersion);
   const notesPath = writeNotesFile(newVersion, commits, options.notesFile);
   logStep(`Release notes preview file: ${notesPath}`);
 
@@ -1171,7 +1240,21 @@ function main() {
     writeJson(lockfilePath, lockfile);
     writeJson(versionsPath, versions);
     updateReadmeVersion(readmePath, newVersion);
+  }
 
+  const releaseSurfaceCheck = inspectReleaseSurfaces({
+    root: cwd,
+    version: newVersion,
+    notesFile: options.notesFile,
+    requireNotes: true,
+    checkArtifacts: true,
+  });
+  if (!releaseSurfaceCheck.ok) {
+    fail(`Release surface check failed:\n${releaseSurfaceCheck.problems.map((problem) => `- ${problem}`).join("\n")}`);
+  }
+  logStep("Release surfaces verified.");
+
+  if (!usePreBumpedMetadata) {
     logStep("Staging release metadata files");
     run("git", ["add", "manifest.json", "package.json", "package-lock.json", "versions.json", "README.md"]);
 
@@ -1207,6 +1290,7 @@ export {
   parseGitHubAuthStatus,
   resolveGitHubReleaseAuthStrategy,
   resolveReleaseVersionPlan,
+  validateAuthoredReleaseNotesFile,
   runWithGitHubAuthFallback,
   shouldRetryWithoutGitHubEnv,
   withoutGitHubEnvTokens,

--- a/scripts/release-plugin.test.mjs
+++ b/scripts/release-plugin.test.mjs
@@ -10,6 +10,7 @@ import {
   resolveReleaseVersionPlan,
   runWithGitHubAuthFallback,
   shouldRetryWithoutGitHubEnv,
+  validateAuthoredReleaseNotesFile,
   withoutGitHubEnvTokens,
   writeNotesFile,
 } from "./release-plugin.mjs";
@@ -155,6 +156,58 @@ test("resolveReleaseVersionPlan reuses pre-bumped metadata only without explicit
       inferredBump: "minor",
       bump: "minor",
       newVersion: "5.6.0",
+    }
+  );
+});
+
+test("validateAuthoredReleaseNotesFile requires canonical notes for real releases", () => {
+  assert.deepEqual(
+    validateAuthoredReleaseNotesFile({
+      version: "5.6.0",
+      dryRun: false,
+      notesFile: "docs/release-notes/5.6.0.md",
+      root: process.cwd(),
+    }),
+    {
+      ok: true,
+      expectedPath: "docs/release-notes/5.6.0.md",
+      relativePath: "docs/release-notes/5.6.0.md",
+      problem: "",
+    }
+  );
+
+  assert.match(
+    validateAuthoredReleaseNotesFile({
+      version: "5.6.0",
+      dryRun: false,
+      notesFile: "",
+      root: process.cwd(),
+    }).problem,
+    /Real releases require authored public notes/
+  );
+
+  assert.match(
+    validateAuthoredReleaseNotesFile({
+      version: "5.6.0",
+      dryRun: false,
+      notesFile: "notes.md",
+      root: process.cwd(),
+    }).problem,
+    /must be docs\/release-notes\/5\.6\.0\.md/
+  );
+
+  assert.deepEqual(
+    validateAuthoredReleaseNotesFile({
+      version: "5.6.0",
+      dryRun: true,
+      notesFile: "draft-notes.md",
+      root: process.cwd(),
+    }),
+    {
+      ok: true,
+      expectedPath: "docs/release-notes/5.6.0.md",
+      relativePath: "draft-notes.md",
+      problem: "",
     }
   );
 });

--- a/src/css/views/systemsculpt-studio.css
+++ b/src/css/views/systemsculpt-studio.css
@@ -1371,6 +1371,20 @@ select.ss-pi-wizard__select { width: 100%; }
   box-shadow: 0 0 0 1px var(--interactive-accent);
 }
 
+/* When a selected card joins top/bottom overlay panels, extend the accent
+   ring across the full composite. The card's own 1px box-shadow would paint
+   across the seam (the card sits at z-index 5 above overlays at z-index 3),
+   so it's dropped and the overlay panels pick up the accent border. */
+.ss-studio-node-card:has(> .ss-studio-node-chrome-overlay).is-selected,
+.ss-studio-node-card:has(> .ss-studio-node-chrome-overlay-top).is-selected {
+  box-shadow: none;
+}
+
+.ss-studio-node-card.is-selected > .ss-studio-node-chrome-overlay,
+.ss-studio-node-card.is-selected > .ss-studio-node-chrome-overlay-top {
+  border-color: var(--interactive-accent);
+}
+
 .ss-studio-node-card.is-managed-pending {
   border-color: color-mix(in srgb, var(--ss-studio-info-bright) 58%, var(--ss-studio-border) 42%);
   box-shadow:

--- a/src/css/views/systemsculpt-studio.css
+++ b/src/css/views/systemsculpt-studio.css
@@ -1183,8 +1183,8 @@ select.ss-pi-wizard__select { width: 100%; }
   display: none;
 }
 
-/* Status row hidden when idle — status stripe (left border) handles state.    */
-/* Row reappears automatically when running/succeeded/failed via non-idle class */
+/* Hide the status row when idle — there's nothing meaningful to show. It
+   reappears automatically when running/succeeded/failed via the non-idle class. */
 .ss-studio-node-run-status-row:has(.ss-studio-node-run-status.is-idle):not(:has(.ss-studio-node-run-message)):not(:has(.ss-studio-node-badge)) {
   display: none;
 }
@@ -1366,20 +1366,20 @@ select.ss-pi-wizard__select { width: 100%; }
   cursor: grabbing;
 }
 
+.ss-studio-node-card:hover,
 .ss-studio-node-card.is-selected {
   border-color: var(--interactive-accent);
-  box-shadow: 0 0 0 1px var(--interactive-accent);
+  filter:
+    drop-shadow(0 0 3px color-mix(in srgb, var(--interactive-accent) 75%, transparent))
+    drop-shadow(0 0 14px color-mix(in srgb, var(--interactive-accent) 32%, transparent));
 }
 
-/* When a selected card joins top/bottom overlay panels, extend the accent
-   ring across the full composite. The card's own 1px box-shadow would paint
-   across the seam (the card sits at z-index 5 above overlays at z-index 3),
-   so it's dropped and the overlay panels pick up the accent border. */
-.ss-studio-node-card:has(> .ss-studio-node-chrome-overlay).is-selected,
-.ss-studio-node-card:has(> .ss-studio-node-chrome-overlay-top).is-selected {
-  box-shadow: none;
-}
-
+/* Overlay panels adopt the accent border so the full composite edge reads
+   as a continuous accent line. The card's drop-shadow filter wraps the
+   composite automatically — overlays are absolute-positioned descendants
+   of the card, so the filter applies to the whole visual shape. */
+.ss-studio-node-card:hover > .ss-studio-node-chrome-overlay,
+.ss-studio-node-card:hover > .ss-studio-node-chrome-overlay-top,
 .ss-studio-node-card.is-selected > .ss-studio-node-chrome-overlay,
 .ss-studio-node-card.is-selected > .ss-studio-node-chrome-overlay-top {
   border-color: var(--interactive-accent);
@@ -1407,6 +1407,13 @@ select.ss-pi-wizard__select { width: 100%; }
 .ss-studio-graph-viewport.is-interacting .ss-studio-link-path,
 .ss-studio-graph-viewport.is-interacting .ss-studio-link-preview {
   pointer-events: none;
+}
+
+/* Drop the halo only during active node drag — per-frame filter repaint
+   adds real cost there. Zoom/scroll is a pure transform composite and
+   keeps the halo visible. */
+.ss-studio-graph-viewport.is-interacting .ss-studio-node-card {
+  filter: none;
 }
 
 .ss-studio-graph-viewport.is-zoomed-far .ss-studio-node-card textarea,
@@ -1633,21 +1640,6 @@ select.ss-pi-wizard__select { width: 100%; }
 .ss-studio-node-run-status.is-failed {
   color: var(--ss-studio-error-muted);
   border-color: color-mix(in srgb, var(--ss-studio-error) 65%, var(--ss-studio-border));
-}
-
-/* ── Left-edge status stripe on node cards ── */
-.ss-studio-node-card:has(.ss-studio-node-run-status.is-pending) {
-  border-left-color: var(--text-muted);
-}
-.ss-studio-node-card:has(.ss-studio-node-run-status.is-running) {
-  border-left-color: var(--interactive-accent);
-}
-.ss-studio-node-card:has(.ss-studio-node-run-status.is-cached),
-.ss-studio-node-card:has(.ss-studio-node-run-status.is-succeeded) {
-  border-left-color: var(--color-green, var(--ss-studio-success-tint));
-}
-.ss-studio-node-card:has(.ss-studio-node-run-status.is-failed) {
-  border-left-color: var(--color-red, var(--ss-studio-error));
 }
 
 .ss-studio-node-run-message {


### PR DESCRIPTION
## Summary
- Wrap Studio node selection and hover halos around expanded chrome overlays instead of only the base card box.
- Remove the run-status left stripe so selection and status styling do not compete on the card edge.
- Add a release-surface checker for version-bearing files, authored release notes, ignored release artifacts, and built artifact presence.
- Require canonical authored release notes for real plugin releases while keeping dry-run note previews flexible.

## Verification
- npm run test:release-script
- npm run check:release-surfaces -- --version 5.5.0 --require-notes
- npm run check:plugin:fast
- npm test
- npm run build
- npm run check:release-surfaces -- --version 5.5.0 --require-notes --check-artifacts
- npm run check:plugin
- gitleaks git --redact --log-opts='origin/main..HEAD'
