### PR TITLE
Optimize and stabilize SystemSculpt Search

### DIFF
--- a/src/css/components/systemsculpt-search.css
+++ b/src/css/components/systemsculpt-search.css
@@ -77,13 +77,6 @@
   color: var(--text-normal);
 }
 
-.ss-search__metrics,
-.ss-search__state {
-  color: var(--text-muted);
-  font-size: 12px;
-  padding: 0 2px;
-}
-
 /* Results */
 .ss-search__list {
   display: flex;

--- a/src/css/components/systemsculpt-search.css
+++ b/src/css/components/systemsculpt-search.css
@@ -14,88 +14,6 @@
   min-height: 0;
 }
 
-/* Controls */
-.ss-search__controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
-  gap: 8px;
-  padding: 4px 0 0;
-  border-bottom: 1px solid var(--background-modifier-border);
-}
-
-.ss-search__mode-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  flex: 1 1 220px;
-}
-
-.ss-search__sort {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  align-items: center;
-}
-
-.ss-search__pill {
-  appearance: none;
-  border: 1px solid var(--background-modifier-border);
-  background: var(--background-primary);
-  color: var(--text-normal);
-  border-radius: 6px;
-  padding: 10px 12px;
-  min-height: 40px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 2px;
-  text-align: left;
-  font-size: 13px;
-  line-height: 1.3;
-  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
-  box-shadow: none;
-}
-
-.ss-search__pill:disabled,
-.ss-search__pill.is-disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-  background: var(--background-modifier-hover);
-}
-
-.ss-search__pill:hover {
-  border-color: var(--interactive-accent);
-  background: var(--background-modifier-hover);
-}
-
-.ss-search__pill.is-active {
-  border-color: var(--interactive-accent);
-  background: color-mix(in srgb, var(--interactive-accent) 14%, var(--background-primary));
-}
-
-.ss-search__pill-label {
-  font-weight: 600;
-  font-size: 13px;
-}
-
-.ss-search__pill-desc {
-  font-size: 12px;
-  color: var(--text-muted);
-  line-height: 1.35;
-}
-
-.ss-search__pill--chip {
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 6px 12px;
-  min-width: 0;
-  border-radius: 16px;
-  font-weight: 600;
-}
-
 /* Search bar */
 .ss-search__input-row {
   display: flex;
@@ -240,32 +158,6 @@ mark.ss-hl {
   color: var(--text-normal);
   padding: 0 2px;
   border-radius: 3px;
-}
-
-/* Result origin labels */
-.ss-search__pill--lexical,
-.ss-search__pill--blend,
-.ss-search__pill--semantic,
-.ss-search__pill--recent {
-  border-radius: 12px;
-  padding: 4px 8px;
-  min-height: 0;
-  font-weight: 600;
-  font-size: 12px;
-  line-height: 1.2;
-}
-
-.ss-search__pill--lexical,
-.ss-search__pill--recent {
-  background: var(--background-secondary);
-}
-
-.ss-search__pill--blend {
-  background: color-mix(in srgb, var(--interactive-accent) 14%, var(--background-secondary));
-}
-
-.ss-search__pill--semantic {
-  background: color-mix(in srgb, var(--interactive-accent) 24%, var(--background-secondary));
 }
 
 .ss-search__loading,

--- a/src/css/components/systemsculpt-search.css
+++ b/src/css/components/systemsculpt-search.css
@@ -1,17 +1,41 @@
-/* SystemSculpt Search — rebuilt to match native Obsidian, minimal and compact */
+/* SystemSculpt Search - focused vault search layout */
+
+.ss-modal.ss-search-modal {
+  width: min(860px, 94vw);
+  height: min(760px, 84vh);
+  max-width: 94vw;
+  max-height: 86vh;
+}
+
+.ss-search-modal .ss-modal__header {
+  display: none;
+}
+
+body.ss-search-open .tooltip {
+  display: none !important;
+}
+
+.ss-search-modal .ss-modal__content {
+  min-height: 0;
+  overflow: hidden;
+  padding: 16px 16px 0;
+}
 
 .ss-search__content {
   display: flex;
   flex-direction: column;
   min-height: 0;
   height: 100%;
+  overflow: hidden;
 }
 
 .ss-search {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  gap: 10px;
   min-height: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 /* Search bar */
@@ -24,6 +48,7 @@
   border-radius: 6px;
   background: var(--background-primary);
   min-height: 36px;
+  flex-shrink: 0;
 }
 
 .ss-search__icon {
@@ -37,6 +62,7 @@
 
 .ss-search__input {
   flex: 1;
+  min-width: 0;
   border: none;
   background: transparent;
   outline: none;
@@ -67,29 +93,41 @@
   color: var(--text-normal);
 }
 
+.ss-search__status {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.3;
+  min-height: 16px;
+  padding: 0 2px;
+  flex-shrink: 0;
+}
+
 /* Results */
 .ss-search__list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  overflow-y: auto;
-  padding: 6px 2px 12px;
-  scroll-padding: 8px;
-  flex: 1;
+  display: block;
   min-height: 0;
+  margin: 0;
+  padding: 0 4px 12px;
+  overflow-y: auto;
+  scroll-padding: 10px;
   overscroll-behavior: contain;
 }
 
 .ss-search__item {
-  border: 1px solid var(--background-modifier-border);
-  border-radius: 8px;
-  padding: 10px 12px;
-  background: var(--background-primary);
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  border-bottom: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  padding: 10px 12px 11px;
+  background: transparent;
+  cursor: pointer;
+  overflow: hidden;
   transition: border-color 120ms ease, background-color 120ms ease;
 }
 
 .ss-search__item:hover {
-  border-color: var(--interactive-accent);
   background: var(--background-modifier-hover);
 }
 
@@ -98,36 +136,51 @@
   outline-offset: 2px;
 }
 
+.ss-search__item[aria-selected="true"] {
+  background: var(--background-modifier-hover);
+}
+
 .ss-search__item-top {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  align-items: flex-start;
+  display: block;
+  min-width: 0;
 }
 
 .ss-search__title {
+  display: block;
+  min-width: 0;
   font-size: 14px;
   font-weight: 600;
   line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ss-search__meta {
-  margin-top: 4px;
+  margin-top: 2px;
   color: var(--text-muted);
   font-size: 12px;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ss-search__excerpt {
-  margin-top: 6px;
+  display: block;
+  margin-top: 5px;
   color: var(--text-normal);
-  line-height: 1.45;
+  line-height: 18px;
   font-size: 13px;
+  max-height: 36px;
+  overflow: hidden;
+  overflow-wrap: anywhere;
 }
 
-.ss-search__excerpt mark.ss-hl,
-mark.ss-hl {
+.ss-search-modal mark.ss-hl {
   background: color-mix(in srgb, var(--interactive-accent) 35%, var(--background-primary));
   color: var(--text-normal);
+  text-decoration: none;
   padding: 0 2px;
   border-radius: 3px;
 }
@@ -137,4 +190,41 @@ mark.ss-hl {
   text-align: center;
   color: var(--text-muted);
   padding: 12px 0;
+}
+
+.ss-search__footer {
+  border-top: 1px solid var(--background-modifier-border);
+  flex: 0 0 auto;
+  justify-content: center;
+  min-height: 32px;
+  padding: 8px 16px;
+}
+
+.ss-search__hint {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.is-mobile .ss-search-modal .ss-search__footer,
+.is-phone .ss-search-modal .ss-search__footer {
+  display: none;
+}
+
+@media (max-width: 700px) {
+  .ss-modal.ss-search-modal {
+    width: 96vw;
+    height: 82vh;
+  }
+
+  .ss-search-modal .ss-modal__content {
+    padding: 12px 12px 0;
+  }
+
+  .ss-search__list {
+    padding-inline: 0;
+  }
+
+  .ss-search__excerpt {
+    max-height: 18px;
+  }
 }

--- a/src/css/components/systemsculpt-search.css
+++ b/src/css/components/systemsculpt-search.css
@@ -35,12 +35,6 @@
   color: var(--text-muted);
 }
 
-.ss-search__icon::before {
-  content: "\1F50D";
-  opacity: 0.7;
-  font-size: 14px;
-}
-
 .ss-search__input {
   flex: 1;
   border: none;
@@ -55,21 +49,17 @@
 }
 
 .ss-search__clear {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
   border: 1px solid var(--background-modifier-border);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 14px;
-}
-
-.ss-search__clear::before {
-  content: "×";
-  line-height: 1;
+  background: transparent;
+  padding: 0;
 }
 
 .ss-search__clear:hover {
@@ -103,6 +93,11 @@
   background: var(--background-modifier-hover);
 }
 
+.ss-search__item:focus {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
+}
+
 .ss-search__item-top {
   display: flex;
   justify-content: space-between;
@@ -114,22 +109,6 @@
   font-size: 14px;
   font-weight: 600;
   line-height: 1.35;
-}
-
-.ss-search__badges {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  flex-shrink: 0;
-}
-
-.ss-search__score {
-  padding: 4px 8px;
-  border-radius: 999px;
-  background: var(--background-secondary);
-  color: var(--text-normal);
-  font-weight: 600;
-  font-size: 12px;
 }
 
 .ss-search__meta {
@@ -158,9 +137,4 @@ mark.ss-hl {
   text-align: center;
   color: var(--text-muted);
   padding: 12px 0;
-}
-
-/* Draggable cursor for results list */
-.ss-modal__list.scs-draggable {
-  cursor: grab;
 }

--- a/src/mcp-tools/filesystem/__tests__/utils-pure.test.ts
+++ b/src/mcp-tools/filesystem/__tests__/utils-pure.test.ts
@@ -724,6 +724,21 @@ describe("shouldExcludeFromSearch", () => {
     expect(shouldExcludeFromSearch(file, plugin)).toBe(false);
   });
 
+  it("skips likely unsafe regex patterns", () => {
+    const plugin = createMockPlugin({
+      settings: {
+        embeddingsExclusions: {
+          patterns: ["(a+)+b", "\\.tmp$"],
+        },
+      },
+    });
+    const regularFile = new TFile({ path: "notes/aaaaaaaaaaaaaaaaaaaaaaaaaaaa.md" });
+    const tmpFile = new TFile({ path: "notes/cache.tmp" });
+
+    expect(shouldExcludeFromSearch(regularFile, plugin)).toBe(false);
+    expect(shouldExcludeFromSearch(tmpFile, plugin)).toBe(true);
+  });
+
   it("respects ignoreChatHistory setting when false", () => {
     const plugin = createMockPlugin({
       settings: {

--- a/src/mcp-tools/filesystem/searchUtils.ts
+++ b/src/mcp-tools/filesystem/searchUtils.ts
@@ -1,6 +1,37 @@
 import { TFile } from "obsidian";
 import type SystemSculptPlugin from "../../main";
 
+const regexCache = new Map<string, RegExp | null>();
+const REGEX_CACHE_LIMIT = 200;
+
+function getCachedSafeRegex(pattern: string): RegExp | null {
+  const cached = regexCache.get(pattern);
+  if (cached !== undefined) return cached;
+
+  if (regexCache.size >= REGEX_CACHE_LIMIT) {
+    regexCache.clear();
+  }
+
+  if (isLikelyUnsafeRegex(pattern)) {
+    regexCache.set(pattern, null);
+    return null;
+  }
+
+  try {
+    const regex = new RegExp(pattern);
+    regexCache.set(pattern, regex);
+    return regex;
+  } catch {
+    regexCache.set(pattern, null);
+    return null;
+  }
+}
+
+function isLikelyUnsafeRegex(pattern: string): boolean {
+  if (pattern.length > 240) return true;
+  return /\((?:[^()\\]|\\.)*[+*](?:[^()\\]|\\.)*\)[+*{]/.test(pattern);
+}
+
 /**
  * Check if a file should be excluded from search results.
  * This lives in a mobile-safe module so search surfaces do not pull Node helpers.
@@ -21,13 +52,9 @@ export function shouldExcludeFromSearch(file: TFile, plugin: SystemSculptPlugin)
       const userIgnoreFilters = plugin.app.vault.getConfig("userIgnoreFilters");
       if (userIgnoreFilters && Array.isArray(userIgnoreFilters)) {
         for (const pattern of userIgnoreFilters) {
-          try {
-            const regex = new RegExp(pattern);
-            if (regex.test(file.path)) {
-              return true;
-            }
-          } catch {
-            // Ignore invalid user regex patterns.
+          const regex = getCachedSafeRegex(String(pattern));
+          if (regex?.test(file.path)) {
+            return true;
           }
         }
       }
@@ -63,13 +90,9 @@ export function shouldExcludeFromSearch(file: TFile, plugin: SystemSculptPlugin)
 
   if (plugin.settings.embeddingsExclusions?.patterns) {
     for (const pattern of plugin.settings.embeddingsExclusions.patterns) {
-      try {
-        const regex = new RegExp(pattern);
-        if (regex.test(file.path)) {
-          return true;
-        }
-      } catch {
-        // Ignore invalid user regex patterns.
+      const regex = getCachedSafeRegex(String(pattern));
+      if (regex?.test(file.path)) {
+        return true;
       }
     }
   }

--- a/src/modals/SystemSculptSearchModal.ts
+++ b/src/modals/SystemSculptSearchModal.ts
@@ -3,8 +3,6 @@ import type SystemSculptPlugin from "../main";
 import { StandardModal } from "../core/ui/modals/standard/StandardModal";
 import type {
   SystemSculptSearchEngine,
-  SearchMode,
-  SortMode,
   SearchHit,
   SearchResponse,
 } from "../services/search/SystemSculptSearchEngine";
@@ -16,12 +14,9 @@ export class SystemSculptSearchModal extends StandardModal {
   private listEl: HTMLElement | null = null;
   private metricsEl: HTMLElement | null = null;
   private stateEl: HTMLElement | null = null;
-  private modeButtons: Partial<Record<SearchMode, HTMLButtonElement>> = {};
-  private sortButtons: Partial<Record<SortMode, HTMLButtonElement>> = {};
   private embeddings: SearchResponse["embeddings"] | null = null;
 
-  private mode: SearchMode = "smart";
-  private sort: SortMode = "relevance";
+  private readonly SEARCH_LIMIT = 80;
   private currentQuery = "";
   private debounceHandle: number | null = null;
   private querySerial = 0;
@@ -40,14 +35,10 @@ export class SystemSculptSearchModal extends StandardModal {
 
     this.addTitle(
       "SystemSculpt Search",
-      "Fast lexical search with optional semantic lift. Mode indicators show exactly when embeddings are used."
+      "Search your notes. Embeddings join automatically when they are ready."
     );
 
     const shell = this.contentEl.createDiv({ cls: "ss-search" });
-
-    const controlRow = shell.createDiv({ cls: "ss-search__controls" });
-    this.buildModeSelector(controlRow);
-    this.buildSortToggle(controlRow);
 
     this.searchInputEl = this.buildSearchBar(shell, "Search your vault...", (value) => this.onSearchChange(value));
 
@@ -61,6 +52,7 @@ export class SystemSculptSearchModal extends StandardModal {
 
     setTimeout(() => this.searchInputEl?.focus(), 0);
     void this.renderRecents();
+    this.engine.warmIndex();
   }
 
   onClose() {
@@ -69,64 +61,6 @@ export class SystemSculptSearchModal extends StandardModal {
       this.debounceHandle = null;
     }
     super.onClose();
-  }
-
-  private buildModeSelector(container: HTMLElement) {
-    const group = container.createDiv({ cls: "ss-search__mode-group" });
-    const modes: Array<{ id: SearchMode; label: string; desc: string }> = [
-      { id: "lexical", label: "Fast", desc: "Pure lexical, zero embeddings" },
-      { id: "smart", label: "Smart", desc: "Lexical + embeddings when available" },
-      { id: "semantic", label: "Semantic", desc: "Embeddings first" },
-    ];
-
-    modes.forEach((mode) => {
-      const btn = group.createEl("button", {
-        cls: "ss-search__pill ss-search__pill--ghost",
-        attr: { "data-mode": mode.id },
-      });
-      btn.createSpan({ cls: "ss-search__pill-label", text: mode.label });
-      btn.createSpan({ cls: "ss-search__pill-desc", text: mode.desc });
-
-      this.registerDomEvent(btn, "click", () => {
-        if (btn.disabled) return;
-        this.mode = mode.id;
-        this.syncModeButtons();
-        void this.executeSearch(this.currentQuery);
-      });
-
-      this.modeButtons[mode.id] = btn;
-    });
-
-    this.syncModeButtons();
-    if (this.embeddings) {
-      this.syncModeAvailability(this.embeddings);
-    }
-  }
-
-  private buildSortToggle(container: HTMLElement) {
-    const sortWrap = container.createDiv({ cls: "ss-search__sort" });
-    const sorts: Array<{ id: SortMode; label: string }> = [
-      { id: "relevance", label: "Relevance" },
-      { id: "recency", label: "Recency" },
-    ];
-
-    sorts.forEach((sort) => {
-      const btn = sortWrap.createEl("button", {
-        cls: "ss-search__pill ss-search__pill--chip",
-        attr: { "data-sort": sort.id },
-        text: sort.label,
-      });
-
-      this.registerDomEvent(btn, "click", () => {
-        this.sort = sort.id;
-        this.syncSortButtons();
-        void this.executeSearch(this.currentQuery);
-      });
-
-      this.sortButtons[sort.id] = btn;
-    });
-
-    this.syncSortButtons();
   }
 
   private buildSearchBar(parent: HTMLElement, placeholder: string, onInput: (value: string) => void): HTMLInputElement {
@@ -178,12 +112,12 @@ export class SystemSculptSearchModal extends StandardModal {
       return;
     }
 
-    this.renderLoading("Indexing & searching...");
+    this.renderLoading("Searching...");
 
     const response = await this.engine.search(trimmed, {
-      mode: this.mode,
-      sort: this.sort,
-      limit: 80,
+      mode: "smart",
+      sort: "relevance",
+      limit: this.SEARCH_LIMIT,
     });
 
     if (serial < this.querySerial) return;
@@ -193,7 +127,7 @@ export class SystemSculptSearchModal extends StandardModal {
 
   private async renderRecents() {
     const serial = ++this.querySerial;
-    this.renderLoading("Pulling your newest notes...");
+    this.renderLoading("Opening recent notes...");
     const recents = await this.engine.getRecent(25);
     if (serial < this.querySerial) return;
     const indicator = this.engine.getEmbeddingsIndicator();
@@ -203,18 +137,16 @@ export class SystemSculptSearchModal extends StandardModal {
       totalMs: 0,
       indexedCount: recents.length,
       inspectedCount: recents.length,
-      mode: this.mode,
+      mode: "smart",
       usedEmbeddings: false,
     });
-    this.syncModeAvailability(indicator);
-    this.renderState("Showing your 25 most recent files.");
+    this.renderState(this.recentsStateText(indicator));
   }
 
   private renderResponse(response: SearchResponse) {
     this.embeddings = response.embeddings;
     this.renderMetrics(response.stats);
     this.renderState(this.stateTextFor(response));
-    this.syncModeAvailability(response.embeddings);
     this.renderResults(response.results);
   }
 
@@ -223,7 +155,7 @@ export class SystemSculptSearchModal extends StandardModal {
     this.listEl.empty();
 
     if (results.length === 0) {
-      this.renderEmpty("No matches yet. Try fewer words or switch modes.");
+      this.renderEmpty("No matches yet. Try fewer words.");
       return;
     }
 
@@ -237,11 +169,9 @@ export class SystemSculptSearchModal extends StandardModal {
       titleEl.innerHTML = this.getHighlightedText(result.title, this.currentQuery);
 
       const badges = header.createDiv({ cls: "ss-search__badges" });
-      badges.createSpan({
-        cls: `ss-search__pill ss-search__pill--${result.origin}`,
-        text: this.labelForOrigin(result.origin),
-      });
-      badges.createSpan({ cls: "ss-search__score", text: `${Math.round((result.score || 0) * 100)}%` });
+      if (result.origin !== "recent") {
+        badges.createSpan({ cls: "ss-search__score", text: `${Math.round((result.score || 0) * 100)}%` });
+      }
 
       const meta = item.createDiv({ cls: "ss-search__meta" });
       meta.setText(`${result.path} • ${this.formatUpdated(result.updatedAt)}${result.size ? ` • ${this.formatSize(result.size)}` : ""}`);
@@ -286,14 +216,13 @@ export class SystemSculptSearchModal extends StandardModal {
     if (!this.metricsEl) return;
     const parts: string[] = [];
     if (typeof stats.totalMs === "number") parts.push(`Total ${Math.round(stats.totalMs)} ms`);
-    if (typeof stats.lexMs === "number") parts.push(`Lex ${Math.round(stats.lexMs)} ms`);
-    if (typeof stats.semMs === "number") parts.push(`Semantic ${Math.round(stats.semMs)} ms`);
+    if (typeof stats.lexMs === "number") parts.push(`Notes ${Math.round(stats.lexMs)} ms`);
+    if (typeof stats.semMs === "number") parts.push(`Embeddings ${Math.round(stats.semMs)} ms`);
     if (typeof stats.indexMs === "number") parts.push(`Index ${Math.round(stats.indexMs)} ms`);
     if (typeof stats.indexedCount === "number") parts.push(`${stats.indexedCount} indexed`);
-    if (typeof stats.inspectedCount === "number") parts.push(`${stats.inspectedCount} scanned`);
+    if (typeof stats.inspectedCount === "number") parts.push(`${stats.inspectedCount} checked`);
 
-    const modeLabel = stats.mode ? this.labelForMode(stats.mode) : "";
-    this.metricsEl.setText(parts.length ? `${modeLabel} • ${parts.join(" • ")}` : modeLabel);
+    this.metricsEl.setText(parts.join(" • "));
   }
 
   private renderState(message: string) {
@@ -304,85 +233,39 @@ export class SystemSculptSearchModal extends StandardModal {
   private stateTextFor(response: SearchResponse): string {
     const usedEmbeddings = response.stats.usedEmbeddings;
     const emb = response.embeddings;
-    if (this.mode === "lexical") {
-      return "Fast – fastest path.";
-    }
     if (usedEmbeddings) {
-      return "Smart blend: embeddings contributed to these results.";
+      return "Searching notes and embeddings.";
     }
     if (!emb.enabled) {
-      return "Embeddings off in settings – running lexical search only.";
+      return "Searching notes. Embeddings are off.";
     }
-    if (!emb.available) {
-      return emb.reason ? `Embeddings unavailable: ${emb.reason}` : "Embeddings not ready yet; showing lexical results.";
+    if (!emb.ready || !emb.available) {
+      return emb.reason ? `Searching notes. Embeddings unavailable: ${emb.reason}` : "Searching notes. Embeddings are still preparing.";
     }
-    return "Embeddings ready but not used for this query (short query or no vectors).";
+    const processed = emb.processed ?? 0;
+    const total = emb.total ?? 0;
+    if (total > 0 && processed / total < 0.75) {
+      return "Searching notes. Embeddings will join when more of the vault is indexed.";
+    }
+    if (response.stats.embeddingsEligible) {
+      return "Searching notes. Embeddings checked in, but note matches won.";
+    }
+    return "Searching notes.";
   }
 
-  private syncModeButtons() {
-    Object.entries(this.modeButtons).forEach(([mode, btn]) => {
-      if (!btn) return;
-      if (mode === this.mode) {
-        btn.addClass("is-active");
-      } else {
-        btn.removeClass("is-active");
-      }
-    });
-  }
-
-  private syncModeAvailability(indicator: SearchResponse["embeddings"]) {
-    const embeddingsReady = indicator.enabled && indicator.ready && indicator.available;
-
-    Object.entries(this.modeButtons).forEach(([mode, btn]) => {
-      if (!btn) return;
-      if (mode === "lexical") {
-        btn.disabled = false;
-        btn.removeClass("is-disabled");
-        return;
-      }
-      btn.disabled = !embeddingsReady;
-      btn.toggleClass("is-disabled", !embeddingsReady);
-    });
-
-    if (!embeddingsReady && this.mode !== "lexical") {
-      this.mode = "lexical";
-      this.syncModeButtons();
+  private recentsStateText(indicator: SearchResponse["embeddings"]): string {
+    if (!indicator.enabled) {
+      return "Recent notes. Search will use note text.";
     }
-  }
-
-  private syncSortButtons() {
-    Object.entries(this.sortButtons).forEach(([sort, btn]) => {
-      if (!btn) return;
-      if (sort === this.sort) {
-        btn.addClass("is-active");
-      } else {
-        btn.removeClass("is-active");
-      }
-    });
-  }
-
-  private labelForOrigin(origin: SearchHit["origin"]): string {
-    switch (origin) {
-      case "semantic":
-        return "Semantic";
-      case "blend":
-        return "Blended";
-      case "recent":
-        return "Recent";
-      default:
-        return "Lexical";
+    const processed = indicator.processed ?? 0;
+    const total = indicator.total ?? 0;
+    if (!indicator.ready || !indicator.available) {
+      return "Recent notes. Embeddings are still preparing.";
     }
-  }
-
-  private labelForMode(mode: SearchMode): string {
-    switch (mode) {
-      case "lexical":
-        return "Fast";
-      case "semantic":
-        return "Semantic first";
-      default:
-        return "Smart blend";
+    if (total > 0 && processed / total < 0.75) {
+      return "Recent notes. Embeddings will join after more of the vault is indexed.";
     }
+    return "Recent notes. Embeddings are ready for detailed searches.";
   }
 
   private formatUpdated(ts?: number): string {

--- a/src/modals/SystemSculptSearchModal.ts
+++ b/src/modals/SystemSculptSearchModal.ts
@@ -8,11 +8,17 @@ import type {
 } from "../services/search/SystemSculptSearchEngine";
 
 export class SystemSculptSearchModal extends StandardModal {
+  private static nextListId = 0;
   private engine: SystemSculptSearchEngine;
   private searchInputEl: HTMLInputElement | null = null;
+  private statusEl: HTMLElement | null = null;
   private listEl: HTMLElement | null = null;
+  private activeResultEl: HTMLElement | null = null;
 
-  private readonly SEARCH_LIMIT = 80;
+  private readonly SEARCH_LIMIT = 30;
+  private readonly RECENT_LIMIT = 25;
+  private readonly STABLE_TOP_COUNT = 14;
+  private readonly listId = `ss-search-results-${++SystemSculptSearchModal.nextListId}`;
   private currentQuery = "";
   private debounceHandle: number | null = null;
   private recentPreviewHandle: number | null = null;
@@ -24,30 +30,37 @@ export class SystemSculptSearchModal extends StandardModal {
   constructor(plugin: SystemSculptPlugin) {
     super(plugin.app);
     this.engine = plugin.getSearchEngine();
-    this.setSize("fullwidth");
+    this.setSize("large");
+    this.modalEl.addClass("ss-search-modal");
   }
 
   onOpen() {
     super.onOpen();
+    document.body.classList.add("ss-search-open");
     this.contentEl.addClass("ss-search__content");
-    this.footerEl.style.display = "none";
-
-    this.addTitle("SystemSculpt Search");
+    this.footerEl.addClass("ss-search__footer");
+    this.footerEl.createDiv({ text: "↑/↓ Navigate · Enter Open · Esc Close", cls: "ss-search__hint" });
 
     const shell = this.contentEl.createDiv({ cls: "ss-search" });
     this.searchInputEl = this.buildSearchBar(shell, "Search your vault...", (value) => this.onSearchChange(value));
 
-    this.listEl = shell.createDiv({ cls: "ss-modal__list ss-search__list" });
+    this.statusEl = shell.createDiv({ cls: "ss-search__status" });
+    this.statusEl.setAttr("aria-live", "polite");
+
+    this.listEl = shell.createDiv({ cls: "ss-search__list" });
+    this.listEl.id = this.listId;
     this.listEl.setAttr("role", "listbox");
     this.listEl.setAttr("aria-label", "Search results");
     this.registerDomEvent(this.listEl, "click", (event) => void this.handleResultClick(event));
     this.registerDomEvent(this.listEl, "keydown", (event) => void this.handleResultKeydown(event as KeyboardEvent));
+    this.registerDomEvent(this.listEl, "focusin", (event) => this.handleResultFocus(event));
 
     setTimeout(() => this.searchInputEl?.focus(), 0);
     void this.renderRecents();
   }
 
   onClose() {
+    document.body.classList.remove("ss-search-open");
     this.querySerial += 1;
     this.cancelSearch();
     this.cancelRecentPreviewHydration();
@@ -58,7 +71,9 @@ export class SystemSculptSearchModal extends StandardModal {
     }
     super.onClose();
     this.searchInputEl = null;
+    this.statusEl = null;
     this.listEl = null;
+    this.activeResultEl = null;
   }
 
   private buildSearchBar(parent: HTMLElement, placeholder: string, onInput: (value: string) => void): HTMLInputElement {
@@ -71,6 +86,14 @@ export class SystemSculptSearchModal extends StandardModal {
       type: "text",
       placeholder,
       cls: "ss-search__input",
+      attr: {
+        role: "combobox",
+        autocomplete: "off",
+        "aria-label": "Search your vault",
+        "aria-autocomplete": "list",
+        "aria-controls": this.listId,
+        "aria-expanded": "false",
+      },
     });
 
     const clear = wrapper.createEl("button", {
@@ -94,14 +117,14 @@ export class SystemSculptSearchModal extends StandardModal {
       const firstItem = this.getResultItems()[0];
       if (!firstItem) return;
       keyboardEvent.preventDefault();
-      firstItem.focus();
+      this.focusResult(firstItem);
     });
 
     this.registerDomEvent(clear, "click", () => {
       input.value = "";
       clear.style.display = "none";
       onInput("");
-      input.focus();
+      this.focusSearchInput();
     });
 
     return input;
@@ -197,7 +220,7 @@ export class SystemSculptSearchModal extends StandardModal {
       });
 
       if (serial === this.querySerial && !controller.signal.aborted) {
-        this.renderResponse(response);
+        this.renderResponse(response, { stabilize: true });
       }
     } catch (error) {
       if (!this.isAbortError(error) && serial === this.querySerial) {
@@ -213,41 +236,63 @@ export class SystemSculptSearchModal extends StandardModal {
   private async renderRecents() {
     const serial = ++this.querySerial;
     this.cancelRecentPreviewHydration();
-    const recents = await this.engine.getRecent(25);
-    if (serial < this.querySerial) return;
-    this.renderResults(recents);
-    this.scheduleRecentPreviewHydration(recents, serial);
+    try {
+      const recents = await this.engine.getRecent(this.RECENT_LIMIT);
+      if (serial < this.querySerial) return;
+      this.renderResults(recents, { label: "Recent", context: "recent" });
+      this.scheduleRecentPreviewHydration(recents, serial);
+    } catch {
+      if (serial < this.querySerial) return;
+      this.setStatus("Recent");
+      this.renderEmpty("Could not load recent notes.");
+    }
   }
 
-  private renderResponse(response: SearchResponse) {
-    this.renderResults(response.results);
+  private renderResponse(response: SearchResponse, options: { stabilize?: boolean } = {}) {
+    const count = response.results.length;
+    const label = `${count} ${count === 1 ? "result" : "results"}`;
+    this.renderResults(response.results, {
+      label,
+      context: "search",
+      stabilize: options.stabilize,
+    });
   }
 
-  private renderResults(results: SearchHit[]) {
+  private renderResults(
+    results: SearchHit[],
+    options: { label: string; context: "recent" | "search"; stabilize?: boolean }
+  ) {
     if (!this.listEl) return;
-    this.listEl.empty();
+    const previousState = this.captureListState();
+    const orderedResults = options.stabilize
+      ? this.stabilizeResults(results, previousState.renderedPaths, previousState.focusedPath)
+      : results;
 
-    if (results.length === 0) {
-      this.renderEmpty("No matches yet. Try fewer words.");
+    this.setStatus(options.label);
+    this.clearActiveResult();
+    this.listEl.empty();
+    this.setComboboxExpanded(orderedResults.length > 0);
+
+    if (orderedResults.length === 0) {
+      this.renderEmpty(options.context === "recent" ? "No recent notes yet." : "No matches yet. Try fewer words.");
       return;
     }
 
-    results.forEach((result) => {
+    orderedResults.forEach((result, index) => {
       const item = document.createElement("div");
       item.className = "ss-search__item";
+      item.id = this.resultId(index);
       item.setAttr("data-path", result.path);
       item.setAttr("role", "option");
-      item.setAttr("tabindex", "0");
-      item.setAttr("aria-label", `${result.title}, ${result.path}`);
+      item.setAttr("tabindex", "-1");
+      item.setAttr("aria-selected", "false");
 
       const header = item.createDiv({ cls: "ss-search__item-top" });
       const titleEl = header.createDiv({ cls: "ss-search__title" });
       this.appendHighlightedText(titleEl, result.title, this.currentQuery);
 
       const meta = item.createDiv({ cls: "ss-search__meta" });
-      const metaParts = [result.path, this.formatUpdated(result.updatedAt)];
-      if (result.size) metaParts.push(this.formatSize(result.size));
-      meta.setText(metaParts.join(" - "));
+      meta.setText([result.path, this.formatUpdated(result.updatedAt)].join(" · "));
 
       if (result.excerpt) {
         const excerpt = item.createDiv({ cls: "ss-search__excerpt" });
@@ -256,6 +301,8 @@ export class SystemSculptSearchModal extends StandardModal {
 
       this.listEl!.appendChild(item);
     });
+
+    this.restoreListState(previousState, options.stabilize === true);
   }
 
   private scheduleRecentPreviewHydration(results: SearchHit[], serial: number) {
@@ -300,13 +347,15 @@ export class SystemSculptSearchModal extends StandardModal {
       const preview = previews.get(path);
       if (!preview) return;
       const excerpt = item.createDiv({ cls: "ss-search__excerpt" });
-      this.appendHighlightedText(excerpt, preview, "");
+      excerpt.setText(preview);
     });
   }
 
   private renderLoading(text: string) {
     if (!this.listEl) return;
+    this.setStatus(text);
     this.listEl.empty();
+    this.setComboboxExpanded(false);
     const loading = this.listEl.createDiv("ss-modal__loading ss-search__loading");
     loading.createDiv({ text });
   }
@@ -314,6 +363,8 @@ export class SystemSculptSearchModal extends StandardModal {
   private renderEmpty(text: string) {
     if (!this.listEl) return;
     this.listEl.empty();
+    this.setComboboxExpanded(false);
+    this.clearActiveResult();
     const empty = this.listEl.createDiv("ss-modal__empty-state ss-search__empty");
     empty.createDiv({ text });
   }
@@ -328,7 +379,7 @@ export class SystemSculptSearchModal extends StandardModal {
     const item = this.findResultItem(event.target);
     if (!item) return;
 
-    if (event.key === "Enter" || event.key === " ") {
+    if (event.key === "Enter") {
       event.preventDefault();
       await this.openResult(item.getAttribute("data-path"));
       return;
@@ -341,7 +392,19 @@ export class SystemSculptSearchModal extends StandardModal {
     const nextIndex = event.key === "ArrowDown"
       ? Math.min(items.length - 1, currentIndex + 1)
       : Math.max(0, currentIndex - 1);
-    items[nextIndex]?.focus();
+    const nextItem = items[nextIndex];
+    if (nextItem === item && event.key === "ArrowUp") {
+      this.focusSearchInput();
+      this.clearActiveResult();
+      return;
+    }
+    if (nextItem) this.focusResult(nextItem);
+  }
+
+  private handleResultFocus(event: Event) {
+    const item = this.findResultItem(event.target);
+    if (!item) return;
+    this.setActiveResult(item);
   }
 
   private async openResult(path: string | null) {
@@ -365,6 +428,121 @@ export class SystemSculptSearchModal extends StandardModal {
 
   private hasRenderedResults(): boolean {
     return this.getResultItems().length > 0;
+  }
+
+  private captureListState(): {
+    renderedPaths: string[];
+    focusedPath: string | null;
+    focusedIndex: number;
+    hadListFocus: boolean;
+    scrollTop: number;
+  } {
+    const items = this.getResultItems();
+    const activeItem = this.findResultItem(document.activeElement);
+    const focusedIndex = activeItem ? items.indexOf(activeItem) : -1;
+    return {
+      renderedPaths: items.map((item) => item.getAttribute("data-path") ?? "").filter(Boolean),
+      focusedPath: activeItem?.getAttribute("data-path") ?? null,
+      focusedIndex,
+      hadListFocus: !!activeItem,
+      scrollTop: this.listEl?.scrollTop ?? 0,
+    };
+  }
+
+  private stabilizeResults(results: SearchHit[], renderedPaths: string[], focusedPath: string | null): SearchHit[] {
+    if (renderedPaths.length === 0 || results.length === 0) return results;
+
+    const nextByPath = new Map(results.map((result) => [result.path, result]));
+    const preservedPaths = new Set(renderedPaths.slice(0, this.STABLE_TOP_COUNT));
+    if (focusedPath) preservedPaths.add(focusedPath);
+
+    const preserved: SearchHit[] = [];
+    for (const path of renderedPaths) {
+      if (!preservedPaths.has(path)) continue;
+      const next = nextByPath.get(path);
+      if (next) preserved.push(next);
+    }
+
+    if (preserved.length === 0) return results;
+    const preservedSet = new Set(preserved.map((result) => result.path));
+    const additions = results.filter((result) => !preservedSet.has(result.path));
+    return [...preserved, ...additions].slice(0, results.length);
+  }
+
+  private restoreListState(state: ReturnType<SystemSculptSearchModal["captureListState"]>, stabilized: boolean) {
+    if (!this.listEl) return;
+
+    const focusTarget = state.focusedPath
+      ? this.getResultItems().find((item) => item.getAttribute("data-path") === state.focusedPath)
+      : null;
+
+    if (!stabilized) {
+      if (state.hadListFocus) {
+        this.focusSearchInput();
+      }
+      return;
+    }
+
+    this.listEl.scrollTop = state.scrollTop;
+
+    if (state.hadListFocus && state.focusedPath && !focusTarget) {
+      this.focusSearchInput(true);
+      this.clearActiveResult();
+      return;
+    }
+
+    const fallback = state.hadListFocus && state.focusedIndex >= 0
+      ? this.getResultItems()[Math.min(state.focusedIndex, this.getResultItems().length - 1)]
+      : null;
+    const item = focusTarget ?? fallback;
+    if (item) this.focusResult(item, true);
+  }
+
+  private focusSearchInput(preventScroll = false) {
+    if (!this.searchInputEl) return;
+    try {
+      this.searchInputEl.focus({ preventScroll });
+    } catch {
+      this.searchInputEl.focus();
+    }
+  }
+
+  private focusResult(item: HTMLElement, preventScroll = false) {
+    try {
+      item.focus({ preventScroll });
+    } catch {
+      item.focus();
+    }
+    this.setActiveResult(item);
+  }
+
+  private setActiveResult(activeItem: HTMLElement) {
+    if (this.activeResultEl && this.activeResultEl !== activeItem && this.activeResultEl.isConnected) {
+      this.activeResultEl.setAttr("aria-selected", "false");
+    }
+    activeItem.setAttr("aria-selected", "true");
+    this.activeResultEl = activeItem;
+    this.searchInputEl?.setAttr("aria-activedescendant", activeItem.id);
+  }
+
+  private clearActiveResult() {
+    if (this.activeResultEl?.isConnected) {
+      this.activeResultEl.setAttr("aria-selected", "false");
+    }
+    this.activeResultEl = null;
+    this.searchInputEl?.removeAttribute("aria-activedescendant");
+  }
+
+  private setComboboxExpanded(expanded: boolean) {
+    this.searchInputEl?.setAttr("aria-expanded", expanded ? "true" : "false");
+  }
+
+  private setStatus(text: string) {
+    this.statusEl?.setText(text);
+  }
+
+  private resultId(index: number): string {
+    return `${this.listId}-option-${index}`;
   }
 
   private cancelSearch() {
@@ -436,11 +614,5 @@ export class SystemSculptSearchModal extends StandardModal {
     if (diff < day) return "Updated today";
     if (diff < 7 * day) return `${Math.round(diff / day)}d ago`;
     return date.toLocaleDateString();
-  }
-
-  private formatSize(bytes: number): string {
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 }

--- a/src/modals/SystemSculptSearchModal.ts
+++ b/src/modals/SystemSculptSearchModal.ts
@@ -1,4 +1,4 @@
-import { Notice } from "obsidian";
+import { Notice, setIcon } from "obsidian";
 import type SystemSculptPlugin from "../main";
 import { StandardModal } from "../core/ui/modals/standard/StandardModal";
 import type {
@@ -16,6 +16,9 @@ export class SystemSculptSearchModal extends StandardModal {
   private currentQuery = "";
   private debounceHandle: number | null = null;
   private recentPreviewHandle: number | null = null;
+  private indexRefreshHandle: number | null = null;
+  private searchAbortController: AbortController | null = null;
+  private previewAbortController: AbortController | null = null;
   private querySerial = 0;
 
   constructor(plugin: SystemSculptPlugin) {
@@ -27,17 +30,18 @@ export class SystemSculptSearchModal extends StandardModal {
   onOpen() {
     super.onOpen();
     this.contentEl.addClass("ss-search__content");
+    this.footerEl.style.display = "none";
 
     this.addTitle("SystemSculpt Search");
 
     const shell = this.contentEl.createDiv({ cls: "ss-search" });
-
     this.searchInputEl = this.buildSearchBar(shell, "Search your vault...", (value) => this.onSearchChange(value));
 
     this.listEl = shell.createDiv({ cls: "ss-modal__list ss-search__list" });
-
-    this.addActionButton("Copy Results", () => this.copyResults(), false, "clipboard");
-    this.addActionButton("Close", () => this.close(), false, "x");
+    this.listEl.setAttr("role", "listbox");
+    this.listEl.setAttr("aria-label", "Search results");
+    this.registerDomEvent(this.listEl, "click", (event) => void this.handleResultClick(event));
+    this.registerDomEvent(this.listEl, "keydown", (event) => void this.handleResultKeydown(event as KeyboardEvent));
 
     setTimeout(() => this.searchInputEl?.focus(), 0);
     void this.renderRecents();
@@ -45,7 +49,9 @@ export class SystemSculptSearchModal extends StandardModal {
 
   onClose() {
     this.querySerial += 1;
+    this.cancelSearch();
     this.cancelRecentPreviewHydration();
+    this.cancelIndexRefresh();
     if (this.debounceHandle) {
       window.clearTimeout(this.debounceHandle);
       this.debounceHandle = null;
@@ -59,6 +65,7 @@ export class SystemSculptSearchModal extends StandardModal {
     const wrapper = parent.createDiv({ cls: "ss-search__input-row" });
     const icon = wrapper.createDiv({ cls: "ss-search__icon" });
     icon.setAttr("aria-hidden", "true");
+    setIcon(icon, "search");
 
     const input = wrapper.createEl("input", {
       type: "text",
@@ -66,13 +73,28 @@ export class SystemSculptSearchModal extends StandardModal {
       cls: "ss-search__input",
     });
 
-    const clear = wrapper.createDiv({ cls: "ss-search__clear" });
-    clear.setAttr("aria-label", "Clear search");
+    const clear = wrapper.createEl("button", {
+      type: "button",
+      cls: "ss-search__clear",
+      attr: {
+        "aria-label": "Clear search",
+      },
+    });
+    setIcon(clear, "x");
     clear.style.display = "none";
 
     this.registerDomEvent(input, "input", () => {
       clear.style.display = input.value ? "flex" : "none";
       onInput(input.value);
+    });
+
+    this.registerDomEvent(input, "keydown", (event) => {
+      const keyboardEvent = event as KeyboardEvent;
+      if (keyboardEvent.key !== "ArrowDown") return;
+      const firstItem = this.getResultItems()[0];
+      if (!firstItem) return;
+      keyboardEvent.preventDefault();
+      firstItem.focus();
     });
 
     this.registerDomEvent(clear, "click", () => {
@@ -104,26 +126,93 @@ export class SystemSculptSearchModal extends StandardModal {
     const serial = ++this.querySerial;
 
     if (!trimmed) {
+      this.cancelSearch();
+      this.cancelIndexRefresh();
       await this.renderRecents();
       return;
     }
 
     this.cancelRecentPreviewHydration();
-    this.renderLoading("Searching...");
+    this.cancelIndexRefresh();
+    this.cancelSearch();
 
-    const response = await this.engine.search(trimmed, {
-      mode: "smart",
-      sort: "relevance",
-      limit: this.SEARCH_LIMIT,
-    });
+    const controller = new AbortController();
+    this.searchAbortController = controller;
+    if (!this.hasRenderedResults()) {
+      this.renderLoading("Searching...");
+    }
 
-    if (serial < this.querySerial) return;
+    try {
+      const response = await this.engine.search(trimmed, {
+        mode: "smart",
+        sort: "relevance",
+        limit: this.SEARCH_LIMIT,
+        signal: controller.signal,
+      });
 
-    this.renderResponse(response);
+      if (serial < this.querySerial || controller.signal.aborted) return;
+      this.renderResponse(response);
+
+      if (response.stats.indexingPending && response.stats.metadataOnly) {
+        this.scheduleIndexRefresh(trimmed, serial);
+      }
+    } catch (error) {
+      if (this.isAbortError(error) || serial < this.querySerial) return;
+      this.renderEmpty("Search failed. Try again.");
+    } finally {
+      if (this.searchAbortController === controller) {
+        this.searchAbortController = null;
+      }
+    }
+  }
+
+  private scheduleIndexRefresh(query: string, serial: number) {
+    this.cancelIndexRefresh();
+    this.indexRefreshHandle = window.setTimeout(() => {
+      this.indexRefreshHandle = null;
+      void this.refreshAfterIndexReady(query, serial);
+    }, 0);
+  }
+
+  private cancelIndexRefresh() {
+    if (this.indexRefreshHandle !== null) {
+      window.clearTimeout(this.indexRefreshHandle);
+      this.indexRefreshHandle = null;
+    }
+  }
+
+  private async refreshAfterIndexReady(query: string, serial: number) {
+    let controller: AbortController | null = null;
+    try {
+      await this.engine.whenIndexReady();
+      if (serial !== this.querySerial || this.currentQuery.trim() !== query || !this.listEl) return;
+
+      controller = new AbortController();
+      this.searchAbortController = controller;
+      const response = await this.engine.search(query, {
+        mode: "smart",
+        sort: "relevance",
+        limit: this.SEARCH_LIMIT,
+        signal: controller.signal,
+      });
+
+      if (serial === this.querySerial && !controller.signal.aborted) {
+        this.renderResponse(response);
+      }
+    } catch (error) {
+      if (!this.isAbortError(error) && serial === this.querySerial) {
+        this.renderEmpty("Search failed. Try again.");
+      }
+    } finally {
+      if (controller && this.searchAbortController === controller) {
+        this.searchAbortController = null;
+      }
+    }
   }
 
   private async renderRecents() {
     const serial = ++this.querySerial;
+    this.cancelRecentPreviewHydration();
     const recents = await this.engine.getRecent(25);
     if (serial < this.querySerial) return;
     this.renderResults(recents);
@@ -147,37 +236,26 @@ export class SystemSculptSearchModal extends StandardModal {
       const item = document.createElement("div");
       item.className = "ss-search__item";
       item.setAttr("data-path", result.path);
+      item.setAttr("role", "option");
+      item.setAttr("tabindex", "0");
+      item.setAttr("aria-label", `${result.title}, ${result.path}`);
 
       const header = item.createDiv({ cls: "ss-search__item-top" });
       const titleEl = header.createDiv({ cls: "ss-search__title" });
-      titleEl.innerHTML = this.getHighlightedText(result.title, this.currentQuery);
-
-      const badges = header.createDiv({ cls: "ss-search__badges" });
-      if (result.origin !== "recent") {
-        badges.createSpan({ cls: "ss-search__score", text: `${Math.round((result.score || 0) * 100)}%` });
-      }
+      this.appendHighlightedText(titleEl, result.title, this.currentQuery);
 
       const meta = item.createDiv({ cls: "ss-search__meta" });
-      meta.setText(`${result.path} • ${this.formatUpdated(result.updatedAt)}${result.size ? ` • ${this.formatSize(result.size)}` : ""}`);
+      const metaParts = [result.path, this.formatUpdated(result.updatedAt)];
+      if (result.size) metaParts.push(this.formatSize(result.size));
+      meta.setText(metaParts.join(" - "));
 
       if (result.excerpt) {
         const excerpt = item.createDiv({ cls: "ss-search__excerpt" });
-        excerpt.innerHTML = this.getHighlightedText(result.excerpt, this.currentQuery);
+        this.appendHighlightedText(excerpt, result.excerpt, this.currentQuery);
       }
-
-      this.registerDomEvent(item, "click", async () => {
-        try {
-          await this.app.workspace.openLinkText(result.path, "");
-          this.close();
-        } catch {
-          new Notice(`Failed to open: ${result.path}`);
-        }
-      });
 
       this.listEl!.appendChild(item);
     });
-
-    this.makeDraggable(results);
   }
 
   private scheduleRecentPreviewHydration(results: SearchHit[], serial: number) {
@@ -190,7 +268,7 @@ export class SystemSculptSearchModal extends StandardModal {
     this.recentPreviewHandle = window.setTimeout(() => {
       this.recentPreviewHandle = null;
       void this.hydrateRecentPreviews(paths, serial);
-    }, 0);
+    }, 30);
   }
 
   private cancelRecentPreviewHydration() {
@@ -198,11 +276,20 @@ export class SystemSculptSearchModal extends StandardModal {
       window.clearTimeout(this.recentPreviewHandle);
       this.recentPreviewHandle = null;
     }
+    this.previewAbortController?.abort();
+    this.previewAbortController = null;
   }
 
   private async hydrateRecentPreviews(paths: string[], serial: number) {
-    const previews = await this.engine.getRecentPreviews(paths, 25);
-    if (serial !== this.querySerial || this.currentQuery.trim().length > 0 || !this.listEl) {
+    const controller = new AbortController();
+    this.previewAbortController = controller;
+    const previews = await this.engine.getRecentPreviews(paths, 25, controller.signal);
+    if (
+      controller.signal.aborted ||
+      serial !== this.querySerial ||
+      this.currentQuery.trim().length > 0 ||
+      !this.listEl
+    ) {
       return;
     }
 
@@ -212,7 +299,8 @@ export class SystemSculptSearchModal extends StandardModal {
       if (!path || item.querySelector(".ss-search__excerpt")) return;
       const preview = previews.get(path);
       if (!preview) return;
-      item.createDiv({ cls: "ss-search__excerpt", text: preview });
+      const excerpt = item.createDiv({ cls: "ss-search__excerpt" });
+      this.appendHighlightedText(excerpt, preview, "");
     });
   }
 
@@ -230,6 +318,115 @@ export class SystemSculptSearchModal extends StandardModal {
     empty.createDiv({ text });
   }
 
+  private async handleResultClick(event: Event) {
+    const item = this.findResultItem(event.target);
+    if (!item) return;
+    await this.openResult(item.getAttribute("data-path"));
+  }
+
+  private async handleResultKeydown(event: KeyboardEvent) {
+    const item = this.findResultItem(event.target);
+    if (!item) return;
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      await this.openResult(item.getAttribute("data-path"));
+      return;
+    }
+
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+    event.preventDefault();
+    const items = this.getResultItems();
+    const currentIndex = items.indexOf(item);
+    const nextIndex = event.key === "ArrowDown"
+      ? Math.min(items.length - 1, currentIndex + 1)
+      : Math.max(0, currentIndex - 1);
+    items[nextIndex]?.focus();
+  }
+
+  private async openResult(path: string | null) {
+    if (!path) return;
+    try {
+      await this.app.workspace.openLinkText(path, "");
+      this.close();
+    } catch {
+      new Notice(`Failed to open: ${path}`);
+    }
+  }
+
+  private findResultItem(target: EventTarget | null): HTMLElement | null {
+    if (!(target instanceof HTMLElement)) return null;
+    return target.closest<HTMLElement>(".ss-search__item");
+  }
+
+  private getResultItems(): HTMLElement[] {
+    return Array.from(this.listEl?.querySelectorAll<HTMLElement>(".ss-search__item") ?? []);
+  }
+
+  private hasRenderedResults(): boolean {
+    return this.getResultItems().length > 0;
+  }
+
+  private cancelSearch() {
+    this.searchAbortController?.abort();
+    this.searchAbortController = null;
+  }
+
+  private isAbortError(error: unknown): boolean {
+    return error instanceof DOMException && error.name === "AbortError";
+  }
+
+  private appendHighlightedText(parent: HTMLElement, text: string, query: string) {
+    const matches = this.getHighlightRanges(text, query);
+    if (matches.length === 0) {
+      parent.setText(text);
+      return;
+    }
+
+    let last = 0;
+    for (const match of matches) {
+      if (match.start > last) {
+        parent.appendText(text.slice(last, match.start));
+      }
+      const mark = parent.createEl("mark", { cls: "ss-hl" });
+      mark.setText(text.slice(match.start, match.end));
+      last = match.end;
+    }
+    if (last < text.length) {
+      parent.appendText(text.slice(last));
+    }
+  }
+
+  private getHighlightRanges(text: string, query: string): Array<{ start: number; end: number }> {
+    if (!query || !query.trim()) return [];
+
+    const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+    const lowerText = text.toLowerCase();
+    const rawMatches: Array<{ start: number; end: number }> = [];
+
+    terms.forEach((term) => {
+      let idx = 0;
+      while ((idx = lowerText.indexOf(term, idx)) > -1) {
+        rawMatches.push({ start: idx, end: idx + term.length });
+        idx += term.length;
+      }
+    });
+
+    if (rawMatches.length === 0) return [];
+    rawMatches.sort((a, b) => a.start - b.start || b.end - a.end);
+
+    const merged: Array<{ start: number; end: number }> = [];
+    for (const match of rawMatches) {
+      const previous = merged[merged.length - 1];
+      if (!previous || match.start > previous.end) {
+        merged.push({ ...match });
+      } else {
+        previous.end = Math.max(previous.end, match.end);
+      }
+    }
+    return merged;
+  }
+
   private formatUpdated(ts?: number): string {
     if (!ts) return "No date";
     const date = new Date(ts);
@@ -245,80 +442,5 @@ export class SystemSculptSearchModal extends StandardModal {
     if (bytes < 1024) return `${bytes} B`;
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  }
-
-  private getHighlightedText(text: string, query: string): string {
-    if (!query || !query.trim()) {
-      return text;
-    }
-    const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
-    const lc = text.toLowerCase();
-    const matches: Array<{ start: number; end: number }> = [];
-
-    terms.forEach((t) => {
-      let idx = 0;
-      while ((idx = lc.indexOf(t, idx)) > -1) {
-        matches.push({ start: idx, end: idx + t.length });
-        idx += t.length;
-      }
-    });
-
-    if (matches.length === 0) return text;
-
-    matches.sort((a, b) => a.start - b.start);
-    let result = "";
-    let last = 0;
-
-    matches.forEach((m) => {
-      if (m.start > last) {
-        result += text.slice(last, m.start);
-      }
-      result += `<mark class="ss-hl">${text.slice(m.start, m.end)}</mark>`;
-      last = m.end;
-    });
-
-    if (last < text.length) {
-      result += text.slice(last);
-    }
-
-    return result;
-  }
-
-  private makeDraggable(results: SearchHit[]) {
-    if (!this.listEl) return;
-    const el = this.listEl;
-    el.draggable = true;
-    el.addClass("scs-draggable");
-    this.registerDomEvent(el, "dragstart", (e: Event) => {
-      const ev = e as DragEvent;
-      if (!ev.dataTransfer) return;
-      const payload = {
-        type: "search-results",
-        query: this.currentQuery,
-        results: results.slice(0, 50).map((r) => ({ path: r.path, score: r.score })),
-      };
-      const text = results.map((r) => r.path).join("\n");
-      ev.dataTransfer.setData("text/plain", JSON.stringify(payload));
-      ev.dataTransfer.setData("application/json", JSON.stringify(payload));
-      ev.dataTransfer.setData("text/uri-list", text);
-    });
-  }
-
-  private async copyResults() {
-    try {
-      const items = Array.from(this.listEl?.querySelectorAll(".ss-search__item") || []);
-      if (items.length === 0) {
-        new Notice("No results to copy.");
-        return;
-      }
-      const paths = items
-        .map((el) => el.getAttribute("data-path") || "")
-        .filter(Boolean)
-        .join("\n");
-      await navigator.clipboard.writeText(paths);
-      new Notice("Search results copied to clipboard", 3000);
-    } catch {
-      new Notice("Failed to copy results", 4000);
-    }
   }
 }

--- a/src/modals/SystemSculptSearchModal.ts
+++ b/src/modals/SystemSculptSearchModal.ts
@@ -8,44 +8,31 @@ import type {
 } from "../services/search/SystemSculptSearchEngine";
 
 export class SystemSculptSearchModal extends StandardModal {
-  private plugin: SystemSculptPlugin;
   private engine: SystemSculptSearchEngine;
   private searchInputEl: HTMLInputElement | null = null;
   private listEl: HTMLElement | null = null;
-  private metricsEl: HTMLElement | null = null;
-  private stateEl: HTMLElement | null = null;
-  private embeddings: SearchResponse["embeddings"] | null = null;
 
   private readonly SEARCH_LIMIT = 80;
   private currentQuery = "";
   private debounceHandle: number | null = null;
+  private recentPreviewHandle: number | null = null;
   private querySerial = 0;
-  private isModalOpen = false;
 
   constructor(plugin: SystemSculptPlugin) {
     super(plugin.app);
-    this.plugin = plugin;
     this.engine = plugin.getSearchEngine();
-    this.embeddings = this.engine.getEmbeddingsIndicator();
     this.setSize("fullwidth");
   }
 
   onOpen() {
     super.onOpen();
-    this.isModalOpen = true;
     this.contentEl.addClass("ss-search__content");
 
-    this.addTitle(
-      "SystemSculpt Search",
-      "Search your notes. Embeddings join automatically when they are ready."
-    );
+    this.addTitle("SystemSculpt Search");
 
     const shell = this.contentEl.createDiv({ cls: "ss-search" });
 
     this.searchInputEl = this.buildSearchBar(shell, "Search your vault...", (value) => this.onSearchChange(value));
-
-    this.stateEl = shell.createDiv({ cls: "ss-search__state" });
-    this.metricsEl = shell.createDiv({ cls: "ss-search__metrics" });
 
     this.listEl = shell.createDiv({ cls: "ss-modal__list ss-search__list" });
 
@@ -54,16 +41,18 @@ export class SystemSculptSearchModal extends StandardModal {
 
     setTimeout(() => this.searchInputEl?.focus(), 0);
     void this.renderRecents();
-    void this.refreshRecentsAfterWarmIndex();
   }
 
   onClose() {
-    this.isModalOpen = false;
+    this.querySerial += 1;
+    this.cancelRecentPreviewHydration();
     if (this.debounceHandle) {
       window.clearTimeout(this.debounceHandle);
       this.debounceHandle = null;
     }
     super.onClose();
+    this.searchInputEl = null;
+    this.listEl = null;
   }
 
   private buildSearchBar(parent: HTMLElement, placeholder: string, onInput: (value: string) => void): HTMLInputElement {
@@ -98,6 +87,9 @@ export class SystemSculptSearchModal extends StandardModal {
 
   private onSearchChange(query: string) {
     this.currentQuery = query;
+    if (query.trim()) {
+      this.cancelRecentPreviewHydration();
+    }
     if (this.debounceHandle) {
       window.clearTimeout(this.debounceHandle);
     }
@@ -116,6 +108,7 @@ export class SystemSculptSearchModal extends StandardModal {
       return;
     }
 
+    this.cancelRecentPreviewHydration();
     this.renderLoading("Searching...");
 
     const response = await this.engine.search(trimmed, {
@@ -129,36 +122,15 @@ export class SystemSculptSearchModal extends StandardModal {
     this.renderResponse(response);
   }
 
-  private async renderRecents(options: { showLoading?: boolean } = {}) {
+  private async renderRecents() {
     const serial = ++this.querySerial;
-    if (options.showLoading !== false) {
-      this.renderLoading("Opening recent notes...");
-    }
     const recents = await this.engine.getRecent(25);
     if (serial < this.querySerial) return;
-    const indicator = this.engine.getEmbeddingsIndicator();
-    this.embeddings = indicator;
     this.renderResults(recents);
-    this.renderMetrics({
-      totalMs: 0,
-      indexedCount: recents.length,
-      inspectedCount: recents.length,
-      mode: "smart",
-      usedEmbeddings: false,
-    });
-    this.renderState(this.recentsStateText(indicator));
-  }
-
-  private async refreshRecentsAfterWarmIndex() {
-    await this.engine.warmIndex();
-    if (!this.isModalOpen || this.currentQuery.trim().length > 0) return;
-    await this.renderRecents({ showLoading: false });
+    this.scheduleRecentPreviewHydration(recents, serial);
   }
 
   private renderResponse(response: SearchResponse) {
-    this.embeddings = response.embeddings;
-    this.renderMetrics(response.stats);
-    this.renderState(this.stateTextFor(response));
     this.renderResults(response.results);
   }
 
@@ -208,6 +180,42 @@ export class SystemSculptSearchModal extends StandardModal {
     this.makeDraggable(results);
   }
 
+  private scheduleRecentPreviewHydration(results: SearchHit[], serial: number) {
+    this.cancelRecentPreviewHydration();
+    const paths = results
+      .filter((result) => result.origin === "recent" && !result.excerpt)
+      .map((result) => result.path);
+    if (paths.length === 0) return;
+
+    this.recentPreviewHandle = window.setTimeout(() => {
+      this.recentPreviewHandle = null;
+      void this.hydrateRecentPreviews(paths, serial);
+    }, 0);
+  }
+
+  private cancelRecentPreviewHydration() {
+    if (this.recentPreviewHandle) {
+      window.clearTimeout(this.recentPreviewHandle);
+      this.recentPreviewHandle = null;
+    }
+  }
+
+  private async hydrateRecentPreviews(paths: string[], serial: number) {
+    const previews = await this.engine.getRecentPreviews(paths, 25);
+    if (serial !== this.querySerial || this.currentQuery.trim().length > 0 || !this.listEl) {
+      return;
+    }
+
+    const items = Array.from(this.listEl.querySelectorAll<HTMLElement>(".ss-search__item"));
+    items.forEach((item) => {
+      const path = item.getAttribute("data-path");
+      if (!path || item.querySelector(".ss-search__excerpt")) return;
+      const preview = previews.get(path);
+      if (!preview) return;
+      item.createDiv({ cls: "ss-search__excerpt", text: preview });
+    });
+  }
+
   private renderLoading(text: string) {
     if (!this.listEl) return;
     this.listEl.empty();
@@ -220,62 +228,6 @@ export class SystemSculptSearchModal extends StandardModal {
     this.listEl.empty();
     const empty = this.listEl.createDiv("ss-modal__empty-state ss-search__empty");
     empty.createDiv({ text });
-  }
-
-  private renderMetrics(stats: Partial<SearchResponse["stats"]>) {
-    if (!this.metricsEl) return;
-    const parts: string[] = [];
-    if (typeof stats.totalMs === "number") parts.push(`Total ${Math.round(stats.totalMs)} ms`);
-    if (typeof stats.lexMs === "number") parts.push(`Notes ${Math.round(stats.lexMs)} ms`);
-    if (typeof stats.semMs === "number") parts.push(`Embeddings ${Math.round(stats.semMs)} ms`);
-    if (typeof stats.indexMs === "number") parts.push(`Index ${Math.round(stats.indexMs)} ms`);
-    if (typeof stats.indexedCount === "number") parts.push(`${stats.indexedCount} indexed`);
-    if (typeof stats.inspectedCount === "number") parts.push(`${stats.inspectedCount} checked`);
-
-    this.metricsEl.setText(parts.join(" • "));
-  }
-
-  private renderState(message: string) {
-    if (!this.stateEl) return;
-    this.stateEl.setText(message);
-  }
-
-  private stateTextFor(response: SearchResponse): string {
-    const usedEmbeddings = response.stats.usedEmbeddings;
-    const emb = response.embeddings;
-    if (usedEmbeddings) {
-      return "Searching notes and embeddings.";
-    }
-    if (!emb.enabled) {
-      return "Searching notes. Embeddings are off.";
-    }
-    if (!emb.ready || !emb.available) {
-      return emb.reason ? `Searching notes. Embeddings unavailable: ${emb.reason}` : "Searching notes. Embeddings are still preparing.";
-    }
-    const processed = emb.processed ?? 0;
-    const total = emb.total ?? 0;
-    if (total > 0 && processed / total < 0.75) {
-      return "Searching notes. Embeddings will join when more of the vault is indexed.";
-    }
-    if (response.stats.embeddingsEligible) {
-      return "Searching notes. Embeddings checked in, but note matches won.";
-    }
-    return "Searching notes.";
-  }
-
-  private recentsStateText(indicator: SearchResponse["embeddings"]): string {
-    if (!indicator.enabled) {
-      return "Recent notes. Search will use note text.";
-    }
-    const processed = indicator.processed ?? 0;
-    const total = indicator.total ?? 0;
-    if (!indicator.ready || !indicator.available) {
-      return "Recent notes. Embeddings are still preparing.";
-    }
-    if (total > 0 && processed / total < 0.75) {
-      return "Recent notes. Embeddings will join after more of the vault is indexed.";
-    }
-    return "Recent notes. Embeddings are ready for detailed searches.";
   }
 
   private formatUpdated(ts?: number): string {

--- a/src/modals/SystemSculptSearchModal.ts
+++ b/src/modals/SystemSculptSearchModal.ts
@@ -20,6 +20,7 @@ export class SystemSculptSearchModal extends StandardModal {
   private currentQuery = "";
   private debounceHandle: number | null = null;
   private querySerial = 0;
+  private isModalOpen = false;
 
   constructor(plugin: SystemSculptPlugin) {
     super(plugin.app);
@@ -31,6 +32,7 @@ export class SystemSculptSearchModal extends StandardModal {
 
   onOpen() {
     super.onOpen();
+    this.isModalOpen = true;
     this.contentEl.addClass("ss-search__content");
 
     this.addTitle(
@@ -52,10 +54,11 @@ export class SystemSculptSearchModal extends StandardModal {
 
     setTimeout(() => this.searchInputEl?.focus(), 0);
     void this.renderRecents();
-    this.engine.warmIndex();
+    void this.refreshRecentsAfterWarmIndex();
   }
 
   onClose() {
+    this.isModalOpen = false;
     if (this.debounceHandle) {
       window.clearTimeout(this.debounceHandle);
       this.debounceHandle = null;
@@ -104,6 +107,7 @@ export class SystemSculptSearchModal extends StandardModal {
   }
 
   private async executeSearch(query: string) {
+    this.currentQuery = query;
     const trimmed = query.trim();
     const serial = ++this.querySerial;
 
@@ -125,9 +129,11 @@ export class SystemSculptSearchModal extends StandardModal {
     this.renderResponse(response);
   }
 
-  private async renderRecents() {
+  private async renderRecents(options: { showLoading?: boolean } = {}) {
     const serial = ++this.querySerial;
-    this.renderLoading("Opening recent notes...");
+    if (options.showLoading !== false) {
+      this.renderLoading("Opening recent notes...");
+    }
     const recents = await this.engine.getRecent(25);
     if (serial < this.querySerial) return;
     const indicator = this.engine.getEmbeddingsIndicator();
@@ -141,6 +147,12 @@ export class SystemSculptSearchModal extends StandardModal {
       usedEmbeddings: false,
     });
     this.renderState(this.recentsStateText(indicator));
+  }
+
+  private async refreshRecentsAfterWarmIndex() {
+    await this.engine.warmIndex();
+    if (!this.isModalOpen || this.currentQuery.trim().length > 0) return;
+    await this.renderRecents({ showLoading: false });
   }
 
   private renderResponse(response: SearchResponse) {
@@ -176,11 +188,9 @@ export class SystemSculptSearchModal extends StandardModal {
       const meta = item.createDiv({ cls: "ss-search__meta" });
       meta.setText(`${result.path} • ${this.formatUpdated(result.updatedAt)}${result.size ? ` • ${this.formatSize(result.size)}` : ""}`);
 
-      const excerpt = item.createDiv({ cls: "ss-search__excerpt" });
       if (result.excerpt) {
+        const excerpt = item.createDiv({ cls: "ss-search__excerpt" });
         excerpt.innerHTML = this.getHighlightedText(result.excerpt, this.currentQuery);
-      } else {
-        excerpt.setText("No preview available");
       }
 
       this.registerDomEvent(item, "click", async () => {

--- a/src/modals/__tests__/SystemSculptSearchModal.test.ts
+++ b/src/modals/__tests__/SystemSculptSearchModal.test.ts
@@ -39,6 +39,7 @@ const createMockSearchResponse = (overrides: Partial<SearchResponse> = {}): Sear
 
 const createMockEngine = (overrides: Record<string, any> = {}) => ({
   search: jest.fn().mockResolvedValue(createMockSearchResponse()),
+  warmIndex: jest.fn(),
   getRecent: jest.fn().mockResolvedValue([
     { path: "notes/recent.md", title: "Recent Note", score: 1, origin: "recent" as const, updatedAt: Date.now() },
   ]),
@@ -83,14 +84,6 @@ describe("SystemSculptSearchModal", () => {
       expect(plugin.getSearchEngine).toHaveBeenCalled();
     });
 
-    it("defaults mode to 'smart'", () => {
-      expect((modal as any).mode).toBe("smart");
-    });
-
-    it("defaults sort to 'relevance'", () => {
-      expect((modal as any).sort).toBe("relevance");
-    });
-
     it("fetches initial embeddings indicator", () => {
       expect(plugin._testEngine.getEmbeddingsIndicator).toHaveBeenCalled();
     });
@@ -117,19 +110,10 @@ describe("SystemSculptSearchModal", () => {
       expect((modal as any).stateEl).not.toBeNull();
     });
 
-    it("creates mode buttons", () => {
+    it("does not render mode or sort controls", () => {
       modal.onOpen();
-      const modeButtons = (modal as any).modeButtons;
-      expect(modeButtons.lexical).toBeDefined();
-      expect(modeButtons.smart).toBeDefined();
-      expect(modeButtons.semantic).toBeDefined();
-    });
-
-    it("creates sort buttons", () => {
-      modal.onOpen();
-      const sortButtons = (modal as any).sortButtons;
-      expect(sortButtons.relevance).toBeDefined();
-      expect(sortButtons.recency).toBeDefined();
+      expect(modal.contentEl.querySelector("[data-mode]")).toBeNull();
+      expect(modal.contentEl.querySelector("[data-sort]")).toBeNull();
     });
 
     it("renders recent files on open", async () => {
@@ -137,6 +121,11 @@ describe("SystemSculptSearchModal", () => {
       jest.advanceTimersByTime(10);
       await Promise.resolve();
       expect(plugin._testEngine.getRecent).toHaveBeenCalledWith(25);
+    });
+
+    it("warms the content index in the background", () => {
+      modal.onOpen();
+      expect(plugin._testEngine.warmIndex).toHaveBeenCalled();
     });
   });
 
@@ -146,143 +135,6 @@ describe("SystemSculptSearchModal", () => {
       (modal as any).debounceHandle = 123;
       modal.onClose();
       expect((modal as any).debounceHandle).toBeNull();
-    });
-  });
-
-  describe("mode selection", () => {
-    it("defaults to 'smart' mode when embeddings available", () => {
-      modal.onOpen();
-      expect((modal as any).mode).toBe("smart");
-      expect((modal as any).modeButtons.smart?.classList.contains("is-active")).toBe(true);
-    });
-
-    it("disables semantic button when embeddings unavailable", () => {
-      plugin = createMockPlugin({
-        getEmbeddingsIndicator: jest.fn().mockReturnValue({
-          enabled: true,
-          ready: false,
-          available: false,
-        }),
-      });
-      modal = new SystemSculptSearchModal(plugin);
-      modal.onOpen();
-
-      expect((modal as any).modeButtons.semantic?.disabled).toBe(true);
-      expect((modal as any).modeButtons.semantic?.classList.contains("is-disabled")).toBe(true);
-    });
-
-    it("disables smart button when embeddings unavailable", () => {
-      plugin = createMockPlugin({
-        getEmbeddingsIndicator: jest.fn().mockReturnValue({
-          enabled: true,
-          ready: false,
-          available: false,
-        }),
-      });
-      modal = new SystemSculptSearchModal(plugin);
-      modal.onOpen();
-
-      expect((modal as any).modeButtons.smart?.disabled).toBe(true);
-    });
-
-    it("never disables lexical button", () => {
-      plugin = createMockPlugin({
-        getEmbeddingsIndicator: jest.fn().mockReturnValue({
-          enabled: false,
-          ready: false,
-          available: false,
-        }),
-      });
-      modal = new SystemSculptSearchModal(plugin);
-      modal.onOpen();
-
-      expect((modal as any).modeButtons.lexical?.disabled).toBe(false);
-    });
-
-    it("falls back to lexical when embeddings become unavailable", () => {
-      modal.onOpen();
-      (modal as any).mode = "smart";
-
-      const unavailableIndicator = {
-        enabled: false,
-        ready: false,
-        available: false,
-      };
-      (modal as any).syncModeAvailability(unavailableIndicator);
-
-      expect((modal as any).mode).toBe("lexical");
-    });
-
-    it("changes mode on button click", () => {
-      modal.onOpen();
-      const lexicalBtn = (modal as any).modeButtons.lexical;
-
-      lexicalBtn?.click();
-
-      expect((modal as any).mode).toBe("lexical");
-    });
-
-    it("triggers search on mode change", async () => {
-      modal.onOpen();
-      (modal as any).currentQuery = "test query";
-
-      const smartBtn = (modal as any).modeButtons.smart;
-      smartBtn?.click();
-
-      await Promise.resolve();
-      expect(plugin._testEngine.search).toHaveBeenCalled();
-    });
-
-    it("updates mode availability after each search", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        embeddings: { enabled: true, ready: false, available: false, processed: 0, total: 100 },
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      await (modal as any).executeSearch("test");
-
-      expect((modal as any).modeButtons.semantic?.disabled).toBe(true);
-    });
-  });
-
-  describe("sort toggle", () => {
-    it("defaults to relevance sort", () => {
-      modal.onOpen();
-      expect((modal as any).sort).toBe("relevance");
-      expect((modal as any).sortButtons.relevance?.classList.contains("is-active")).toBe(true);
-    });
-
-    it("changes sort on button click", () => {
-      modal.onOpen();
-      const recencyBtn = (modal as any).sortButtons.recency;
-
-      recencyBtn?.click();
-
-      expect((modal as any).sort).toBe("recency");
-    });
-
-    it("triggers search on sort change", async () => {
-      modal.onOpen();
-      (modal as any).currentQuery = "test query";
-      plugin._testEngine.search.mockClear();
-
-      const recencyBtn = (modal as any).sortButtons.recency;
-      recencyBtn?.click();
-
-      await Promise.resolve();
-      expect(plugin._testEngine.search).toHaveBeenCalled();
-    });
-
-    it("updates active class on sort buttons", () => {
-      modal.onOpen();
-      const recencyBtn = (modal as any).sortButtons.recency;
-
-      recencyBtn?.click();
-
-      expect((modal as any).sortButtons.recency?.classList.contains("is-active")).toBe(true);
-      expect((modal as any).sortButtons.relevance?.classList.contains("is-active")).toBe(false);
     });
   });
 
@@ -352,38 +204,21 @@ describe("SystemSculptSearchModal", () => {
       expect(plugin._testEngine.getRecent).toHaveBeenCalled();
     });
 
-    it("passes mode and sort to search engine", async () => {
+    it("uses one adaptive search path", async () => {
       modal.onOpen();
-      (modal as any).mode = "semantic";
-      (modal as any).sort = "recency";
 
       await (modal as any).executeSearch("test");
 
       expect(plugin._testEngine.search).toHaveBeenCalledWith("test", {
-        mode: "semantic",
-        sort: "recency",
+        mode: "smart",
+        sort: "relevance",
         limit: 80,
       });
     });
   });
 
   describe("state messages", () => {
-    it("shows 'Fast – fastest path.' for lexical mode", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        stats: { ...createMockSearchResponse().stats, usedEmbeddings: false },
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      (modal as any).mode = "lexical";
-      await (modal as any).executeSearch("test");
-
-      const stateText = (modal as any).stateTextFor(response);
-      expect(stateText).toBe("Fast – fastest path.");
-    });
-
-    it("shows smart blend message when embeddings contributed", async () => {
+    it("shows the embeddings message when embeddings contributed", async () => {
       modal.onOpen();
 
       const response = createMockSearchResponse({
@@ -391,11 +226,10 @@ describe("SystemSculptSearchModal", () => {
       });
       plugin._testEngine.search.mockResolvedValue(response);
 
-      (modal as any).mode = "smart";
       await (modal as any).executeSearch("test");
 
       const stateText = (modal as any).stateTextFor(response);
-      expect(stateText).toBe("Smart blend: embeddings contributed to these results.");
+      expect(stateText).toBe("Searching notes and embeddings.");
     });
 
     it("shows 'Embeddings off in settings' when disabled", () => {
@@ -406,12 +240,11 @@ describe("SystemSculptSearchModal", () => {
         embeddings: { enabled: false, ready: false, available: false, processed: 0, total: 0 },
       });
 
-      (modal as any).mode = "smart";
       const stateText = (modal as any).stateTextFor(response);
-      expect(stateText).toBe("Embeddings off in settings – running lexical search only.");
+      expect(stateText).toBe("Searching notes. Embeddings are off.");
     });
 
-    it("shows 'Embeddings unavailable' with reason when not available", () => {
+    it("shows embeddings unavailable with reason when not available", () => {
       modal.onOpen();
 
       const response = createMockSearchResponse({
@@ -426,22 +259,20 @@ describe("SystemSculptSearchModal", () => {
         },
       });
 
-      (modal as any).mode = "smart";
       const stateText = (modal as any).stateTextFor(response);
-      expect(stateText).toBe("Embeddings unavailable: No vectors generated yet");
+      expect(stateText).toBe("Searching notes. Embeddings unavailable: No vectors generated yet");
     });
 
-    it("shows generic message when embeddings ready but not used", () => {
+    it("shows progress message before embeddings are sufficiently indexed", () => {
       modal.onOpen();
 
       const response = createMockSearchResponse({
         stats: { ...createMockSearchResponse().stats, usedEmbeddings: false },
-        embeddings: { enabled: true, ready: true, available: true, processed: 80, total: 100 },
+        embeddings: { enabled: true, ready: true, available: true, processed: 60, total: 100 },
       });
 
-      (modal as any).mode = "smart";
       const stateText = (modal as any).stateTextFor(response);
-      expect(stateText).toBe("Embeddings ready but not used for this query (short query or no vectors).");
+      expect(stateText).toBe("Searching notes. Embeddings will join when more of the vault is indexed.");
     });
   });
 
@@ -459,7 +290,7 @@ describe("SystemSculptSearchModal", () => {
       expect(item?.getAttribute("data-path")).toBe("notes/test.md");
     });
 
-    it("renders origin badge", async () => {
+    it("does not render origin badges", async () => {
       modal.onOpen();
 
       const response = createMockSearchResponse({
@@ -472,7 +303,7 @@ describe("SystemSculptSearchModal", () => {
       await (modal as any).executeSearch("test");
 
       const badge = (modal as any).listEl?.querySelector(".ss-search__pill--semantic");
-      expect(badge).not.toBeNull();
+      expect(badge).toBeNull();
     });
 
     it("renders score as percentage", async () => {
@@ -552,7 +383,7 @@ describe("SystemSculptSearchModal", () => {
       expect(metricsEl?.textContent).toContain("Total 42 ms");
     });
 
-    it("renders lexMs metric", async () => {
+    it("renders notes metric", async () => {
       modal.onOpen();
 
       const response = createMockSearchResponse({
@@ -563,10 +394,10 @@ describe("SystemSculptSearchModal", () => {
       await (modal as any).executeSearch("test");
 
       const metricsEl = (modal as any).metricsEl;
-      expect(metricsEl?.textContent).toContain("Lex 15 ms");
+      expect(metricsEl?.textContent).toContain("Notes 15 ms");
     });
 
-    it("renders semantic metric when present", async () => {
+    it("renders embeddings metric when present", async () => {
       modal.onOpen();
 
       const response = createMockSearchResponse({
@@ -577,7 +408,7 @@ describe("SystemSculptSearchModal", () => {
       await (modal as any).executeSearch("test");
 
       const metricsEl = (modal as any).metricsEl;
-      expect(metricsEl?.textContent).toContain("Semantic 30 ms");
+      expect(metricsEl?.textContent).toContain("Embeddings 30 ms");
     });
 
     it("renders indexed count", async () => {
@@ -592,25 +423,6 @@ describe("SystemSculptSearchModal", () => {
 
       const metricsEl = (modal as any).metricsEl;
       expect(metricsEl?.textContent).toContain("250 indexed");
-    });
-  });
-
-  describe("label formatting", () => {
-    it("labelForOrigin returns correct labels", () => {
-      modal.onOpen();
-
-      expect((modal as any).labelForOrigin("semantic")).toBe("Semantic");
-      expect((modal as any).labelForOrigin("blend")).toBe("Blended");
-      expect((modal as any).labelForOrigin("recent")).toBe("Recent");
-      expect((modal as any).labelForOrigin("lexical")).toBe("Lexical");
-    });
-
-    it("labelForMode returns correct labels", () => {
-      modal.onOpen();
-
-      expect((modal as any).labelForMode("lexical")).toBe("Fast");
-      expect((modal as any).labelForMode("semantic")).toBe("Semantic first");
-      expect((modal as any).labelForMode("smart")).toBe("Smart blend");
     });
   });
 

--- a/src/modals/__tests__/SystemSculptSearchModal.test.ts
+++ b/src/modals/__tests__/SystemSculptSearchModal.test.ts
@@ -94,16 +94,31 @@ describe("SystemSculptSearchModal", () => {
       expect(plugin._testEngine.getEmbeddingsIndicator).not.toHaveBeenCalled();
     });
 
-    it("renders one simple search view without metrics, modes, or footer actions", () => {
+    it("renders one simple command-palette search view without metrics or mode controls", () => {
       modal.onOpen();
 
       expect((modal as any).searchInputEl).not.toBeNull();
       expect((modal as any).listEl).not.toBeNull();
+      expect(modal.modalEl.hasClass("ss-search-modal")).toBe(true);
+      expect((modal as any).footerEl.querySelector(".ss-search__hint")?.textContent).toContain("Enter Open");
       expect(modal.contentEl.querySelector(".ss-search__metrics")).toBeNull();
       expect(modal.contentEl.querySelector(".ss-search__state")).toBeNull();
       expect(modal.contentEl.querySelector("[data-mode]")).toBeNull();
       expect(modal.contentEl.querySelector("[data-sort]")).toBeNull();
-      expect((modal as any).footerEl.style.display).toBe("none");
+      expect((modal as any).headerEl.textContent).not.toContain("SystemSculpt Search");
+    });
+
+    it("uses combobox/listbox attributes for the result list", () => {
+      modal.onOpen();
+
+      const input = (modal as any).searchInputEl as HTMLInputElement;
+      const listEl = (modal as any).listEl as HTMLElement;
+      expect(input.getAttribute("role")).toBe("combobox");
+      expect(input.getAttribute("aria-label")).toBe("Search your vault");
+      expect(input.getAttribute("aria-controls")).toBe(listEl.id);
+      expect(input.getAttribute("aria-autocomplete")).toBe("list");
+      expect(listEl.getAttribute("role")).toBe("listbox");
+      expect(listEl.getAttribute("aria-label")).toBe("Search results");
     });
 
     it("renders recent files on open without warming or checking backends", async () => {
@@ -113,6 +128,18 @@ describe("SystemSculptSearchModal", () => {
       expect(plugin._testEngine.getRecent).toHaveBeenCalledWith(25);
       expect(plugin._testEngine.getEmbeddingsIndicator).not.toHaveBeenCalled();
       expect((modal as any).listEl?.textContent).toContain("Recent Note");
+    });
+
+    it("shows a graceful empty state if recent files cannot be loaded", async () => {
+      plugin = createMockPlugin({
+        getRecent: jest.fn().mockRejectedValue(new Error("metadata unavailable")),
+      });
+      modal = new SystemSculptSearchModal(plugin);
+
+      modal.onOpen();
+      await flush();
+
+      expect((modal as any).listEl?.textContent).toContain("Could not load recent notes.");
     });
   });
 
@@ -177,9 +204,26 @@ describe("SystemSculptSearchModal", () => {
       expect(plugin._testEngine.search).toHaveBeenCalledWith("test", {
         mode: "smart",
         sort: "relevance",
-        limit: 80,
+        limit: 30,
         signal: expect.any(AbortSignal),
       });
+    });
+
+    it("clears the active query and returns to recents with the clear button", async () => {
+      modal.onOpen();
+      const input = (modal as any).searchInputEl as HTMLInputElement;
+      const clear = modal.contentEl.querySelector(".ss-search__clear") as HTMLButtonElement;
+
+      input.value = "test";
+      input.dispatchEvent(new Event("input"));
+      expect(clear.style.display).toBe("flex");
+
+      clear.click();
+      await flush();
+
+      expect(input.value).toBe("");
+      expect(clear.style.display).toBe("none");
+      expect(plugin._testEngine.getRecent).toHaveBeenCalledWith(25);
     });
 
     it("uses query serials to prevent stale responses from replacing newer results", async () => {
@@ -227,11 +271,50 @@ describe("SystemSculptSearchModal", () => {
       modal.onOpen();
 
       await (modal as any).executeSearch("body");
+      expect(modal.contentEl.querySelector(".ss-search__status")?.textContent).toBe("1 result");
       jest.advanceTimersByTime(0);
       await flush(4);
 
       expect(plugin._testEngine.whenIndexReady).toHaveBeenCalled();
       expect((modal as any).listEl?.querySelector('[data-path="notes/body-hit.md"]')).not.toBeNull();
+    });
+
+    it("stabilizes fast metadata-to-index refreshes without waiting for interaction", async () => {
+      const first = createMockSearchResponse({
+        results: [
+          { path: "notes/a.md", title: "A", score: 0.8, origin: "lexical", updatedAt: Date.now() },
+          { path: "notes/b.md", title: "B", score: 0.7, origin: "lexical", updatedAt: Date.now() },
+        ],
+        stats: {
+          ...createMockSearchResponse().stats,
+          indexingPending: true,
+          metadataOnly: true,
+        },
+      });
+      const second = createMockSearchResponse({
+        results: [
+          { path: "notes/c.md", title: "C", score: 0.95, origin: "lexical", updatedAt: Date.now() },
+          { path: "notes/b.md", title: "B", score: 0.9, origin: "lexical", updatedAt: Date.now() },
+          { path: "notes/a.md", title: "A", score: 0.4, origin: "lexical", updatedAt: Date.now() },
+        ],
+      });
+      plugin = createMockPlugin({
+        search: jest.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+        whenIndexReady: jest.fn().mockResolvedValue(undefined),
+      });
+      modal = new SystemSculptSearchModal(plugin);
+      modal.onOpen();
+
+      await (modal as any).executeSearch("body");
+      expect(modal.contentEl.querySelector(".ss-search__status")?.textContent).toBe("2 results");
+      jest.advanceTimersByTime(0);
+      await flush(4);
+
+      expect(Array.from((modal as any).listEl.querySelectorAll<HTMLElement>(".ss-search__item")).map((item) => item.getAttribute("data-path"))).toEqual([
+        "notes/a.md",
+        "notes/b.md",
+        "notes/c.md",
+      ]);
     });
   });
 
@@ -243,8 +326,18 @@ describe("SystemSculptSearchModal", () => {
       const listEl = (modal as any).listEl;
       const item = listEl?.querySelector(".ss-search__item");
       expect(item?.getAttribute("data-path")).toBe("notes/test.md");
+      expect(item?.getAttribute("tabindex")).toBe("-1");
       expect(listEl?.querySelector(".ss-search__score")).toBeNull();
       expect(listEl?.querySelector(".ss-search__pill--semantic")).toBeNull();
+    });
+
+    it("shows section labels and omits file size noise", async () => {
+      modal.onOpen();
+      await (modal as any).executeSearch("test");
+
+      expect(modal.contentEl.querySelector(".ss-search__status")?.textContent).toBe("1 result");
+      expect((modal as any).listEl?.textContent).toContain("notes/test.md");
+      expect((modal as any).listEl?.textContent).not.toContain("1.0 KB");
     });
 
     it("escapes note content while still highlighting matching terms", async () => {
@@ -314,6 +407,16 @@ describe("SystemSculptSearchModal", () => {
       expect(plugin.app.workspace.openLinkText).toHaveBeenCalledWith("notes/test.md", "");
     });
 
+    it("does not open a focused result with Space", async () => {
+      modal.onOpen();
+      await (modal as any).executeSearch("test");
+
+      const item = (modal as any).listEl?.querySelector(".ss-search__item") as HTMLElement;
+      item.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+
+      expect(plugin.app.workspace.openLinkText).not.toHaveBeenCalled();
+    });
+
     it("moves focus from the input to the first result with ArrowDown", async () => {
       document.body.appendChild((modal as any).modalEl);
       modal.onOpen();
@@ -323,6 +426,68 @@ describe("SystemSculptSearchModal", () => {
       input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
 
       expect(document.activeElement).toBe((modal as any).listEl?.querySelector(".ss-search__item"));
+      expect(((modal as any).searchInputEl as HTMLInputElement).getAttribute("aria-activedescendant")).toBe(
+        ((modal as any).listEl?.querySelector(".ss-search__item") as HTMLElement).id
+      );
+    });
+
+    it("preserves focused result and scroll position across stabilized refreshes", async () => {
+      document.body.appendChild((modal as any).modalEl);
+      modal.onOpen();
+      const first = createMockSearchResponse({
+        results: [
+          { path: "notes/a.md", title: "A", score: 0.8, origin: "lexical", updatedAt: Date.now() },
+          { path: "notes/b.md", title: "B", score: 0.7, origin: "lexical", updatedAt: Date.now() },
+        ],
+      });
+      const second = createMockSearchResponse({
+        results: [
+          { path: "notes/c.md", title: "C", score: 0.95, origin: "lexical", updatedAt: Date.now() },
+          { path: "notes/b.md", title: "B", score: 0.9, origin: "lexical", updatedAt: Date.now() },
+          { path: "notes/a.md", title: "A", score: 0.4, origin: "lexical", updatedAt: Date.now() },
+        ],
+      });
+
+      (modal as any).renderResponse(first);
+      const listEl = (modal as any).listEl as HTMLElement;
+      const focused = listEl.querySelector('[data-path="notes/b.md"]') as HTMLElement;
+      focused.focus();
+      listEl.scrollTop = 48;
+
+      (modal as any).renderResponse(second, { stabilize: true });
+
+      expect(document.activeElement?.getAttribute("data-path")).toBe("notes/b.md");
+      expect(listEl.scrollTop).toBe(48);
+      expect(Array.from(listEl.querySelectorAll<HTMLElement>(".ss-search__item")).map((item) => item.getAttribute("data-path"))).toEqual([
+        "notes/a.md",
+        "notes/b.md",
+        "notes/c.md",
+      ]);
+    });
+
+    it("returns focus to the input instead of a different result when the focused path disappears", async () => {
+      document.body.appendChild((modal as any).modalEl);
+      modal.onOpen();
+      const first = createMockSearchResponse({
+        results: [
+          { path: "notes/a.md", title: "A", score: 0.8, origin: "lexical", updatedAt: Date.now() },
+          { path: "notes/b.md", title: "B", score: 0.7, origin: "lexical", updatedAt: Date.now() },
+        ],
+      });
+      const second = createMockSearchResponse({
+        results: [
+          { path: "notes/c.md", title: "C", score: 0.95, origin: "lexical", updatedAt: Date.now() },
+        ],
+      });
+
+      (modal as any).renderResponse(first);
+      const listEl = (modal as any).listEl as HTMLElement;
+      (listEl.querySelector('[data-path="notes/b.md"]') as HTMLElement).focus();
+
+      (modal as any).renderResponse(second);
+
+      expect(document.activeElement).toBe((modal as any).searchInputEl);
+      expect(((modal as any).searchInputEl as HTMLInputElement).getAttribute("aria-activedescendant")).toBeNull();
     });
   });
 
@@ -332,11 +497,5 @@ describe("SystemSculptSearchModal", () => {
       expect((modal as any).formatUpdated(Date.now() - 1000)).toBe("Updated today");
     });
 
-    it("formats sizes", () => {
-      modal.onOpen();
-      expect((modal as any).formatSize(500)).toBe("500 B");
-      expect((modal as any).formatSize(2048)).toBe("2.0 KB");
-      expect((modal as any).formatSize(1500000)).toBe("1.4 MB");
-    });
   });
 });

--- a/src/modals/__tests__/SystemSculptSearchModal.test.ts
+++ b/src/modals/__tests__/SystemSculptSearchModal.test.ts
@@ -3,7 +3,7 @@
  */
 import { App } from "obsidian";
 import { SystemSculptSearchModal } from "../SystemSculptSearchModal";
-import { SearchResponse, EmbeddingsIndicator } from "../../services/search/SystemSculptSearchEngine";
+import { SearchResponse } from "../../services/search/SystemSculptSearchEngine";
 
 const createMockSearchResponse = (overrides: Partial<SearchResponse> = {}): SearchResponse => ({
   results: [
@@ -40,6 +40,7 @@ const createMockSearchResponse = (overrides: Partial<SearchResponse> = {}): Sear
 const createMockEngine = (overrides: Record<string, any> = {}) => ({
   search: jest.fn().mockResolvedValue(createMockSearchResponse()),
   warmIndex: jest.fn().mockResolvedValue(undefined),
+  getRecentPreviews: jest.fn().mockResolvedValue(new Map()),
   getRecent: jest.fn().mockResolvedValue([
     { path: "notes/recent.md", title: "Recent Note", score: 1, origin: "recent" as const, updatedAt: Date.now() },
   ]),
@@ -49,7 +50,7 @@ const createMockEngine = (overrides: Record<string, any> = {}) => ({
     available: true,
     processed: 80,
     total: 100,
-  } as EmbeddingsIndicator),
+  }),
   ...overrides,
 });
 
@@ -84,8 +85,8 @@ describe("SystemSculptSearchModal", () => {
       expect(plugin.getSearchEngine).toHaveBeenCalled();
     });
 
-    it("fetches initial embeddings indicator", () => {
-      expect(plugin._testEngine.getEmbeddingsIndicator).toHaveBeenCalled();
+    it("does not check backend readiness during construction", () => {
+      expect(plugin._testEngine.getEmbeddingsIndicator).not.toHaveBeenCalled();
     });
   });
 
@@ -100,14 +101,14 @@ describe("SystemSculptSearchModal", () => {
       expect((modal as any).listEl).not.toBeNull();
     });
 
-    it("creates metrics element", () => {
+    it("does not create metrics chrome", () => {
       modal.onOpen();
-      expect((modal as any).metricsEl).not.toBeNull();
+      expect(modal.contentEl.querySelector(".ss-search__metrics")).toBeNull();
     });
 
-    it("creates state element", () => {
+    it("does not create backend state chrome", () => {
       modal.onOpen();
-      expect((modal as any).stateEl).not.toBeNull();
+      expect(modal.contentEl.querySelector(".ss-search__state")).toBeNull();
     });
 
     it("does not render mode or sort controls", () => {
@@ -123,49 +124,35 @@ describe("SystemSculptSearchModal", () => {
       expect(plugin._testEngine.getRecent).toHaveBeenCalledWith(25);
     });
 
-    it("warms the content index in the background", () => {
+    it("does not warm the content index on open", () => {
       modal.onOpen();
-      expect(plugin._testEngine.warmIndex).toHaveBeenCalled();
+      expect(plugin._testEngine.warmIndex).not.toHaveBeenCalled();
     });
 
-    it("refreshes recent previews after the background index warms", async () => {
-      let resolveWarmIndex!: () => void;
-      const warmIndex = new Promise<void>((resolve) => {
-        resolveWarmIndex = resolve;
-      });
+    it("does not check backend readiness on open", () => {
+      modal.onOpen();
+      expect(plugin._testEngine.getEmbeddingsIndicator).not.toHaveBeenCalled();
+    });
 
+    it("hydrates only visible recent previews after the initial render", async () => {
       plugin = createMockPlugin({
-        warmIndex: jest.fn().mockReturnValue(warmIndex),
-        getRecent: jest.fn()
-          .mockResolvedValueOnce([
-            { path: "notes/recent.md", title: "Recent Note", score: 1, origin: "recent" as const, updatedAt: Date.now() },
-          ])
-          .mockResolvedValueOnce([
-            {
-              path: "notes/recent.md",
-              title: "Recent Note",
-              excerpt: "Indexed preview text",
-              score: 1,
-              origin: "recent" as const,
-              updatedAt: Date.now(),
-            },
-          ]),
+        getRecentPreviews: jest.fn().mockResolvedValue(new Map([["notes/recent.md", "Recent note opening text"]])),
       });
       modal = new SystemSculptSearchModal(plugin);
 
       modal.onOpen();
       await Promise.resolve();
 
-      expect(plugin._testEngine.getRecent).toHaveBeenCalledTimes(1);
       expect((modal as any).listEl?.textContent).toContain("Recent Note");
-      expect((modal as any).listEl?.textContent).not.toContain("No preview available");
+      expect((modal as any).listEl?.textContent).not.toContain("Recent note opening text");
 
-      resolveWarmIndex();
+      jest.runOnlyPendingTimers();
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(plugin._testEngine.getRecent).toHaveBeenCalledTimes(2);
-      expect((modal as any).listEl?.textContent).toContain("Indexed preview text");
+      expect(plugin._testEngine.getRecentPreviews).toHaveBeenCalledWith(["notes/recent.md"], 25);
+      expect((modal as any).listEl?.textContent).toContain("Recent note opening text");
+      expect(plugin._testEngine.warmIndex).not.toHaveBeenCalled();
     });
   });
 
@@ -254,65 +241,6 @@ describe("SystemSculptSearchModal", () => {
         sort: "relevance",
         limit: 80,
       });
-    });
-  });
-
-  describe("state messages", () => {
-    it("shows the embeddings message when embeddings contributed", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        stats: { ...createMockSearchResponse().stats, usedEmbeddings: true },
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      await (modal as any).executeSearch("test");
-
-      const stateText = (modal as any).stateTextFor(response);
-      expect(stateText).toBe("Searching notes and embeddings.");
-    });
-
-    it("shows 'Embeddings off in settings' when disabled", () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        stats: { ...createMockSearchResponse().stats, usedEmbeddings: false },
-        embeddings: { enabled: false, ready: false, available: false, processed: 0, total: 0 },
-      });
-
-      const stateText = (modal as any).stateTextFor(response);
-      expect(stateText).toBe("Searching notes. Embeddings are off.");
-    });
-
-    it("shows embeddings unavailable with reason when not available", () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        stats: { ...createMockSearchResponse().stats, usedEmbeddings: false },
-        embeddings: {
-          enabled: true,
-          ready: true,
-          available: false,
-          reason: "No vectors generated yet",
-          processed: 0,
-          total: 100,
-        },
-      });
-
-      const stateText = (modal as any).stateTextFor(response);
-      expect(stateText).toBe("Searching notes. Embeddings unavailable: No vectors generated yet");
-    });
-
-    it("shows progress message before embeddings are sufficiently indexed", () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        stats: { ...createMockSearchResponse().stats, usedEmbeddings: false },
-        embeddings: { enabled: true, ready: true, available: true, processed: 60, total: 100 },
-      });
-
-      const stateText = (modal as any).stateTextFor(response);
-      expect(stateText).toBe("Searching notes. Embeddings will join when more of the vault is indexed.");
     });
   });
 
@@ -416,64 +344,6 @@ describe("SystemSculptSearchModal", () => {
       const text = "Machine Learning Guide";
       const result = (modal as any).getHighlightedText(text, "xyz");
       expect(result).toBe(text);
-    });
-  });
-
-  describe("metrics display", () => {
-    it("renders totalMs metric", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        stats: { ...createMockSearchResponse().stats, totalMs: 42 },
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      await (modal as any).executeSearch("test");
-
-      const metricsEl = (modal as any).metricsEl;
-      expect(metricsEl?.textContent).toContain("Total 42 ms");
-    });
-
-    it("renders notes metric", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        stats: { ...createMockSearchResponse().stats, lexMs: 15 },
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      await (modal as any).executeSearch("test");
-
-      const metricsEl = (modal as any).metricsEl;
-      expect(metricsEl?.textContent).toContain("Notes 15 ms");
-    });
-
-    it("renders embeddings metric when present", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        stats: { ...createMockSearchResponse().stats, semMs: 30 },
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      await (modal as any).executeSearch("test");
-
-      const metricsEl = (modal as any).metricsEl;
-      expect(metricsEl?.textContent).toContain("Embeddings 30 ms");
-    });
-
-    it("renders indexed count", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        stats: { ...createMockSearchResponse().stats, indexedCount: 250 },
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      await (modal as any).executeSearch("test");
-
-      const metricsEl = (modal as any).metricsEl;
-      expect(metricsEl?.textContent).toContain("250 indexed");
     });
   });
 

--- a/src/modals/__tests__/SystemSculptSearchModal.test.ts
+++ b/src/modals/__tests__/SystemSculptSearchModal.test.ts
@@ -5,6 +5,12 @@ import { App } from "obsidian";
 import { SystemSculptSearchModal } from "../SystemSculptSearchModal";
 import { SearchResponse } from "../../services/search/SystemSculptSearchEngine";
 
+const flush = async (cycles = 2) => {
+  for (let i = 0; i < cycles; i++) {
+    await Promise.resolve();
+  }
+};
+
 const createMockSearchResponse = (overrides: Partial<SearchResponse> = {}): SearchResponse => ({
   results: [
     {
@@ -24,7 +30,7 @@ const createMockSearchResponse = (overrides: Partial<SearchResponse> = {}): Sear
     indexMs: 5,
     indexedCount: 100,
     inspectedCount: 50,
-    mode: "lexical",
+    mode: "smart",
     usedEmbeddings: false,
   },
   embeddings: {
@@ -39,7 +45,7 @@ const createMockSearchResponse = (overrides: Partial<SearchResponse> = {}): Sear
 
 const createMockEngine = (overrides: Record<string, any> = {}) => ({
   search: jest.fn().mockResolvedValue(createMockSearchResponse()),
-  warmIndex: jest.fn().mockResolvedValue(undefined),
+  whenIndexReady: jest.fn().mockResolvedValue(undefined),
   getRecentPreviews: jest.fn().mockResolvedValue(new Map()),
   getRecent: jest.fn().mockResolvedValue([
     { path: "notes/recent.md", title: "Recent Note", score: 1, origin: "recent" as const, updatedAt: Date.now() },
@@ -72,138 +78,116 @@ describe("SystemSculptSearchModal", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
+    document.body.innerHTML = "";
     plugin = createMockPlugin();
     modal = new SystemSculptSearchModal(plugin);
   });
 
   afterEach(() => {
+    modal.onClose();
     jest.useRealTimers();
   });
 
   describe("initialization", () => {
-    it("creates engine from plugin.getSearchEngine()", () => {
+    it("creates the engine lazily from plugin.getSearchEngine()", () => {
       expect(plugin.getSearchEngine).toHaveBeenCalled();
+      expect(plugin._testEngine.getEmbeddingsIndicator).not.toHaveBeenCalled();
     });
 
-    it("does not check backend readiness during construction", () => {
+    it("renders one simple search view without metrics, modes, or footer actions", () => {
+      modal.onOpen();
+
+      expect((modal as any).searchInputEl).not.toBeNull();
+      expect((modal as any).listEl).not.toBeNull();
+      expect(modal.contentEl.querySelector(".ss-search__metrics")).toBeNull();
+      expect(modal.contentEl.querySelector(".ss-search__state")).toBeNull();
+      expect(modal.contentEl.querySelector("[data-mode]")).toBeNull();
+      expect(modal.contentEl.querySelector("[data-sort]")).toBeNull();
+      expect((modal as any).footerEl.style.display).toBe("none");
+    });
+
+    it("renders recent files on open without warming or checking backends", async () => {
+      modal.onOpen();
+      await flush();
+
+      expect(plugin._testEngine.getRecent).toHaveBeenCalledWith(25);
       expect(plugin._testEngine.getEmbeddingsIndicator).not.toHaveBeenCalled();
+      expect((modal as any).listEl?.textContent).toContain("Recent Note");
     });
   });
 
-  describe("onOpen", () => {
-    it("creates search input element", () => {
-      modal.onOpen();
-      expect((modal as any).searchInputEl).not.toBeNull();
-    });
-
-    it("creates list element for results", () => {
-      modal.onOpen();
-      expect((modal as any).listEl).not.toBeNull();
-    });
-
-    it("does not create metrics chrome", () => {
-      modal.onOpen();
-      expect(modal.contentEl.querySelector(".ss-search__metrics")).toBeNull();
-    });
-
-    it("does not create backend state chrome", () => {
-      modal.onOpen();
-      expect(modal.contentEl.querySelector(".ss-search__state")).toBeNull();
-    });
-
-    it("does not render mode or sort controls", () => {
-      modal.onOpen();
-      expect(modal.contentEl.querySelector("[data-mode]")).toBeNull();
-      expect(modal.contentEl.querySelector("[data-sort]")).toBeNull();
-    });
-
-    it("renders recent files on open", async () => {
-      modal.onOpen();
-      jest.advanceTimersByTime(10);
-      await Promise.resolve();
-      expect(plugin._testEngine.getRecent).toHaveBeenCalledWith(25);
-    });
-
-    it("does not warm the content index on open", () => {
-      modal.onOpen();
-      expect(plugin._testEngine.warmIndex).not.toHaveBeenCalled();
-    });
-
-    it("does not check backend readiness on open", () => {
-      modal.onOpen();
-      expect(plugin._testEngine.getEmbeddingsIndicator).not.toHaveBeenCalled();
-    });
-
-    it("hydrates only visible recent previews after the initial render", async () => {
+  describe("recent preview hydration", () => {
+    it("hydrates only visible recent previews after the first paint", async () => {
       plugin = createMockPlugin({
         getRecentPreviews: jest.fn().mockResolvedValue(new Map([["notes/recent.md", "Recent note opening text"]])),
       });
       modal = new SystemSculptSearchModal(plugin);
 
       modal.onOpen();
-      await Promise.resolve();
+      await flush();
 
       expect((modal as any).listEl?.textContent).toContain("Recent Note");
       expect((modal as any).listEl?.textContent).not.toContain("Recent note opening text");
 
-      jest.runOnlyPendingTimers();
-      await Promise.resolve();
-      await Promise.resolve();
+      jest.advanceTimersByTime(30);
+      await flush(3);
 
-      expect(plugin._testEngine.getRecentPreviews).toHaveBeenCalledWith(["notes/recent.md"], 25);
+      expect(plugin._testEngine.getRecentPreviews).toHaveBeenCalledWith(
+        ["notes/recent.md"],
+        25,
+        expect.any(AbortSignal)
+      );
       expect((modal as any).listEl?.textContent).toContain("Recent note opening text");
-      expect(plugin._testEngine.warmIndex).not.toHaveBeenCalled();
     });
-  });
 
-  describe("onClose", () => {
-    it("clears debounce handle", () => {
+    it("aborts preview hydration when the user starts searching", async () => {
+      let previewSignal: AbortSignal | undefined;
+      plugin = createMockPlugin({
+        getRecentPreviews: jest.fn((_paths, _limit, signal) => {
+          previewSignal = signal;
+          return new Promise(() => undefined);
+        }),
+      });
+      modal = new SystemSculptSearchModal(plugin);
       modal.onOpen();
-      (modal as any).debounceHandle = 123;
-      modal.onClose();
-      expect((modal as any).debounceHandle).toBeNull();
+      await flush();
+
+      jest.advanceTimersByTime(30);
+      await flush();
+
+      const input = (modal as any).searchInputEl as HTMLInputElement;
+      input.value = "test";
+      input.dispatchEvent(new Event("input"));
+
+      expect(previewSignal?.aborted).toBe(true);
     });
   });
 
   describe("search execution", () => {
-    it("debounces search input by 180ms", () => {
+    it("debounces input and uses one smart search path with cancellation support", () => {
       modal.onOpen();
-      const searchInput = (modal as any).searchInputEl;
+      const searchInput = (modal as any).searchInputEl as HTMLInputElement;
 
       searchInput.value = "test";
       searchInput.dispatchEvent(new Event("input"));
 
       expect(plugin._testEngine.search).not.toHaveBeenCalled();
-
       jest.advanceTimersByTime(180);
 
-      expect(plugin._testEngine.search).toHaveBeenCalledWith("test", expect.any(Object));
+      expect(plugin._testEngine.search).toHaveBeenCalledWith("test", {
+        mode: "smart",
+        sort: "relevance",
+        limit: 80,
+        signal: expect.any(AbortSignal),
+      });
     });
 
-    it("clears previous debounce on new input", () => {
-      modal.onOpen();
-      const searchInput = (modal as any).searchInputEl;
-
-      searchInput.value = "first";
-      searchInput.dispatchEvent(new Event("input"));
-
-      jest.advanceTimersByTime(100);
-
-      searchInput.value = "second";
-      searchInput.dispatchEvent(new Event("input"));
-
-      jest.advanceTimersByTime(180);
-
-      expect(plugin._testEngine.search).toHaveBeenCalledTimes(1);
-      expect(plugin._testEngine.search).toHaveBeenCalledWith("second", expect.any(Object));
-    });
-
-    it("uses query serial to prevent race conditions", async () => {
+    it("uses query serials to prevent stale responses from replacing newer results", async () => {
       modal.onOpen();
 
       let resolveFirst: (val: SearchResponse) => void;
-      const firstPromise = new Promise<SearchResponse>((r) => {
-        resolveFirst = r;
+      const firstPromise = new Promise<SearchResponse>((resolve) => {
+        resolveFirst = resolve;
       });
 
       plugin._testEngine.search.mockReturnValueOnce(firstPromise);
@@ -213,85 +197,85 @@ describe("SystemSculptSearchModal", () => {
         })
       );
 
-      (modal as any).executeSearch("first");
-      (modal as any).executeSearch("second");
-      await Promise.resolve();
-
+      void (modal as any).executeSearch("first");
+      await (modal as any).executeSearch("second");
       resolveFirst!(createMockSearchResponse());
-      await Promise.resolve();
+      await flush();
 
       const listEl = (modal as any).listEl;
       expect(listEl?.querySelector('[data-path="notes/second.md"]')).not.toBeNull();
+      expect(listEl?.querySelector('[data-path="notes/test.md"]')).toBeNull();
     });
 
-    it("renders recents for empty query", async () => {
-      modal.onOpen();
-      await (modal as any).executeSearch("");
-
-      expect(plugin._testEngine.getRecent).toHaveBeenCalled();
-    });
-
-    it("uses one adaptive search path", async () => {
-      modal.onOpen();
-
-      await (modal as any).executeSearch("test");
-
-      expect(plugin._testEngine.search).toHaveBeenCalledWith("test", {
-        mode: "smart",
-        sort: "relevance",
-        limit: 80,
+    it("refreshes metadata-only results after the content index finishes", async () => {
+      const first = createMockSearchResponse({
+        results: [{ path: "notes/title-hit.md", title: "Title Hit", score: 0.8, origin: "lexical", updatedAt: Date.now() }],
+        stats: {
+          ...createMockSearchResponse().stats,
+          indexingPending: true,
+          metadataOnly: true,
+        },
       });
+      const second = createMockSearchResponse({
+        results: [{ path: "notes/body-hit.md", title: "Body Hit", score: 0.95, origin: "lexical", updatedAt: Date.now() }],
+      });
+      plugin = createMockPlugin({
+        search: jest.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+        whenIndexReady: jest.fn().mockResolvedValue(undefined),
+      });
+      modal = new SystemSculptSearchModal(plugin);
+      modal.onOpen();
+
+      await (modal as any).executeSearch("body");
+      jest.advanceTimersByTime(0);
+      await flush(4);
+
+      expect(plugin._testEngine.whenIndexReady).toHaveBeenCalled();
+      expect((modal as any).listEl?.querySelector('[data-path="notes/body-hit.md"]')).not.toBeNull();
     });
   });
 
   describe("result rendering", () => {
-    it("renders results with title and path", async () => {
+    it("renders results without scores or origin badges", async () => {
       modal.onOpen();
-
-      const response = createMockSearchResponse();
-      plugin._testEngine.search.mockResolvedValue(response);
-
       await (modal as any).executeSearch("test");
 
       const listEl = (modal as any).listEl;
       const item = listEl?.querySelector(".ss-search__item");
       expect(item?.getAttribute("data-path")).toBe("notes/test.md");
+      expect(listEl?.querySelector(".ss-search__score")).toBeNull();
+      expect(listEl?.querySelector(".ss-search__pill--semantic")).toBeNull();
     });
 
-    it("does not render origin badges", async () => {
+    it("escapes note content while still highlighting matching terms", async () => {
       modal.onOpen();
+      plugin._testEngine.search.mockResolvedValue(
+        createMockSearchResponse({
+          results: [
+            {
+              path: "notes/xss.md",
+              title: 'Machine <img src=x onerror="alert(1)">',
+              excerpt: 'Learning <script>alert("x")</script> guide',
+              score: 0.9,
+              origin: "lexical",
+              updatedAt: Date.now(),
+            },
+          ],
+        })
+      );
 
-      const response = createMockSearchResponse({
-        results: [
-          { path: "notes/semantic.md", title: "Semantic", score: 0.9, origin: "semantic", updatedAt: Date.now() },
-        ],
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
+      await (modal as any).executeSearch("machine learning");
 
-      await (modal as any).executeSearch("test");
-
-      const badge = (modal as any).listEl?.querySelector(".ss-search__pill--semantic");
-      expect(badge).toBeNull();
-    });
-
-    it("renders score as percentage", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        results: [{ path: "notes/test.md", title: "Test", score: 0.857, origin: "lexical", updatedAt: Date.now() }],
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      await (modal as any).executeSearch("test");
-
-      const scoreEl = (modal as any).listEl?.querySelector(".ss-search__score");
-      expect(scoreEl?.textContent).toBe("86%");
+      const listEl = (modal as any).listEl as HTMLElement;
+      expect(listEl.querySelector("img")).toBeNull();
+      expect(listEl.querySelector("script")).toBeNull();
+      expect(listEl.textContent).toContain('<img src=x onerror="alert(1)">');
+      expect(listEl.querySelectorAll("mark.ss-hl")).toHaveLength(2);
     });
 
     it("does not show a missing-preview placeholder for metadata-only recents", async () => {
       modal.onOpen();
-      await Promise.resolve();
-      await Promise.resolve();
+      await flush();
 
       const listEl = (modal as any).listEl;
       expect(listEl?.textContent).toContain("Recent Note");
@@ -299,158 +283,60 @@ describe("SystemSculptSearchModal", () => {
       expect(listEl?.querySelector(".ss-search__excerpt")).toBeNull();
     });
 
-    it("shows 'No matches yet' for empty results", async () => {
+    it("shows a simple empty state for empty results", async () => {
       modal.onOpen();
-
-      const response = createMockSearchResponse({ results: [] });
-      plugin._testEngine.search.mockResolvedValue(response);
+      plugin._testEngine.search.mockResolvedValue(createMockSearchResponse({ results: [] }));
 
       await (modal as any).executeSearch("nonexistent");
 
-      const emptyEl = (modal as any).listEl?.querySelector(".ss-search__empty");
-      expect(emptyEl).not.toBeNull();
-    });
-
-    it("highlights query terms in title using mark elements", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        results: [
-          { path: "notes/test.md", title: "Machine Learning Guide", score: 0.9, origin: "lexical", updatedAt: Date.now() },
-        ],
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      (modal as any).currentQuery = "machine";
-      await (modal as any).executeSearch("machine");
-
-      const titleEl = (modal as any).listEl?.querySelector(".ss-search__title");
-      const markEl = titleEl?.querySelector("mark.ss-hl");
-      expect(markEl).not.toBeNull();
-      expect(markEl?.textContent).toBe("Machine");
-    });
-
-    it("highlights multiple query terms", async () => {
-      modal.onOpen();
-      const highlightedText = (modal as any).getHighlightedText("Machine Learning Guide", "machine guide");
-      const container = document.createElement("div");
-      container.insertAdjacentHTML("beforeend", highlightedText);
-      const marks = container.querySelectorAll("mark.ss-hl");
-      expect(marks.length).toBe(2);
-    });
-
-    it("returns original text when no query matches", () => {
-      modal.onOpen();
-      const text = "Machine Learning Guide";
-      const result = (modal as any).getHighlightedText(text, "xyz");
-      expect(result).toBe(text);
-    });
-  });
-
-  describe("date formatting", () => {
-    it("formats today as 'Updated today'", () => {
-      modal.onOpen();
-      const now = Date.now();
-      expect((modal as any).formatUpdated(now - 1000)).toBe("Updated today");
-    });
-
-    it("formats recent days as 'Xd ago'", () => {
-      modal.onOpen();
-      const threeDaysAgo = Date.now() - 3 * 24 * 60 * 60 * 1000;
-      expect((modal as any).formatUpdated(threeDaysAgo)).toBe("3d ago");
-    });
-
-    it("formats old dates as locale date string", () => {
-      modal.onOpen();
-      const oldDate = Date.now() - 30 * 24 * 60 * 60 * 1000;
-      const result = (modal as any).formatUpdated(oldDate);
-      expect(result).toMatch(/\d/);
-    });
-
-    it("returns 'No date' for undefined", () => {
-      modal.onOpen();
-      expect((modal as any).formatUpdated(undefined)).toBe("No date");
-    });
-  });
-
-  describe("size formatting", () => {
-    it("formats bytes", () => {
-      modal.onOpen();
-      expect((modal as any).formatSize(500)).toBe("500 B");
-    });
-
-    it("formats kilobytes", () => {
-      modal.onOpen();
-      expect((modal as any).formatSize(2048)).toBe("2.0 KB");
-    });
-
-    it("formats megabytes", () => {
-      modal.onOpen();
-      expect((modal as any).formatSize(1500000)).toBe("1.4 MB");
-    });
-  });
-
-  describe("copy results", () => {
-    beforeEach(() => {
-      Object.defineProperty(navigator, "clipboard", {
-        value: {
-          writeText: jest.fn().mockResolvedValue(undefined),
-        },
-        writable: true,
-      });
-    });
-
-    it("copies paths to clipboard", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse({
-        results: [
-          { path: "notes/one.md", title: "One", score: 1, origin: "lexical", updatedAt: Date.now() },
-          { path: "notes/two.md", title: "Two", score: 0.9, origin: "lexical", updatedAt: Date.now() },
-        ],
-      });
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      await (modal as any).executeSearch("test");
-      await (modal as any).copyResults();
-
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("notes/one.md\nnotes/two.md");
-    });
-
-    it("handles empty results list", async () => {
-      modal.onOpen();
-      (modal as any).listEl!.textContent = "";
-
-      await expect((modal as any).copyResults()).resolves.not.toThrow();
-    });
-  });
-
-  describe("drag and drop", () => {
-    it("makes results draggable", async () => {
-      modal.onOpen();
-
-      const response = createMockSearchResponse();
-      plugin._testEngine.search.mockResolvedValue(response);
-
-      await (modal as any).executeSearch("test");
-
-      expect((modal as any).listEl?.classList.contains("scs-draggable")).toBe(true);
+      expect((modal as any).listEl?.querySelector(".ss-search__empty")).not.toBeNull();
     });
   });
 
   describe("result item interaction", () => {
-    it("opens file on item click", async () => {
+    it("opens a file on delegated item click", async () => {
       modal.onOpen();
-
-      const response = createMockSearchResponse();
-      plugin._testEngine.search.mockResolvedValue(response);
-
       await (modal as any).executeSearch("test");
 
-      const item = (modal as any).listEl?.querySelector(".ss-search__item");
-      item?.click();
+      const item = (modal as any).listEl?.querySelector(".ss-search__item") as HTMLElement;
+      item.click();
 
       expect(plugin.app.workspace.openLinkText).toHaveBeenCalledWith("notes/test.md", "");
+    });
+
+    it("opens a focused result with Enter", async () => {
+      modal.onOpen();
+      await (modal as any).executeSearch("test");
+
+      const item = (modal as any).listEl?.querySelector(".ss-search__item") as HTMLElement;
+      item.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+      expect(plugin.app.workspace.openLinkText).toHaveBeenCalledWith("notes/test.md", "");
+    });
+
+    it("moves focus from the input to the first result with ArrowDown", async () => {
+      document.body.appendChild((modal as any).modalEl);
+      modal.onOpen();
+      await (modal as any).executeSearch("test");
+
+      const input = (modal as any).searchInputEl as HTMLInputElement;
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+
+      expect(document.activeElement).toBe((modal as any).listEl?.querySelector(".ss-search__item"));
+    });
+  });
+
+  describe("formatting helpers", () => {
+    it("formats today as 'Updated today'", () => {
+      modal.onOpen();
+      expect((modal as any).formatUpdated(Date.now() - 1000)).toBe("Updated today");
+    });
+
+    it("formats sizes", () => {
+      modal.onOpen();
+      expect((modal as any).formatSize(500)).toBe("500 B");
+      expect((modal as any).formatSize(2048)).toBe("2.0 KB");
+      expect((modal as any).formatSize(1500000)).toBe("1.4 MB");
     });
   });
 });

--- a/src/modals/__tests__/SystemSculptSearchModal.test.ts
+++ b/src/modals/__tests__/SystemSculptSearchModal.test.ts
@@ -39,7 +39,7 @@ const createMockSearchResponse = (overrides: Partial<SearchResponse> = {}): Sear
 
 const createMockEngine = (overrides: Record<string, any> = {}) => ({
   search: jest.fn().mockResolvedValue(createMockSearchResponse()),
-  warmIndex: jest.fn(),
+  warmIndex: jest.fn().mockResolvedValue(undefined),
   getRecent: jest.fn().mockResolvedValue([
     { path: "notes/recent.md", title: "Recent Note", score: 1, origin: "recent" as const, updatedAt: Date.now() },
   ]),
@@ -126,6 +126,46 @@ describe("SystemSculptSearchModal", () => {
     it("warms the content index in the background", () => {
       modal.onOpen();
       expect(plugin._testEngine.warmIndex).toHaveBeenCalled();
+    });
+
+    it("refreshes recent previews after the background index warms", async () => {
+      let resolveWarmIndex!: () => void;
+      const warmIndex = new Promise<void>((resolve) => {
+        resolveWarmIndex = resolve;
+      });
+
+      plugin = createMockPlugin({
+        warmIndex: jest.fn().mockReturnValue(warmIndex),
+        getRecent: jest.fn()
+          .mockResolvedValueOnce([
+            { path: "notes/recent.md", title: "Recent Note", score: 1, origin: "recent" as const, updatedAt: Date.now() },
+          ])
+          .mockResolvedValueOnce([
+            {
+              path: "notes/recent.md",
+              title: "Recent Note",
+              excerpt: "Indexed preview text",
+              score: 1,
+              origin: "recent" as const,
+              updatedAt: Date.now(),
+            },
+          ]),
+      });
+      modal = new SystemSculptSearchModal(plugin);
+
+      modal.onOpen();
+      await Promise.resolve();
+
+      expect(plugin._testEngine.getRecent).toHaveBeenCalledTimes(1);
+      expect((modal as any).listEl?.textContent).toContain("Recent Note");
+      expect((modal as any).listEl?.textContent).not.toContain("No preview available");
+
+      resolveWarmIndex();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(plugin._testEngine.getRecent).toHaveBeenCalledTimes(2);
+      expect((modal as any).listEl?.textContent).toContain("Indexed preview text");
     });
   });
 
@@ -318,6 +358,17 @@ describe("SystemSculptSearchModal", () => {
 
       const scoreEl = (modal as any).listEl?.querySelector(".ss-search__score");
       expect(scoreEl?.textContent).toBe("86%");
+    });
+
+    it("does not show a missing-preview placeholder for metadata-only recents", async () => {
+      modal.onOpen();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const listEl = (modal as any).listEl;
+      expect(listEl?.textContent).toContain("Recent Note");
+      expect(listEl?.textContent).not.toContain("No preview available");
+      expect(listEl?.querySelector(".ss-search__excerpt")).toBeNull();
     });
 
     it("shows 'No matches yet' for empty results", async () => {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -49,6 +49,10 @@ interface IndexedDocument {
   title: string;
   lowerTitle: string;
   lowerPath: string;
+  titleTokens: Set<string>;
+  pathTokens: Set<string>;
+  bodyTokens: Set<string>;
+  tokens: Set<string>;
   body: string; // truncated, lowercased content (frontmatter stripped)
   rawBody: string; // truncated, original casing for excerpts
   preview: string; // short excerpt for list view
@@ -56,10 +60,20 @@ interface IndexedDocument {
   size: number;
 }
 
+interface QueryTerm {
+  value: string;
+  exact: Set<string>;
+  prefix: Set<string>;
+  fuzzy: Set<string>;
+}
+
 export class SystemSculptSearchEngine {
   private app: App;
   private plugin: SystemSculptPlugin;
   private index: Map<string, IndexedDocument> = new Map();
+  private tokenIndex: Map<string, Set<string>> = new Map();
+  private tokenVocabulary: Set<string> = new Set();
+  private recentDocsCache: IndexedDocument[] | null = null;
   private indexPromise: Promise<void> | null = null;
   private dirtyPaths: Set<string> = new Set();
   private eventRefs: EventRef[] = [];
@@ -158,9 +172,12 @@ export class SystemSculptSearchEngine {
     await this.ensureIndex();
     await this.refreshDirtyIndex();
 
-    const docs = Array.from(this.index.values())
-      .sort((a, b) => (b.mtime || 0) - (a.mtime || 0))
-      .slice(0, limit);
+    if (!this.recentDocsCache) {
+      this.recentDocsCache = Array.from(this.index.values())
+        .sort((a, b) => (b.mtime || 0) - (a.mtime || 0));
+    }
+
+    const docs = this.recentDocsCache.slice(0, limit);
 
     return docs.map((doc) => ({
       path: doc.path,
@@ -201,8 +218,13 @@ export class SystemSculptSearchEngine {
     this.eventRefs.push(
       this.app.vault.on("delete", (file) => {
         if (file instanceof TFile) {
+          const existing = this.index.get(file.path);
+          if (existing) {
+            this.removeFromTokenIndex(existing);
+          }
           this.index.delete(file.path);
           this.dirtyPaths.delete(file.path);
+          this.recentDocsCache = null;
         }
       })
     );
@@ -249,6 +271,13 @@ export class SystemSculptSearchEngine {
   }
 
   private async buildIndex(files: TFile[], incremental = false): Promise<void> {
+    if (!incremental) {
+      this.index.clear();
+      this.tokenIndex.clear();
+      this.tokenVocabulary.clear();
+      this.recentDocsCache = null;
+    }
+
     const tasks = files.map((file) => async () => {
       try {
         const content = await this.safeRead(file);
@@ -256,12 +285,20 @@ export class SystemSculptSearchEngine {
         const rawBody = extracted.slice(0, this.MAX_INDEX_CHARS);
         const body = rawBody.toLowerCase();
         const preview = this.buildPreviewFromText(extracted);
+        const titleTokens = this.tokenizeSearchText(file.basename);
+        const pathTokens = this.tokenizeSearchText(file.path);
+        const bodyTokens = this.tokenizeSearchText(body);
+        const tokens = new Set([...titleTokens, ...pathTokens, ...bodyTokens]);
 
         const doc: IndexedDocument = {
           path: file.path,
           title: file.basename,
           lowerTitle: file.basename.toLowerCase(),
           lowerPath: file.path.toLowerCase(),
+          titleTokens,
+          pathTokens,
+          bodyTokens,
+          tokens,
           body,
           rawBody,
           preview,
@@ -269,23 +306,19 @@ export class SystemSculptSearchEngine {
           size: file.stat?.size || 0,
         };
 
+        const existing = this.index.get(file.path);
+        if (existing) {
+          this.removeFromTokenIndex(existing);
+        }
         this.index.set(file.path, doc);
+        this.addToTokenIndex(doc);
       } catch {
         // Skip failed file
       }
     });
 
     await this.runLimited(tasks, this.CONTENT_CONCURRENCY);
-
-    if (!incremental) {
-      // Remove any stale paths not present anymore
-      const validPaths = new Set(files.map((f) => f.path));
-      for (const key of Array.from(this.index.keys())) {
-        if (!validPaths.has(key) && !this.dirtyPaths.has(key)) {
-          this.index.delete(key);
-        }
-      }
-    }
+    this.recentDocsCache = null;
   }
 
   private async safeRead(file: TFile): Promise<string> {
@@ -327,19 +360,18 @@ export class SystemSculptSearchEngine {
   }
 
   private runLexicalSearch(terms: string[], phrase: string, limit: number, sort: SortMode): SearchHit[] {
-    const docs = Array.from(this.index.values());
-    const candidates = docs.filter((doc) => {
-      if (phrase && doc.body.includes(phrase)) return true;
-      return terms.some((t) => doc.lowerTitle.includes(t) || doc.lowerPath.includes(t) || doc.body.includes(t));
-    });
+    const queryTerms = this.buildQueryTerms(terms);
+    const candidates = this.collectCandidateDocs(queryTerms, limit);
 
     this.lastLexicalInspect = candidates.length;
 
-    // Fallback to top name matches if nothing matched the body/title/path
-    const pool = candidates.length > 0 ? candidates : docs.slice(0, Math.min(this.CANDIDATE_LIMIT, docs.length));
+    // Fallback to the first indexed docs if no indexed token can match the query at all.
+    const pool = candidates.length > 0
+      ? candidates
+      : Array.from(this.index.values()).slice(0, Math.min(this.CANDIDATE_LIMIT, this.index.size));
 
     const scored = pool
-      .map((doc) => this.scoreDocument(doc, terms, phrase))
+      .map((doc) => this.scoreDocument(doc, queryTerms, phrase))
       .filter((r): r is SearchHit => r !== null)
       .sort((a, b) => b.score - a.score)
       .slice(0, limit * 2); // keep extra for merge step
@@ -351,44 +383,32 @@ export class SystemSculptSearchEngine {
     return scored;
   }
 
-  private fastNameScore(doc: IndexedDocument, query: string): number {
-    if (!query) return 0;
-    const lc = query.toLowerCase();
-    let score = 0;
-    if (doc.lowerTitle.includes(lc)) score += 18;
-    if (doc.lowerPath.includes(lc)) score += 8;
-    const fuzzy = fuzzyMatchScore(lc, doc.lowerTitle);
-    if (fuzzy !== null) {
-      score += Math.max(0, 12 - Math.min(fuzzy, 24));
-    }
-    return score;
-  }
-
-  private scoreDocument(doc: IndexedDocument, terms: string[], phrase: string): SearchHit | null {
-    if (terms.length === 0) return null;
+  private scoreDocument(doc: IndexedDocument, queryTerms: QueryTerm[], phrase: string): SearchHit | null {
+    if (queryTerms.length === 0) return null;
     let total = 0;
     let matchedTerms = 0;
 
-    for (const term of terms) {
-      const inTitle = doc.lowerTitle.includes(term);
-      const inPath = doc.lowerPath.includes(term);
-      const inBody = doc.body.includes(term);
-
-      if (inTitle) total += 10;
-      if (inPath) total += 5;
-      if (inBody) total += 4;
-      if (inTitle || inBody) matchedTerms += 1;
+    for (const term of queryTerms) {
+      const fieldScore = this.scoreTermInDocument(doc, term);
+      if (fieldScore > 0) {
+        total += fieldScore;
+        matchedTerms += 1;
+      }
     }
 
-    const phraseHit = phrase && doc.body.includes(phrase) ? 10 : 0;
-    total += phraseHit;
+    if (phrase) {
+      if (doc.lowerTitle.includes(phrase)) total += 20;
+      if (doc.lowerPath.includes(phrase)) total += 10;
+      if (doc.body.includes(phrase)) total += 14;
+    }
 
-    const coverageBonus = matchedTerms > 0 ? (matchedTerms / terms.length) * 10 : 0;
+    const coverageRatio = matchedTerms / queryTerms.length;
+    const coverageBonus = matchedTerms > 0 ? coverageRatio * 16 : 0;
     total += coverageBonus;
 
-    total += this.computeRecencyBoost(doc.mtime);
+    total += this.computeRecencyBoost(doc.mtime) * Math.max(0.25, coverageRatio);
 
-    const maxPossible = terms.length * 19 + 16;
+    const maxPossible = queryTerms.length * 24 + 60;
     const score = Math.min(1, total / maxPossible);
 
     if (score <= 0) return null;
@@ -396,13 +416,44 @@ export class SystemSculptSearchEngine {
     return {
       path: doc.path,
       title: doc.title,
-      excerpt: this.extractExcerpt(doc, terms, phrase),
+      excerpt: this.extractExcerpt(doc, queryTerms.map((term) => term.value), phrase),
       score,
       lexScore: score,
       origin: "lexical",
       updatedAt: doc.mtime,
       size: doc.size,
     };
+  }
+
+  private scoreTermInDocument(doc: IndexedDocument, term: QueryTerm): number {
+    const exactTitle = this.hasAny(doc.titleTokens, term.exact);
+    const exactPath = this.hasAny(doc.pathTokens, term.exact);
+    const exactBody = this.hasAny(doc.bodyTokens, term.exact);
+
+    let total = 0;
+    if (exactTitle) total += 14;
+    if (exactPath) total += 7;
+    if (exactBody) total += 5;
+
+    if (total > 0) return total;
+
+    const prefixTitle = this.hasAny(doc.titleTokens, term.prefix);
+    const prefixPath = this.hasAny(doc.pathTokens, term.prefix);
+    const prefixBody = this.hasAny(doc.bodyTokens, term.prefix);
+    if (prefixTitle) total += 11;
+    if (prefixPath) total += 5;
+    if (prefixBody) total += 3.5;
+
+    if (total > 0) return total;
+
+    const fuzzyTitle = this.hasAny(doc.titleTokens, term.fuzzy);
+    const fuzzyPath = this.hasAny(doc.pathTokens, term.fuzzy);
+    const fuzzyBody = this.hasAny(doc.bodyTokens, term.fuzzy);
+    if (fuzzyTitle) total += 9;
+    if (fuzzyPath) total += 4;
+    if (fuzzyBody) total += 2.5;
+
+    return total;
   }
 
   private computeRecencyBoost(mtime: number | undefined): number {
@@ -413,6 +464,127 @@ export class SystemSculptSearchEngine {
     if (ageDays <= 30) return 3;
     if (ageDays <= 90) return 1.5;
     return 0.5;
+  }
+
+  private tokenizeSearchText(text: string): Set<string> {
+    const tokens = text
+      .toLowerCase()
+      .match(/[a-z0-9]+/g);
+    if (!tokens) return new Set();
+    return new Set(tokens.filter((token) => token.length > 1));
+  }
+
+  private addToTokenIndex(doc: IndexedDocument): void {
+    for (const token of doc.tokens) {
+      this.tokenVocabulary.add(token);
+      let paths = this.tokenIndex.get(token);
+      if (!paths) {
+        paths = new Set();
+        this.tokenIndex.set(token, paths);
+      }
+      paths.add(doc.path);
+    }
+  }
+
+  private removeFromTokenIndex(doc: IndexedDocument): void {
+    for (const token of doc.tokens) {
+      const paths = this.tokenIndex.get(token);
+      if (!paths) continue;
+      paths.delete(doc.path);
+      if (paths.size === 0) {
+        this.tokenIndex.delete(token);
+        this.tokenVocabulary.delete(token);
+      }
+    }
+  }
+
+  private buildQueryTerms(terms: string[]): QueryTerm[] {
+    return terms.map((value) => {
+      const exact = new Set<string>();
+      const prefix = new Set<string>();
+      const fuzzy = new Set<string>();
+
+      if (this.tokenIndex.has(value)) {
+        exact.add(value);
+      }
+
+      if (value.length >= 3) {
+        for (const token of this.tokenVocabulary) {
+          if (token === value) continue;
+          if (token.startsWith(value) || value.startsWith(token)) {
+            prefix.add(token);
+            continue;
+          }
+
+          if (value.length >= 5) {
+            const fuzzyScore = fuzzyMatchScore(value, token);
+            const maxGap = Math.max(2, Math.floor(value.length * 0.45));
+            if (fuzzyScore !== null && fuzzyScore <= maxGap) {
+              fuzzy.add(token);
+            }
+          }
+        }
+      }
+
+      return { value, exact, prefix, fuzzy };
+    });
+  }
+
+  private collectCandidateDocs(queryTerms: QueryTerm[], limit: number): IndexedDocument[] {
+    const counts = new Map<string, number>();
+    for (const term of queryTerms) {
+      const termPaths = this.pathsForQueryTerm(term);
+      for (const path of termPaths) {
+        counts.set(path, (counts.get(path) ?? 0) + 1);
+      }
+    }
+
+    if (counts.size === 0) {
+      return [];
+    }
+
+    const targetMatches = queryTerms.length >= 3
+      ? Math.max(2, queryTerms.length - 1)
+      : 1;
+
+    let candidates = this.docsForPathCounts(counts, targetMatches, limit);
+    if (candidates.length < limit) {
+      candidates = this.docsForPathCounts(counts, Math.max(1, targetMatches - 1), limit);
+    }
+
+    return candidates.slice(0, Math.max(limit * 8, this.CANDIDATE_LIMIT));
+  }
+
+  private pathsForQueryTerm(term: QueryTerm): Set<string> {
+    const paths = new Set<string>();
+    const add = (token: string) => {
+      const tokenPaths = this.tokenIndex.get(token);
+      if (!tokenPaths) return;
+      for (const path of tokenPaths) {
+        paths.add(path);
+      }
+    };
+
+    term.exact.forEach(add);
+    term.prefix.forEach(add);
+    term.fuzzy.forEach(add);
+    return paths;
+  }
+
+  private docsForPathCounts(counts: Map<string, number>, minCount: number, limit: number): IndexedDocument[] {
+    return Array.from(counts.entries())
+      .filter(([, count]) => count >= minCount)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, Math.max(limit * 8, this.CANDIDATE_LIMIT))
+      .map(([path]) => this.index.get(path))
+      .filter((doc): doc is IndexedDocument => doc !== undefined);
+  }
+
+  private hasAny(tokens: Set<string>, candidates: Set<string>): boolean {
+    for (const candidate of candidates) {
+      if (tokens.has(candidate)) return true;
+    }
+    return false;
   }
 
   private extractExcerpt(doc: IndexedDocument, terms: string[], phrase: string): string {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -36,6 +36,7 @@ export interface SearchStats {
   inspectedCount: number;
   mode: SearchMode;
   usedEmbeddings: boolean;
+  embeddingsEligible?: boolean;
 }
 
 export interface SearchResponse {
@@ -73,7 +74,7 @@ export class SystemSculptSearchEngine {
   private index: Map<string, IndexedDocument> = new Map();
   private tokenIndex: Map<string, Set<string>> = new Map();
   private tokenVocabulary: Set<string> = new Set();
-  private recentDocsCache: IndexedDocument[] | null = null;
+  private recentHitsCache: SearchHit[] | null = null;
   private indexPromise: Promise<void> | null = null;
   private dirtyPaths: Set<string> = new Set();
   private eventRefs: EventRef[] = [];
@@ -100,12 +101,6 @@ export class SystemSculptSearchEngine {
     const limit = options?.limit ?? 80;
 
     const searchStart = performance.now();
-    const indexStart = performance.now();
-    await this.ensureIndex();
-    await this.refreshDirtyIndex();
-    const indexMs = performance.now() - indexStart;
-    this.lastLexicalInspect = 0;
-
     const normalizedQuery = query.trim().toLowerCase();
     const terms = normalizedQuery.split(/\s+/).filter(Boolean);
     const phrase = normalizedQuery;
@@ -116,15 +111,22 @@ export class SystemSculptSearchEngine {
         results: recents,
         stats: {
           totalMs: performance.now() - searchStart,
-          indexMs,
+          indexMs: 0,
           indexedCount: this.index.size,
           inspectedCount: 0,
           mode,
           usedEmbeddings: false,
+          embeddingsEligible: false,
         },
         embeddings: this.getEmbeddingsIndicator(),
       };
     }
+
+    const indexStart = performance.now();
+    await this.ensureIndex();
+    await this.refreshDirtyIndex();
+    const indexMs = performance.now() - indexStart;
+    this.lastLexicalInspect = 0;
 
     const lexStart = performance.now();
     const lexicalHits = this.runLexicalSearch(terms, phrase, limit, sort);
@@ -135,8 +137,9 @@ export class SystemSculptSearchEngine {
     let usedEmbeddings = false;
 
     const embeddingsIndicator = this.getEmbeddingsIndicator();
+    const embeddingsEligible = this.shouldUseEmbeddings(mode, embeddingsIndicator, terms);
 
-    if (mode !== "lexical" && embeddingsIndicator.enabled && embeddingsIndicator.ready && embeddingsIndicator.available) {
+    if (embeddingsEligible) {
       const semStart = performance.now();
       semanticHits = await this.runSemanticSearch(query, limit);
       semMs = performance.now() - semStart;
@@ -160,6 +163,7 @@ export class SystemSculptSearchEngine {
         inspectedCount: this.lastLexicalInspect,
         mode,
         usedEmbeddings,
+        embeddingsEligible,
       },
       embeddings: embeddingsIndicator,
     };
@@ -169,31 +173,39 @@ export class SystemSculptSearchEngine {
    * Recent files snapshot for empty queries
    */
   async getRecent(limit = 25): Promise<SearchHit[]> {
-    await this.ensureIndex();
-    await this.refreshDirtyIndex();
-
-    if (!this.recentDocsCache) {
-      this.recentDocsCache = Array.from(this.index.values())
-        .sort((a, b) => (b.mtime || 0) - (a.mtime || 0));
+    if (!this.recentHitsCache) {
+      this.recentHitsCache = this.getEligibleFiles()
+        .sort((a, b) => (b.stat?.mtime || 0) - (a.stat?.mtime || 0))
+        .map((file) => {
+          const indexed = this.index.get(file.path);
+          return {
+            path: file.path,
+            title: indexed?.title ?? file.basename,
+            excerpt: indexed?.preview,
+            score: 0.5,
+            origin: "recent" as const,
+            updatedAt: file.stat?.mtime || 0,
+            size: file.stat?.size || 0,
+          };
+        });
     }
 
-    const docs = this.recentDocsCache.slice(0, limit);
+    return this.recentHitsCache.slice(0, limit);
+  }
 
-    return docs.map((doc) => ({
-      path: doc.path,
-      title: doc.title,
-      excerpt: doc.preview,
-      score: 0.5,
-      origin: "recent",
-      updatedAt: doc.mtime,
-      size: doc.size,
-    }));
+  warmIndex(): void {
+    void this.ensureIndex().catch(() => {
+      // Search can recover on the next explicit query.
+    });
   }
 
   destroy(): void {
     this.eventRefs.forEach((ref) => this.app.vault.offref(ref));
     this.eventRefs = [];
     this.index.clear();
+    this.tokenIndex.clear();
+    this.tokenVocabulary.clear();
+    this.recentHitsCache = null;
     this.dirtyPaths.clear();
     this.indexPromise = null;
   }
@@ -203,6 +215,7 @@ export class SystemSculptSearchEngine {
       this.app.vault.on("modify", (file) => {
         if (file instanceof TFile && this.isEligible(file)) {
           this.dirtyPaths.add(file.path);
+          this.recentHitsCache = null;
         }
       })
     );
@@ -211,6 +224,7 @@ export class SystemSculptSearchEngine {
       this.app.vault.on("create", (file) => {
         if (file instanceof TFile && this.isEligible(file)) {
           this.dirtyPaths.add(file.path);
+          this.recentHitsCache = null;
         }
       })
     );
@@ -224,7 +238,7 @@ export class SystemSculptSearchEngine {
           }
           this.index.delete(file.path);
           this.dirtyPaths.delete(file.path);
-          this.recentDocsCache = null;
+          this.recentHitsCache = null;
         }
       })
     );
@@ -232,10 +246,15 @@ export class SystemSculptSearchEngine {
     this.eventRefs.push(
       this.app.vault.on("rename", (file, oldPath) => {
         if (!(file instanceof TFile)) return;
+        const existing = this.index.get(oldPath);
+        if (existing) {
+          this.removeFromTokenIndex(existing);
+        }
         this.index.delete(oldPath);
         if (this.isEligible(file)) {
           this.dirtyPaths.add(file.path);
         }
+        this.recentHitsCache = null;
       })
     );
   }
@@ -275,7 +294,7 @@ export class SystemSculptSearchEngine {
       this.index.clear();
       this.tokenIndex.clear();
       this.tokenVocabulary.clear();
-      this.recentDocsCache = null;
+      this.recentHitsCache = null;
     }
 
     const tasks = files.map((file) => async () => {
@@ -318,7 +337,7 @@ export class SystemSculptSearchEngine {
     });
 
     await this.runLimited(tasks, this.CONTENT_CONCURRENCY);
-    this.recentDocsCache = null;
+    this.recentHitsCache = null;
   }
 
   private async safeRead(file: TFile): Promise<string> {
@@ -658,6 +677,19 @@ export class SystemSculptSearchEngine {
     } catch {
       return [];
     }
+  }
+
+  private shouldUseEmbeddings(mode: SearchMode, indicator: EmbeddingsIndicator, terms: string[]): boolean {
+    if (mode === "lexical") return false;
+    if (!indicator.enabled || !indicator.ready || !indicator.available) return false;
+    if (mode === "semantic") return true;
+    if (terms.length === 0) return false;
+
+    const total = indicator.total ?? 0;
+    const processed = indicator.processed ?? 0;
+    if (total <= 0) return indicator.available;
+
+    return processed / total >= 0.75;
   }
 
   private mergeResults(lexical: SearchHit[], semantic: SearchHit[], limit: number, mode: SearchMode): SearchHit[] {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -181,6 +181,7 @@ export class SystemSculptSearchEngine {
     }
 
     if (mode === "smart" && !this.contentIndexReady) {
+      this.refreshEligibilityIfChanged();
       const metadataStart = performance.now();
       const metadataHits = this.runMetadataSearch(terms, phrase, limit, sort);
       this.scheduleIndexing();

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -74,7 +74,7 @@ export class SystemSculptSearchEngine {
   private index: Map<string, IndexedDocument> = new Map();
   private tokenIndex: Map<string, Set<string>> = new Map();
   private tokenVocabulary: Set<string> = new Set();
-  private recentHitsCache: SearchHit[] | null = null;
+  private recentHitsCache: { limit: number; hits: SearchHit[] } | null = null;
   private indexPromise: Promise<void> | null = null;
   private dirtyPaths: Set<string> = new Set();
   private eventRefs: EventRef[] = [];
@@ -83,6 +83,7 @@ export class SystemSculptSearchEngine {
   private readonly PREVIEW_CHARS = 240;
   private readonly CANDIDATE_LIMIT = 320;
   private readonly CONTENT_CONCURRENCY = 10;
+  private readonly RECENT_PREVIEW_CONCURRENCY = 2;
   private readonly SEMANTIC_TIMEOUT_MS = 1500;
   private lastLexicalInspect = 0;
 
@@ -173,10 +174,11 @@ export class SystemSculptSearchEngine {
    * Recent files snapshot for empty queries
    */
   async getRecent(limit = 25): Promise<SearchHit[]> {
-    if (!this.recentHitsCache) {
-      this.recentHitsCache = this.getEligibleFiles()
-        .sort((a, b) => (b.stat?.mtime || 0) - (a.stat?.mtime || 0))
-        .map((file) => {
+    if (!this.recentHitsCache || this.recentHitsCache.limit < limit) {
+      const recentFiles = this.selectRecentFiles(this.getEligibleFiles(), limit);
+      this.recentHitsCache = {
+        limit,
+        hits: recentFiles.map((file) => {
           const indexed = this.index.get(file.path);
           return {
             path: file.path,
@@ -187,10 +189,33 @@ export class SystemSculptSearchEngine {
             updatedAt: file.stat?.mtime || 0,
             size: file.stat?.size || 0,
           };
-        });
+        }),
+      };
     }
 
-    return this.recentHitsCache.slice(0, limit);
+    return this.recentHitsCache.hits.slice(0, limit);
+  }
+
+  async getRecentPreviews(paths: string[], limit = 25): Promise<Map<string, string>> {
+    const previews = new Map<string, string>();
+    const uniquePaths = Array.from(new Set(paths)).slice(0, limit);
+    const tasks = uniquePaths.map((path) => async () => {
+      const file = this.app.vault.getAbstractFileByPath(path);
+      if (!(file instanceof TFile) || !this.isEligible(file)) return;
+
+      try {
+        const content = await this.safeRead(file);
+        const preview = this.buildPreviewFromText(this.getIndexText(file, content));
+        if (preview) {
+          previews.set(path, preview);
+        }
+      } catch {
+        // Skip failed preview hydration.
+      }
+    });
+
+    await this.runLimited(tasks, this.RECENT_PREVIEW_CONCURRENCY);
+    return previews;
   }
 
   async warmIndex(): Promise<void> {
@@ -359,6 +384,13 @@ export class SystemSculptSearchEngine {
     const cached = this.plugin.vaultFileCache?.getAllFiles?.();
     const files = Array.isArray(cached) ? cached : this.app.vault.getFiles();
     return files.filter((f) => this.isEligible(f));
+  }
+
+  private selectRecentFiles(files: TFile[], limit: number): TFile[] {
+    if (limit <= 0) return [];
+    return files
+      .sort((a, b) => (b.stat?.mtime || 0) - (a.stat?.mtime || 0))
+      .slice(0, limit);
   }
 
   private isEligible(file: TFile): boolean {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -193,10 +193,12 @@ export class SystemSculptSearchEngine {
     return this.recentHitsCache.slice(0, limit);
   }
 
-  warmIndex(): void {
-    void this.ensureIndex().catch(() => {
+  async warmIndex(): Promise<void> {
+    try {
+      await this.ensureIndex();
+    } catch {
       // Search can recover on the next explicit query.
-    });
+    }
   }
 
   destroy(): void {
@@ -270,7 +272,12 @@ export class SystemSculptSearchEngine {
       await this.buildIndex(files);
     })();
 
-    await this.indexPromise;
+    try {
+      await this.indexPromise;
+    } catch (error) {
+      this.indexPromise = null;
+      throw error;
+    }
   }
 
   private async refreshDirtyIndex(): Promise<void> {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -267,6 +267,7 @@ export class SystemSculptSearchEngine {
    * Recent files snapshot for empty queries
    */
   async getRecent(limit = 25): Promise<SearchHit[]> {
+    this.refreshEligibilityIfChanged();
     if (!this.recentHitsCache || this.recentHitsCache.limit < limit) {
       const recentFiles = this.selectRecentFiles(this.getEligibleFiles(), limit);
       this.recentHitsCache = {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -75,12 +75,45 @@ interface CachedPreview {
   preview: string;
 }
 
+interface MetadataTokenSnapshot {
+  lowerTitle: string;
+  lowerPath: string;
+  titleTokens: Set<string>;
+  pathTokens: Set<string>;
+}
+
+interface SearchableEmbeddingsManager {
+  awaitReady?: () => Promise<void>;
+  searchSimilar: (query: string, limit: number, signal?: AbortSignal) => Promise<Array<{
+    path: string;
+    score?: number;
+    metadata?: {
+      title?: string | null;
+      excerpt?: string;
+      lastModified?: number;
+    };
+  }>>;
+  isReady?: () => boolean;
+  hasAnyEmbeddings?: () => boolean;
+  getStats?: () => {
+    total?: number;
+    processed?: number;
+    present?: number;
+    needsProcessing?: number;
+  };
+}
+
 export class SystemSculptSearchEngine {
   private app: App;
   private plugin: SystemSculptPlugin;
   private index: Map<string, IndexedDocument> = new Map();
   private tokenIndex: Map<string, Set<string>> = new Map();
   private tokenVocabulary: Set<string> = new Set();
+  private sortedTokenVocabulary: string[] = [];
+  private tokenLengthBuckets: Map<number, string[]> = new Map();
+  private tokenLookupsDirty = true;
+  private eligibleFilesCache: TFile[] | null = null;
+  private metadataTokenCache: Map<string, MetadataTokenSnapshot> = new Map();
   private recentHitsCache: { limit: number; hits: SearchHit[] } | null = null;
   private recentPreviewCache: Map<string, CachedPreview> = new Map();
   private indexPromise: Promise<void> | null = null;
@@ -92,9 +125,13 @@ export class SystemSculptSearchEngine {
   private workspaceEventRefs: EventRef[] = [];
   private readonly INDEXABLE_EXTENSIONS = new Set(["md", "markdown", "canvas"]);
   private readonly MAX_INDEX_CHARS = 6500;
+  private readonly MAX_EXCERPT_SOURCE_CHARS = 2200;
   private readonly PREVIEW_CHARS = 240;
   private readonly CANDIDATE_LIMIT = 320;
+  private readonly PREFIX_TOKEN_LIMIT = 160;
+  private readonly FUZZY_TOKEN_LIMIT = 80;
   private readonly CONTENT_CONCURRENCY = 10;
+  private readonly INDEX_BUILD_YIELD_EVERY = 128;
   private readonly RECENT_PREVIEW_CONCURRENCY = 2;
   private readonly MAX_RECENT_PREVIEW_FILE_BYTES = 1024 * 1024;
   private readonly SEMANTIC_TIMEOUT_MS = 1500;
@@ -133,7 +170,7 @@ export class SystemSculptSearchEngine {
           usedEmbeddings: false,
           embeddingsEligible: false,
         },
-        embeddings: this.getPassiveEmbeddingsIndicator(),
+        embeddings: this.getEmbeddingsIndicator(),
       };
     }
 
@@ -160,7 +197,7 @@ export class SystemSculptSearchEngine {
           indexingPending: true,
           metadataOnly: true,
         },
-        embeddings: this.getPassiveEmbeddingsIndicator(),
+        embeddings: this.getEmbeddingsIndicator(),
       };
     }
 
@@ -300,6 +337,11 @@ export class SystemSculptSearchEngine {
     this.index.clear();
     this.tokenIndex.clear();
     this.tokenVocabulary.clear();
+    this.sortedTokenVocabulary = [];
+    this.tokenLengthBuckets.clear();
+    this.tokenLookupsDirty = true;
+    this.eligibleFilesCache = null;
+    this.metadataTokenCache.clear();
     this.recentHitsCache = null;
     this.recentPreviewCache.clear();
     this.dirtyPaths.clear();
@@ -320,6 +362,10 @@ export class SystemSculptSearchEngine {
 
     this.eventRefs.push(
       this.app.vault.on("create", (file) => {
+        this.eligibleFilesCache = null;
+        if (file instanceof TFile) {
+          this.metadataTokenCache.delete(file.path);
+        }
         if (file instanceof TFile && this.isEligible(file)) {
           this.dirtyPaths.add(file.path);
           this.recentHitsCache = null;
@@ -330,7 +376,9 @@ export class SystemSculptSearchEngine {
 
     this.eventRefs.push(
       this.app.vault.on("delete", (file) => {
+        this.eligibleFilesCache = null;
         if (file instanceof TFile) {
+          this.metadataTokenCache.delete(file.path);
           const existing = this.index.get(file.path);
           if (existing) {
             this.removeFromTokenIndex(existing);
@@ -345,7 +393,10 @@ export class SystemSculptSearchEngine {
 
     this.eventRefs.push(
       this.app.vault.on("rename", (file, oldPath) => {
+        this.eligibleFilesCache = null;
         if (!(file instanceof TFile)) return;
+        this.metadataTokenCache.delete(oldPath);
+        this.metadataTokenCache.delete(file.path);
         const existing = this.index.get(oldPath);
         if (existing) {
           this.removeFromTokenIndex(existing);
@@ -400,6 +451,11 @@ export class SystemSculptSearchEngine {
     this.index.clear();
     this.tokenIndex.clear();
     this.tokenVocabulary.clear();
+    this.sortedTokenVocabulary = [];
+    this.tokenLengthBuckets.clear();
+    this.tokenLookupsDirty = true;
+    this.eligibleFilesCache = null;
+    this.metadataTokenCache.clear();
     this.recentHitsCache = null;
     this.recentPreviewCache.clear();
     this.dirtyPaths.clear();
@@ -457,12 +513,13 @@ export class SystemSculptSearchEngine {
         }
       });
 
-      await this.runLimited(tasks, this.CONTENT_CONCURRENCY);
+      await this.runLimited(tasks, this.CONTENT_CONCURRENCY, this.INDEX_BUILD_YIELD_EVERY);
       if (generation !== this.indexGeneration) return false;
 
       this.index = nextIndex;
       this.tokenIndex = nextTokenIndex;
       this.tokenVocabulary = nextVocabulary;
+      this.rebuildTokenLookups();
       this.recentHitsCache = null;
       return true;
     }
@@ -484,8 +541,9 @@ export class SystemSculptSearchEngine {
       }
     });
 
-    await this.runLimited(tasks, this.CONTENT_CONCURRENCY);
+    await this.runLimited(tasks, this.CONTENT_CONCURRENCY, this.INDEX_BUILD_YIELD_EVERY);
     if (generation !== this.indexGeneration) return false;
+    this.tokenLookupsDirty = true;
     this.recentHitsCache = null;
     return true;
   }
@@ -493,21 +551,20 @@ export class SystemSculptSearchEngine {
   private async indexFile(file: TFile): Promise<IndexedDocument | null> {
     const content = await this.safeRead(file);
     const extracted = this.getIndexText(file, content);
-    const rawBody = extracted.slice(0, this.MAX_INDEX_CHARS);
-    const body = rawBody.toLowerCase();
+    const metadata = this.getMetadataTokenSnapshot(file);
+    const rawBody = extracted.slice(0, this.MAX_EXCERPT_SOURCE_CHARS);
+    const body = extracted.slice(0, this.MAX_INDEX_CHARS).toLowerCase();
     const preview = this.buildPreviewFromText(extracted);
-    const titleTokens = this.tokenizeSearchText(file.basename);
-    const pathTokens = this.tokenizeSearchText(file.path);
     const bodyTokens = this.tokenizeSearchText(body);
-    const tokens = new Set([...titleTokens, ...pathTokens, ...bodyTokens]);
+    const tokens = new Set([...metadata.titleTokens, ...metadata.pathTokens, ...bodyTokens]);
 
     return {
       path: file.path,
       title: file.basename,
-      lowerTitle: file.basename.toLowerCase(),
-      lowerPath: file.path.toLowerCase(),
-      titleTokens,
-      pathTokens,
+      lowerTitle: metadata.lowerTitle,
+      lowerPath: metadata.lowerPath,
+      titleTokens: metadata.titleTokens,
+      pathTokens: metadata.pathTokens,
       bodyTokens,
       tokens,
       body,
@@ -527,9 +584,28 @@ export class SystemSculptSearchEngine {
   }
 
   private getEligibleFiles(): TFile[] {
+    if (this.eligibleFilesCache) {
+      return this.eligibleFilesCache;
+    }
+
     const cached = this.plugin.vaultFileCache?.getAllFilesView?.() ?? this.plugin.vaultFileCache?.getAllFiles?.();
     const files = Array.isArray(cached) ? cached : this.app.vault.getFiles();
-    return Array.from(files).filter((f) => this.isEligible(f));
+    this.eligibleFilesCache = Array.from(files).filter((f) => this.isEligible(f));
+    return this.eligibleFilesCache;
+  }
+
+  private getMetadataTokenSnapshot(file: TFile): MetadataTokenSnapshot {
+    const cached = this.metadataTokenCache.get(file.path);
+    if (cached) return cached;
+
+    const snapshot: MetadataTokenSnapshot = {
+      lowerTitle: file.basename.toLowerCase(),
+      lowerPath: file.path.toLowerCase(),
+      titleTokens: this.tokenizeSearchText(file.basename),
+      pathTokens: this.tokenizeSearchText(file.path),
+    };
+    this.metadataTokenCache.set(file.path, snapshot);
+    return snapshot;
   }
 
   private selectRecentFiles(files: TFile[], limit: number): TFile[] {
@@ -586,12 +662,8 @@ export class SystemSculptSearchEngine {
   private runLexicalSearch(terms: string[], phrase: string, limit: number, sort: SortMode): SearchHit[] {
     const queryTerms = this.buildQueryTerms(terms);
     const candidates = this.collectCandidateDocs(queryTerms, limit);
-    const directMetadataCandidates = this.collectDirectMetadataDocs(queryTerms, phrase, limit);
     const candidateMap = new Map<string, IndexedDocument>();
 
-    for (const doc of directMetadataCandidates) {
-      candidateMap.set(doc.path, doc);
-    }
     for (const doc of candidates) {
       candidateMap.set(doc.path, doc);
     }
@@ -729,6 +801,9 @@ export class SystemSculptSearchEngine {
       }
       paths.add(doc.path);
     }
+    if (tokenIndex === this.tokenIndex) {
+      this.tokenLookupsDirty = true;
+    }
   }
 
   private removeFromTokenIndex(
@@ -745,9 +820,13 @@ export class SystemSculptSearchEngine {
         tokenVocabulary.delete(token);
       }
     }
+    if (tokenIndex === this.tokenIndex) {
+      this.tokenLookupsDirty = true;
+    }
   }
 
   private buildQueryTerms(terms: string[]): QueryTerm[] {
+    this.ensureTokenLookups();
     return terms.map((value) => {
       const exact = new Set<string>();
       const prefix = new Set<string>();
@@ -758,21 +837,25 @@ export class SystemSculptSearchEngine {
       }
 
       if (value.length >= 3) {
-        for (const token of this.tokenVocabulary) {
+        for (const token of this.findPrefixTokens(value, this.PREFIX_TOKEN_LIMIT)) {
           if (token === value) continue;
-          if (value.length >= 5 && Math.abs(token.length - value.length) > Math.max(2, Math.floor(value.length * 0.45))) {
-            continue;
-          }
-          if (token.startsWith(value) || value.startsWith(token)) {
-            prefix.add(token);
-            continue;
-          }
+          prefix.add(token);
+        }
+        for (const token of this.findIndexedQueryPrefixes(value, this.PREFIX_TOKEN_LIMIT - prefix.size)) {
+          if (token === value) continue;
+          prefix.add(token);
+        }
 
-          if (value.length >= 5) {
+        if (value.length >= 5 && prefix.size < 16) {
+          const maxGap = Math.max(2, Math.floor(value.length * 0.45));
+          let fuzzyCount = 0;
+          for (const token of this.iterLengthBucketTokens(value.length, maxGap)) {
+            if (token === value || prefix.has(token)) continue;
             const fuzzyScore = fuzzyMatchScore(value, token);
-            const maxGap = Math.max(2, Math.floor(value.length * 0.45));
             if (fuzzyScore !== null && fuzzyScore <= maxGap) {
               fuzzy.add(token);
+              fuzzyCount += 1;
+              if (fuzzyCount >= this.FUZZY_TOKEN_LIMIT) break;
             }
           }
         }
@@ -780,6 +863,71 @@ export class SystemSculptSearchEngine {
 
       return { value, exact, prefix, fuzzy };
     });
+  }
+
+  private ensureTokenLookups(): void {
+    if (!this.tokenLookupsDirty) return;
+    this.rebuildTokenLookups();
+  }
+
+  private rebuildTokenLookups(): void {
+    this.sortedTokenVocabulary = Array.from(this.tokenVocabulary).sort();
+    this.tokenLengthBuckets.clear();
+    for (const token of this.sortedTokenVocabulary) {
+      const bucket = this.tokenLengthBuckets.get(token.length) ?? [];
+      bucket.push(token);
+      this.tokenLengthBuckets.set(token.length, bucket);
+    }
+    this.tokenLookupsDirty = false;
+  }
+
+  private findPrefixTokens(prefix: string, limit: number): string[] {
+    const matches: string[] = [];
+    let index = this.lowerBound(this.sortedTokenVocabulary, prefix);
+    while (
+      index < this.sortedTokenVocabulary.length &&
+      this.sortedTokenVocabulary[index].startsWith(prefix) &&
+      matches.length < limit
+    ) {
+      matches.push(this.sortedTokenVocabulary[index]);
+      index += 1;
+    }
+    return matches;
+  }
+
+  private findIndexedQueryPrefixes(value: string, limit: number): string[] {
+    if (limit <= 0) return [];
+    const matches: string[] = [];
+    for (let length = value.length - 1; length >= 3 && matches.length < limit; length -= 1) {
+      const prefix = value.slice(0, length);
+      if (this.tokenIndex.has(prefix)) {
+        matches.push(prefix);
+      }
+    }
+    return matches;
+  }
+
+  private lowerBound(values: string[], target: string): number {
+    let low = 0;
+    let high = values.length;
+    while (low < high) {
+      const mid = (low + high) >> 1;
+      if (values[mid] < target) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    return low;
+  }
+
+  private *iterLengthBucketTokens(length: number, maxGap: number): Iterable<string> {
+    const min = Math.max(1, length - maxGap);
+    const max = length + maxGap;
+    for (let bucketLength = min; bucketLength <= max; bucketLength += 1) {
+      const bucket = this.tokenLengthBuckets.get(bucketLength);
+      if (bucket) yield* bucket;
+    }
   }
 
   private collectCandidateDocs(queryTerms: QueryTerm[], limit: number): IndexedDocument[] {
@@ -807,21 +955,6 @@ export class SystemSculptSearchEngine {
     return candidates.slice(0, Math.max(limit * 8, this.CANDIDATE_LIMIT));
   }
 
-  private collectDirectMetadataDocs(queryTerms: QueryTerm[], phrase: string, limit: number): IndexedDocument[] {
-    const scored: Array<{ doc: IndexedDocument; score: number }> = [];
-    for (const doc of this.index.values()) {
-      const score = this.scoreMetadata(doc, queryTerms, phrase);
-      if (score > 0) {
-        scored.push({ doc, score });
-      }
-    }
-
-    return scored
-      .sort((a, b) => b.score - a.score || (b.doc.mtime || 0) - (a.doc.mtime || 0))
-      .slice(0, Math.max(limit * 4, this.CANDIDATE_LIMIT))
-      .map((entry) => entry.doc);
-  }
-
   private runMetadataSearch(terms: string[], phrase: string, limit: number, sort: SortMode): SearchHit[] {
     const queryTerms = terms.map((value) => ({
       value,
@@ -846,13 +979,14 @@ export class SystemSculptSearchEngine {
   private scoreMetadataFile(file: TFile, queryTerms: QueryTerm[], phrase: string): SearchHit | null {
     const title = file.basename;
     const path = file.path;
+    const metadata = this.getMetadataTokenSnapshot(file);
     const doc: IndexedDocument = {
       path,
       title,
-      lowerTitle: title.toLowerCase(),
-      lowerPath: path.toLowerCase(),
-      titleTokens: this.tokenizeSearchText(title),
-      pathTokens: this.tokenizeSearchText(path),
+      lowerTitle: metadata.lowerTitle,
+      lowerPath: metadata.lowerPath,
+      titleTokens: metadata.titleTokens,
+      pathTokens: metadata.pathTokens,
       bodyTokens: new Set(),
       tokens: new Set(),
       body: "",
@@ -900,13 +1034,15 @@ export class SystemSculptSearchEngine {
         continue;
       }
 
-      const fuzzyTitle = value.length >= 5
+      const relatedTitle = value.length >= 3
         ? Array.from(doc.titleTokens).some((token) => {
+          if (token.startsWith(value) || value.startsWith(token)) return true;
+          if (value.length < 5) return false;
           const fuzzyScore = fuzzyMatchScore(value, token);
           return fuzzyScore !== null && fuzzyScore <= Math.max(2, Math.floor(value.length * 0.45));
         })
         : false;
-      if (fuzzyTitle) {
+      if (relatedTitle) {
         score += 9;
         matchedTerms += 1;
       }
@@ -1001,15 +1137,14 @@ export class SystemSculptSearchEngine {
       const manager = this.getExistingEmbeddingsManager();
       if (!manager || signal?.aborted) return [];
       const semanticPromise = (async () => {
-        // @ts-ignore awaitReady is public but not in types
-        if (typeof (manager as any).awaitReady === "function") {
-          await (manager as any).awaitReady();
+        if (typeof manager.awaitReady === "function") {
+          await manager.awaitReady();
         }
         if (signal?.aborted) return [];
-        const rawResults = await manager.searchSimilar(query, limit);
+        const rawResults = await manager.searchSimilar(query, limit, signal);
         if (signal?.aborted) return [];
         return rawResults
-          .map((item: any) => {
+          .map((item) => {
             const file = this.app.vault.getAbstractFileByPath(item.path);
             if (!(file instanceof TFile) || !this.isEligible(file)) return null;
             const score = Math.max(0, Math.min(1, item.score ?? 0));
@@ -1136,9 +1271,9 @@ export class SystemSculptSearchEngine {
       if (!manager) {
         return { enabled, ready: false, available: false, reason: "Embeddings not initialized" };
       }
-      const ready = typeof (manager as any).isReady === "function" ? (manager as any).isReady() : true;
+      const ready = typeof manager.isReady === "function" ? manager.isReady() : true;
       const stats = typeof manager.getStats === "function" ? manager.getStats() : { total: 0, processed: 0, present: 0, needsProcessing: 0 };
-      const available = typeof (manager as any).hasAnyEmbeddings === "function" ? (manager as any).hasAnyEmbeddings() : stats.present > 0;
+      const available = typeof manager.hasAnyEmbeddings === "function" ? manager.hasAnyEmbeddings() : (stats.present ?? 0) > 0;
 
       return {
         enabled,
@@ -1153,12 +1288,9 @@ export class SystemSculptSearchEngine {
     }
   }
 
-  private getPassiveEmbeddingsIndicator(): EmbeddingsIndicator {
-    return this.getEmbeddingsIndicator();
-  }
-
-  private getExistingEmbeddingsManager(): any | null {
-    return (this.plugin as any).embeddingsManager ?? null;
+  private getExistingEmbeddingsManager(): SearchableEmbeddingsManager | null {
+    const manager = (this.plugin as { embeddingsManager?: SearchableEmbeddingsManager }).embeddingsManager;
+    return manager && typeof manager.searchSimilar === "function" ? manager : null;
   }
 
   private extractTitle(path: string, fallback?: string | null): string {
@@ -1167,14 +1299,27 @@ export class SystemSculptSearchEngine {
     return base.replace(/\.md$/i, "");
   }
 
-  private async runLimited(tasks: Array<() => Promise<void>>, concurrency: number): Promise<void> {
+  private async runLimited(
+    tasks: Array<() => Promise<void>>,
+    concurrency: number,
+    yieldEvery = 0
+  ): Promise<void> {
     let idx = 0;
+    let completed = 0;
     const runners = new Array(Math.min(concurrency, tasks.length)).fill(null).map(async () => {
       while (idx < tasks.length) {
         const current = idx++;
         await tasks[current]();
+        completed += 1;
+        if (yieldEvery > 0 && completed % yieldEvery === 0) {
+          await this.yieldToMainThread();
+        }
       }
     });
     await Promise.all(runners);
+  }
+
+  private yieldToMainThread(): Promise<void> {
+    return new Promise((resolve) => window.setTimeout(resolve, 0));
   }
 }

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -613,31 +613,18 @@ export class SystemSculptSearchEngine {
 
   /**
    * If the user's "Excluded files" filters changed since the last search,
-   * drop any now-ineligible indexed docs and invalidate the eligible-files
-   * snapshot so the next search reflects the new exclusions.
+   * blow away the content/token indexes so the next search sees newly-included
+   * files and forgets newly-excluded ones. Track the new signature so
+   * subsequent changes are still detected — nulling it here previously let the
+   * guard short-circuit later edits until an unrelated event repopulated it.
    */
   private refreshEligibilityIfChanged(): void {
     const signature = this.computeEligibilitySignature();
     if (this.eligibleFilesCacheSignature === null || this.eligibleFilesCacheSignature === signature) {
       return;
     }
-    this.pruneIndexForCurrentEligibility();
-    this.eligibleFilesCache = null;
-    this.eligibleFilesCacheSignature = null;
-  }
-
-  private pruneIndexForCurrentEligibility(): void {
-    if (this.index.size === 0) return;
-    for (const [path] of this.index) {
-      const file = this.app.vault.getAbstractFileByPath(path);
-      if (file instanceof TFile && this.isEligible(file)) continue;
-      const doc = this.index.get(path);
-      if (doc) this.removeFromTokenIndex(doc);
-      this.index.delete(path);
-      this.dirtyPaths.delete(path);
-      this.recentPreviewCache.delete(path);
-    }
-    this.recentHitsCache = null;
+    this.clearIndexes();
+    this.eligibleFilesCacheSignature = signature;
   }
 
   /**
@@ -1048,6 +1035,12 @@ export class SystemSculptSearchEngine {
 
   private needsSubstringFallback(value: string): boolean {
     if (!value) return false;
+    // Prefix expansion in buildQueryTerms requires length >= 3, so 1- and
+    // 2-char tokenizable terms (e.g. "fr" while typing "fresh") would
+    // otherwise have no candidates once the content index is ready. The
+    // `pathsForQueryTerm(...).size === 0` gate in the caller still avoids
+    // running a substring scan when the term has exact token coverage.
+    if (value.length < 3) return true;
     return /[^\x00-\x7F]/.test(value) || this.tokenizeSearchText(value).size === 0;
   }
 

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -135,6 +135,7 @@ export class SystemSculptSearchEngine {
   private readonly RECENT_PREVIEW_CONCURRENCY = 2;
   private readonly MAX_RECENT_PREVIEW_FILE_BYTES = 1024 * 1024;
   private readonly SEMANTIC_TIMEOUT_MS = 1500;
+  private readonly UNICODE_TOKEN_PATTERN = /[\p{L}\p{N}\p{M}]+/gu;
   private lastLexicalInspect = 0;
 
   constructor(app: App, plugin: SystemSculptPlugin) {
@@ -667,6 +668,11 @@ export class SystemSculptSearchEngine {
     for (const doc of candidates) {
       candidateMap.set(doc.path, doc);
     }
+    if (this.shouldUseSubstringCandidateFallback(queryTerms, phrase, candidateMap.size)) {
+      for (const doc of this.collectSubstringCandidateDocs(terms, phrase, limit)) {
+        candidateMap.set(doc.path, doc);
+      }
+    }
 
     const pool = Array.from(candidateMap.values());
     this.lastLexicalInspect = pool.length;
@@ -782,7 +788,7 @@ export class SystemSculptSearchEngine {
   private tokenizeSearchText(text: string): Set<string> {
     const tokens = text
       .toLowerCase()
-      .match(/[a-z0-9]+/g);
+      .match(this.UNICODE_TOKEN_PATTERN);
     if (!tokens) return new Set();
     return new Set(tokens.filter((token) => token.length > 1));
   }
@@ -953,6 +959,42 @@ export class SystemSculptSearchEngine {
     }
 
     return candidates.slice(0, Math.max(limit * 8, this.CANDIDATE_LIMIT));
+  }
+
+  private shouldUseSubstringCandidateFallback(queryTerms: QueryTerm[], phrase: string, candidateCount: number): boolean {
+    if (!phrase) return false;
+    if (candidateCount === 0 && (/[^\x00-\x7F]/.test(phrase) || this.tokenizeSearchText(phrase).size === 0)) {
+      return true;
+    }
+    return queryTerms.some((term) => this.needsSubstringFallback(term.value) && this.pathsForQueryTerm(term).size === 0);
+  }
+
+  private needsSubstringFallback(value: string): boolean {
+    if (!value) return false;
+    return /[^\x00-\x7F]/.test(value) || this.tokenizeSearchText(value).size === 0;
+  }
+
+  private collectSubstringCandidateDocs(terms: string[], phrase: string, limit: number): IndexedDocument[] {
+    const matches: IndexedDocument[] = [];
+    const cap = Math.max(limit * 8, this.CANDIDATE_LIMIT);
+    const searchableTerms = terms.filter(Boolean);
+
+    for (const doc of this.index.values()) {
+      if (
+        this.documentContainsSubstring(doc, phrase) ||
+        searchableTerms.some((term) => this.documentContainsSubstring(doc, term))
+      ) {
+        matches.push(doc);
+        if (matches.length >= cap) break;
+      }
+    }
+
+    return matches;
+  }
+
+  private documentContainsSubstring(doc: IndexedDocument, value: string): boolean {
+    if (!value) return false;
+    return doc.lowerTitle.includes(value) || doc.lowerPath.includes(value) || doc.body.includes(value);
   }
 
   private runMetadataSearch(terms: string[], phrase: string, limit: number, sort: SortMode): SearchHit[] {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -224,10 +224,11 @@ export class SystemSculptSearchEngine {
     let usedEmbeddings = false;
 
     let embeddingsIndicator = this.getEmbeddingsIndicator();
-    // Explicit semantic requests should lazily bootstrap the embeddings manager
-    // so a fresh session (or delayed autostart) can still produce semantic hits
-    // instead of silently falling back to lexical-only.
-    if (mode === "semantic" && embeddingsIndicator.enabled && !this.getExistingEmbeddingsManager()) {
+    // Smart and semantic searches should lazily bootstrap the embeddings
+    // manager so a fresh session (or delayed autostart / auto-processing off)
+    // can still produce semantic hits instead of silently falling back to
+    // lexical-only. Lexical-only searches intentionally skip the bootstrap.
+    if (mode !== "lexical" && embeddingsIndicator.enabled && !this.getExistingEmbeddingsManager()) {
       this.ensureEmbeddingsManager();
       embeddingsIndicator = this.getEmbeddingsIndicator();
     }
@@ -268,6 +269,14 @@ export class SystemSculptSearchEngine {
    */
   async getRecent(limit = 25): Promise<SearchHit[]> {
     this.refreshEligibilityIfChanged();
+    // Reuse indexed previews below requires the index to match on-disk state.
+    // When the content index is already built, flush any modify/create events
+    // that set dirtyPaths so we don't serve stale snippets for modified
+    // notes. The modal only hydrates rows that lack an excerpt, so a stale
+    // indexed.preview would otherwise persist until the next full search.
+    if (this.contentIndexReady) {
+      await this.refreshDirtyIndex();
+    }
     if (!this.recentHitsCache || this.recentHitsCache.limit < limit) {
       const recentFiles = this.selectRecentFiles(this.getEligibleFiles(), limit);
       this.recentHitsCache = {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -113,6 +113,7 @@ export class SystemSculptSearchEngine {
   private tokenLengthBuckets: Map<number, string[]> = new Map();
   private tokenLookupsDirty = true;
   private eligibleFilesCache: TFile[] | null = null;
+  private eligibleFilesCacheSignature: string | null = null;
   private metadataTokenCache: Map<string, MetadataTokenSnapshot> = new Map();
   private recentHitsCache: { limit: number; hits: SearchHit[] } | null = null;
   private recentPreviewCache: Map<string, CachedPreview> = new Map();
@@ -203,6 +204,7 @@ export class SystemSculptSearchEngine {
     }
 
     const indexStart = performance.now();
+    this.refreshEligibilityIfChanged();
     await this.ensureIndex();
     await this.refreshDirtyIndex();
     const indexMs = performance.now() - indexStart;
@@ -220,7 +222,14 @@ export class SystemSculptSearchEngine {
     let semMs: number | undefined;
     let usedEmbeddings = false;
 
-    const embeddingsIndicator = this.getEmbeddingsIndicator();
+    let embeddingsIndicator = this.getEmbeddingsIndicator();
+    // Explicit semantic requests should lazily bootstrap the embeddings manager
+    // so a fresh session (or delayed autostart) can still produce semantic hits
+    // instead of silently falling back to lexical-only.
+    if (mode === "semantic" && embeddingsIndicator.enabled && !this.getExistingEmbeddingsManager()) {
+      this.ensureEmbeddingsManager();
+      embeddingsIndicator = this.getEmbeddingsIndicator();
+    }
     const embeddingsEligible = this.shouldUseEmbeddings(mode, embeddingsIndicator, terms);
 
     if (embeddingsEligible) {
@@ -342,6 +351,7 @@ export class SystemSculptSearchEngine {
     this.tokenLengthBuckets.clear();
     this.tokenLookupsDirty = true;
     this.eligibleFilesCache = null;
+    this.eligibleFilesCacheSignature = null;
     this.metadataTokenCache.clear();
     this.recentHitsCache = null;
     this.recentPreviewCache.clear();
@@ -364,6 +374,7 @@ export class SystemSculptSearchEngine {
     this.eventRefs.push(
       this.app.vault.on("create", (file) => {
         this.eligibleFilesCache = null;
+        this.eligibleFilesCacheSignature = null;
         if (file instanceof TFile) {
           this.metadataTokenCache.delete(file.path);
         }
@@ -378,6 +389,7 @@ export class SystemSculptSearchEngine {
     this.eventRefs.push(
       this.app.vault.on("delete", (file) => {
         this.eligibleFilesCache = null;
+        this.eligibleFilesCacheSignature = null;
         if (file instanceof TFile) {
           this.metadataTokenCache.delete(file.path);
           const existing = this.index.get(file.path);
@@ -395,6 +407,7 @@ export class SystemSculptSearchEngine {
     this.eventRefs.push(
       this.app.vault.on("rename", (file, oldPath) => {
         this.eligibleFilesCache = null;
+        this.eligibleFilesCacheSignature = null;
         if (!(file instanceof TFile)) return;
         this.metadataTokenCache.delete(oldPath);
         this.metadataTokenCache.delete(file.path);
@@ -456,6 +469,7 @@ export class SystemSculptSearchEngine {
     this.tokenLengthBuckets.clear();
     this.tokenLookupsDirty = true;
     this.eligibleFilesCache = null;
+    this.eligibleFilesCacheSignature = null;
     this.metadataTokenCache.clear();
     this.recentHitsCache = null;
     this.recentPreviewCache.clear();
@@ -585,14 +599,64 @@ export class SystemSculptSearchEngine {
   }
 
   private getEligibleFiles(): TFile[] {
-    if (this.eligibleFilesCache) {
+    const signature = this.computeEligibilitySignature();
+    if (this.eligibleFilesCache && this.eligibleFilesCacheSignature === signature) {
       return this.eligibleFilesCache;
     }
 
     const cached = this.plugin.vaultFileCache?.getAllFilesView?.() ?? this.plugin.vaultFileCache?.getAllFiles?.();
     const files = Array.isArray(cached) ? cached : this.app.vault.getFiles();
     this.eligibleFilesCache = Array.from(files).filter((f) => this.isEligible(f));
+    this.eligibleFilesCacheSignature = signature;
     return this.eligibleFilesCache;
+  }
+
+  /**
+   * If the user's "Excluded files" filters changed since the last search,
+   * drop any now-ineligible indexed docs and invalidate the eligible-files
+   * snapshot so the next search reflects the new exclusions.
+   */
+  private refreshEligibilityIfChanged(): void {
+    const signature = this.computeEligibilitySignature();
+    if (this.eligibleFilesCacheSignature === null || this.eligibleFilesCacheSignature === signature) {
+      return;
+    }
+    this.pruneIndexForCurrentEligibility();
+    this.eligibleFilesCache = null;
+    this.eligibleFilesCacheSignature = null;
+  }
+
+  private pruneIndexForCurrentEligibility(): void {
+    if (this.index.size === 0) return;
+    for (const [path] of this.index) {
+      const file = this.app.vault.getAbstractFileByPath(path);
+      if (file instanceof TFile && this.isEligible(file)) continue;
+      const doc = this.index.get(path);
+      if (doc) this.removeFromTokenIndex(doc);
+      this.index.delete(path);
+      this.dirtyPaths.delete(path);
+      this.recentPreviewCache.delete(path);
+    }
+    this.recentHitsCache = null;
+  }
+
+  /**
+   * Produce a cheap signature of the inputs that `isEligible` reads from outside
+   * our own settings. We snapshot Obsidian's `userIgnoreFilters` so the cached
+   * eligible-files list refreshes when the user edits core "Excluded files"
+   * without needing a plugin settings event.
+   */
+  private computeEligibilitySignature(): string {
+    try {
+      const vault = this.app.vault as unknown as { getConfig?: (key: string) => unknown };
+      const filters = typeof vault.getConfig === "function" ? vault.getConfig("userIgnoreFilters") : null;
+      if (Array.isArray(filters) && filters.length > 0) {
+        return filters.map((value) => String(value)).join("\u0000");
+      }
+    } catch {
+      // Vault config lookup may throw on some platforms; treat as "no filters".
+    }
+    return "";
   }
 
   private getMetadataTokenSnapshot(file: TFile): MetadataTokenSnapshot {
@@ -1333,6 +1397,24 @@ export class SystemSculptSearchEngine {
   private getExistingEmbeddingsManager(): SearchableEmbeddingsManager | null {
     const manager = (this.plugin as { embeddingsManager?: SearchableEmbeddingsManager }).embeddingsManager;
     return manager && typeof manager.searchSimilar === "function" ? manager : null;
+  }
+
+  /**
+   * Invoke the plugin's lazy embeddings-manager factory if it exists. Used for
+   * explicit semantic searches so a missing manager doesn't silently degrade to
+   * lexical-only results. Errors (missing license, misconfigured provider) are
+   * swallowed because the subsequent indicator check will report them.
+   */
+  private ensureEmbeddingsManager(): void {
+    const plugin = this.plugin as {
+      getOrCreateEmbeddingsManager?: () => SearchableEmbeddingsManager;
+    };
+    if (typeof plugin.getOrCreateEmbeddingsManager !== "function") return;
+    try {
+      plugin.getOrCreateEmbeddingsManager();
+    } catch {
+      // Bootstrap failures are surfaced through the embeddings indicator.
+    }
   }
 
   private extractTitle(path: string, fallback?: string | null): string {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -37,6 +37,8 @@ export interface SearchStats {
   mode: SearchMode;
   usedEmbeddings: boolean;
   embeddingsEligible?: boolean;
+  indexingPending?: boolean;
+  metadataOnly?: boolean;
 }
 
 export interface SearchResponse {
@@ -68,6 +70,11 @@ interface QueryTerm {
   fuzzy: Set<string>;
 }
 
+interface CachedPreview {
+  key: string;
+  preview: string;
+}
+
 export class SystemSculptSearchEngine {
   private app: App;
   private plugin: SystemSculptPlugin;
@@ -75,15 +82,21 @@ export class SystemSculptSearchEngine {
   private tokenIndex: Map<string, Set<string>> = new Map();
   private tokenVocabulary: Set<string> = new Set();
   private recentHitsCache: { limit: number; hits: SearchHit[] } | null = null;
+  private recentPreviewCache: Map<string, CachedPreview> = new Map();
   private indexPromise: Promise<void> | null = null;
+  private contentIndexReady = false;
+  private indexGeneration = 0;
+  private scheduledIndexHandle: number | null = null;
   private dirtyPaths: Set<string> = new Set();
   private eventRefs: EventRef[] = [];
+  private workspaceEventRefs: EventRef[] = [];
   private readonly INDEXABLE_EXTENSIONS = new Set(["md", "markdown", "canvas"]);
   private readonly MAX_INDEX_CHARS = 6500;
   private readonly PREVIEW_CHARS = 240;
   private readonly CANDIDATE_LIMIT = 320;
   private readonly CONTENT_CONCURRENCY = 10;
   private readonly RECENT_PREVIEW_CONCURRENCY = 2;
+  private readonly MAX_RECENT_PREVIEW_FILE_BYTES = 1024 * 1024;
   private readonly SEMANTIC_TIMEOUT_MS = 1500;
   private lastLexicalInspect = 0;
 
@@ -96,10 +109,11 @@ export class SystemSculptSearchEngine {
   /**
    * Run a search across the vault
    */
-  async search(query: string, options?: { mode?: SearchMode; sort?: SortMode; limit?: number }): Promise<SearchResponse> {
+  async search(query: string, options?: { mode?: SearchMode; sort?: SortMode; limit?: number; signal?: AbortSignal }): Promise<SearchResponse> {
     const mode: SearchMode = options?.mode ?? "smart";
     const sort: SortMode = options?.sort ?? "relevance";
     const limit = options?.limit ?? 80;
+    const signal = options?.signal;
 
     const searchStart = performance.now();
     const normalizedQuery = query.trim().toLowerCase();
@@ -119,7 +133,34 @@ export class SystemSculptSearchEngine {
           usedEmbeddings: false,
           embeddingsEligible: false,
         },
-        embeddings: this.getEmbeddingsIndicator(),
+        embeddings: this.getPassiveEmbeddingsIndicator(),
+      };
+    }
+
+    if (signal?.aborted) {
+      throw new DOMException("Search aborted", "AbortError");
+    }
+
+    if (mode === "smart" && !this.contentIndexReady) {
+      const metadataStart = performance.now();
+      const metadataHits = this.runMetadataSearch(terms, phrase, limit, sort);
+      this.scheduleIndexing();
+      const totalMs = performance.now() - searchStart;
+      return {
+        results: metadataHits,
+        stats: {
+          totalMs,
+          lexMs: performance.now() - metadataStart,
+          indexMs: 0,
+          indexedCount: this.index.size,
+          inspectedCount: metadataHits.length,
+          mode,
+          usedEmbeddings: false,
+          embeddingsEligible: false,
+          indexingPending: true,
+          metadataOnly: true,
+        },
+        embeddings: this.getPassiveEmbeddingsIndicator(),
       };
     }
 
@@ -128,6 +169,10 @@ export class SystemSculptSearchEngine {
     await this.refreshDirtyIndex();
     const indexMs = performance.now() - indexStart;
     this.lastLexicalInspect = 0;
+
+    if (signal?.aborted) {
+      throw new DOMException("Search aborted", "AbortError");
+    }
 
     const lexStart = performance.now();
     const lexicalHits = this.runLexicalSearch(terms, phrase, limit, sort);
@@ -142,7 +187,7 @@ export class SystemSculptSearchEngine {
 
     if (embeddingsEligible) {
       const semStart = performance.now();
-      semanticHits = await this.runSemanticSearch(query, limit);
+      semanticHits = await this.runSemanticSearch(query, limit, signal);
       semMs = performance.now() - semStart;
       usedEmbeddings = semanticHits.length > 0;
     } else if (mode === "semantic" && (!embeddingsIndicator.enabled || !embeddingsIndicator.available)) {
@@ -196,18 +241,31 @@ export class SystemSculptSearchEngine {
     return this.recentHitsCache.hits.slice(0, limit);
   }
 
-  async getRecentPreviews(paths: string[], limit = 25): Promise<Map<string, string>> {
+  async getRecentPreviews(paths: string[], limit = 25, signal?: AbortSignal): Promise<Map<string, string>> {
     const previews = new Map<string, string>();
     const uniquePaths = Array.from(new Set(paths)).slice(0, limit);
     const tasks = uniquePaths.map((path) => async () => {
+      if (signal?.aborted) return;
       const file = this.app.vault.getAbstractFileByPath(path);
       if (!(file instanceof TFile) || !this.isEligible(file)) return;
+      const cacheKey = this.previewCacheKey(file);
+      const cached = this.recentPreviewCache.get(file.path);
+      if (cached?.key === cacheKey) {
+        previews.set(file.path, cached.preview);
+        return;
+      }
+
+      if ((file.stat?.size || 0) > this.MAX_RECENT_PREVIEW_FILE_BYTES) {
+        return;
+      }
 
       try {
         const content = await this.safeRead(file);
+        if (signal?.aborted) return;
         const preview = this.buildPreviewFromText(this.getIndexText(file, content));
         if (preview) {
           previews.set(path, preview);
+          this.recentPreviewCache.set(file.path, { key: cacheKey, preview });
         }
       } catch {
         // Skip failed preview hydration.
@@ -218,23 +276,35 @@ export class SystemSculptSearchEngine {
     return previews;
   }
 
-  async warmIndex(): Promise<void> {
-    try {
-      await this.ensureIndex();
-    } catch {
-      // Search can recover on the next explicit query.
-    }
+  startIndexing(): Promise<void> {
+    return this.ensureIndex();
+  }
+
+  async whenIndexReady(): Promise<void> {
+    await this.ensureIndex();
   }
 
   destroy(): void {
     this.eventRefs.forEach((ref) => this.app.vault.offref(ref));
     this.eventRefs = [];
+    const workspace = this.app.workspace as any;
+    this.workspaceEventRefs.forEach((ref) => {
+      if (typeof workspace.offref === "function") {
+        workspace.offref(ref);
+      } else if (typeof (ref as any)?.unload === "function") {
+        (ref as any).unload();
+      }
+    });
+    this.workspaceEventRefs = [];
+    this.clearScheduledIndexing();
     this.index.clear();
     this.tokenIndex.clear();
     this.tokenVocabulary.clear();
     this.recentHitsCache = null;
+    this.recentPreviewCache.clear();
     this.dirtyPaths.clear();
     this.indexPromise = null;
+    this.contentIndexReady = false;
   }
 
   private registerVaultWatchers() {
@@ -243,6 +313,7 @@ export class SystemSculptSearchEngine {
         if (file instanceof TFile && this.isEligible(file)) {
           this.dirtyPaths.add(file.path);
           this.recentHitsCache = null;
+          this.recentPreviewCache.delete(file.path);
         }
       })
     );
@@ -252,6 +323,7 @@ export class SystemSculptSearchEngine {
         if (file instanceof TFile && this.isEligible(file)) {
           this.dirtyPaths.add(file.path);
           this.recentHitsCache = null;
+          this.recentPreviewCache.delete(file.path);
         }
       })
     );
@@ -266,6 +338,7 @@ export class SystemSculptSearchEngine {
           this.index.delete(file.path);
           this.dirtyPaths.delete(file.path);
           this.recentHitsCache = null;
+          this.recentPreviewCache.delete(file.path);
         }
       })
     );
@@ -278,30 +351,76 @@ export class SystemSculptSearchEngine {
           this.removeFromTokenIndex(existing);
         }
         this.index.delete(oldPath);
+        this.recentPreviewCache.delete(oldPath);
         if (this.isEligible(file)) {
           this.dirtyPaths.add(file.path);
+          this.recentPreviewCache.delete(file.path);
         }
         this.recentHitsCache = null;
       })
     );
+
+    if (typeof this.app.workspace?.on === "function") {
+      this.workspaceEventRefs.push(
+        this.app.workspace.on("systemsculpt:settings-updated", () => {
+          this.clearIndexes();
+        })
+      );
+    }
   }
 
   private async ensureIndex(): Promise<void> {
+    if (this.contentIndexReady) return;
     if (this.indexPromise) {
       await this.indexPromise;
       return;
     }
 
+    const generation = this.indexGeneration;
     this.indexPromise = (async () => {
       const files = this.getEligibleFiles();
-      await this.buildIndex(files);
+      const built = await this.buildIndex(files, false, generation);
+      if (built && generation === this.indexGeneration) {
+        this.contentIndexReady = true;
+      }
     })();
 
     try {
       await this.indexPromise;
     } catch (error) {
       this.indexPromise = null;
+      this.contentIndexReady = false;
       throw error;
+    }
+  }
+
+  private clearIndexes(): void {
+    this.indexGeneration += 1;
+    this.clearScheduledIndexing();
+    this.index.clear();
+    this.tokenIndex.clear();
+    this.tokenVocabulary.clear();
+    this.recentHitsCache = null;
+    this.recentPreviewCache.clear();
+    this.dirtyPaths.clear();
+    this.indexPromise = null;
+    this.contentIndexReady = false;
+  }
+
+  private scheduleIndexing(): void {
+    if (this.contentIndexReady || this.indexPromise || this.scheduledIndexHandle !== null) return;
+    this.scheduledIndexHandle = window.setTimeout(() => {
+      this.scheduledIndexHandle = null;
+      void this.startIndexing().catch(() => {
+        // Explicit searches can retry indexing.
+      });
+    }, 0);
+  }
+
+  private clearScheduledIndexing(): void {
+    if (this.scheduledIndexHandle !== null) {
+      window.clearTimeout(this.scheduledIndexHandle);
+      this.scheduledIndexHandle = null;
     }
   }
 
@@ -318,44 +437,41 @@ export class SystemSculptSearchEngine {
       return;
     }
 
-    await this.buildIndex(filesToRefresh, true);
+    await this.buildIndex(filesToRefresh, true, this.indexGeneration);
   }
 
-  private async buildIndex(files: TFile[], incremental = false): Promise<void> {
+  private async buildIndex(files: TFile[], incremental = false, generation = this.indexGeneration): Promise<boolean> {
     if (!incremental) {
-      this.index.clear();
-      this.tokenIndex.clear();
-      this.tokenVocabulary.clear();
+      const nextIndex = new Map<string, IndexedDocument>();
+      const nextTokenIndex = new Map<string, Set<string>>();
+      const nextVocabulary = new Set<string>();
+
+      const tasks = files.map((file) => async () => {
+        try {
+          const doc = await this.indexFile(file);
+          if (!doc || generation !== this.indexGeneration) return;
+          nextIndex.set(file.path, doc);
+          this.addToTokenIndex(doc, nextTokenIndex, nextVocabulary);
+        } catch {
+          // Skip failed file
+        }
+      });
+
+      await this.runLimited(tasks, this.CONTENT_CONCURRENCY);
+      if (generation !== this.indexGeneration) return false;
+
+      this.index = nextIndex;
+      this.tokenIndex = nextTokenIndex;
+      this.tokenVocabulary = nextVocabulary;
       this.recentHitsCache = null;
+      return true;
     }
 
     const tasks = files.map((file) => async () => {
       try {
-        const content = await this.safeRead(file);
-        const extracted = this.getIndexText(file, content);
-        const rawBody = extracted.slice(0, this.MAX_INDEX_CHARS);
-        const body = rawBody.toLowerCase();
-        const preview = this.buildPreviewFromText(extracted);
-        const titleTokens = this.tokenizeSearchText(file.basename);
-        const pathTokens = this.tokenizeSearchText(file.path);
-        const bodyTokens = this.tokenizeSearchText(body);
-        const tokens = new Set([...titleTokens, ...pathTokens, ...bodyTokens]);
-
-        const doc: IndexedDocument = {
-          path: file.path,
-          title: file.basename,
-          lowerTitle: file.basename.toLowerCase(),
-          lowerPath: file.path.toLowerCase(),
-          titleTokens,
-          pathTokens,
-          bodyTokens,
-          tokens,
-          body,
-          rawBody,
-          preview,
-          mtime: file.stat?.mtime || 0,
-          size: file.stat?.size || 0,
-        };
+        if (generation !== this.indexGeneration) return;
+        const doc = await this.indexFile(file);
+        if (!doc || generation !== this.indexGeneration) return;
 
         const existing = this.index.get(file.path);
         if (existing) {
@@ -369,7 +485,37 @@ export class SystemSculptSearchEngine {
     });
 
     await this.runLimited(tasks, this.CONTENT_CONCURRENCY);
+    if (generation !== this.indexGeneration) return false;
     this.recentHitsCache = null;
+    return true;
+  }
+
+  private async indexFile(file: TFile): Promise<IndexedDocument | null> {
+    const content = await this.safeRead(file);
+    const extracted = this.getIndexText(file, content);
+    const rawBody = extracted.slice(0, this.MAX_INDEX_CHARS);
+    const body = rawBody.toLowerCase();
+    const preview = this.buildPreviewFromText(extracted);
+    const titleTokens = this.tokenizeSearchText(file.basename);
+    const pathTokens = this.tokenizeSearchText(file.path);
+    const bodyTokens = this.tokenizeSearchText(body);
+    const tokens = new Set([...titleTokens, ...pathTokens, ...bodyTokens]);
+
+    return {
+      path: file.path,
+      title: file.basename,
+      lowerTitle: file.basename.toLowerCase(),
+      lowerPath: file.path.toLowerCase(),
+      titleTokens,
+      pathTokens,
+      bodyTokens,
+      tokens,
+      body,
+      rawBody,
+      preview,
+      mtime: file.stat?.mtime || 0,
+      size: file.stat?.size || 0,
+    };
   }
 
   private async safeRead(file: TFile): Promise<string> {
@@ -381,16 +527,36 @@ export class SystemSculptSearchEngine {
   }
 
   private getEligibleFiles(): TFile[] {
-    const cached = this.plugin.vaultFileCache?.getAllFiles?.();
+    const cached = this.plugin.vaultFileCache?.getAllFilesView?.() ?? this.plugin.vaultFileCache?.getAllFiles?.();
     const files = Array.isArray(cached) ? cached : this.app.vault.getFiles();
-    return files.filter((f) => this.isEligible(f));
+    return Array.from(files).filter((f) => this.isEligible(f));
   }
 
   private selectRecentFiles(files: TFile[], limit: number): TFile[] {
     if (limit <= 0) return [];
-    return files
-      .sort((a, b) => (b.stat?.mtime || 0) - (a.stat?.mtime || 0))
-      .slice(0, limit);
+    const top: TFile[] = [];
+    for (const file of files) {
+      const mtime = file.stat?.mtime || 0;
+      if (top.length === 0) {
+        top.push(file);
+        continue;
+      }
+
+      let insertAt = top.findIndex((candidate) => mtime > (candidate.stat?.mtime || 0));
+      if (insertAt === -1) insertAt = top.length;
+
+      if (insertAt < limit) {
+        top.splice(insertAt, 0, file);
+        if (top.length > limit) top.pop();
+      } else if (top.length < limit) {
+        top.push(file);
+      }
+    }
+    return top;
+  }
+
+  private previewCacheKey(file: TFile): string {
+    return `${file.path}:${file.stat?.mtime || 0}:${file.stat?.size || 0}`;
   }
 
   private isEligible(file: TFile): boolean {
@@ -420,13 +586,18 @@ export class SystemSculptSearchEngine {
   private runLexicalSearch(terms: string[], phrase: string, limit: number, sort: SortMode): SearchHit[] {
     const queryTerms = this.buildQueryTerms(terms);
     const candidates = this.collectCandidateDocs(queryTerms, limit);
+    const directMetadataCandidates = this.collectDirectMetadataDocs(queryTerms, phrase, limit);
+    const candidateMap = new Map<string, IndexedDocument>();
 
-    this.lastLexicalInspect = candidates.length;
+    for (const doc of directMetadataCandidates) {
+      candidateMap.set(doc.path, doc);
+    }
+    for (const doc of candidates) {
+      candidateMap.set(doc.path, doc);
+    }
 
-    // Fallback to the first indexed docs if no indexed token can match the query at all.
-    const pool = candidates.length > 0
-      ? candidates
-      : Array.from(this.index.values()).slice(0, Math.min(this.CANDIDATE_LIMIT, this.index.size));
+    const pool = Array.from(candidateMap.values());
+    this.lastLexicalInspect = pool.length;
 
     const scored = pool
       .map((doc) => this.scoreDocument(doc, queryTerms, phrase))
@@ -445,6 +616,7 @@ export class SystemSculptSearchEngine {
     if (queryTerms.length === 0) return null;
     let total = 0;
     let matchedTerms = 0;
+    let phraseMatched = false;
 
     for (const term of queryTerms) {
       const fieldScore = this.scoreTermInDocument(doc, term);
@@ -455,16 +627,27 @@ export class SystemSculptSearchEngine {
     }
 
     if (phrase) {
-      if (doc.lowerTitle.includes(phrase)) total += 20;
-      if (doc.lowerPath.includes(phrase)) total += 10;
-      if (doc.body.includes(phrase)) total += 14;
+      if (doc.lowerTitle.includes(phrase)) {
+        total += 20;
+        phraseMatched = true;
+      }
+      if (doc.lowerPath.includes(phrase)) {
+        total += 10;
+        phraseMatched = true;
+      }
+      if (doc.body.includes(phrase)) {
+        total += 14;
+        phraseMatched = true;
+      }
     }
+
+    if (matchedTerms === 0 && !phraseMatched) return null;
 
     const coverageRatio = matchedTerms / queryTerms.length;
     const coverageBonus = matchedTerms > 0 ? coverageRatio * 16 : 0;
     total += coverageBonus;
 
-    total += this.computeRecencyBoost(doc.mtime) * Math.max(0.25, coverageRatio);
+    total += this.computeRecencyBoost(doc.mtime) * Math.max(0.15, coverageRatio);
 
     const maxPossible = queryTerms.length * 24 + 60;
     const score = Math.min(1, total / maxPossible);
@@ -532,26 +715,34 @@ export class SystemSculptSearchEngine {
     return new Set(tokens.filter((token) => token.length > 1));
   }
 
-  private addToTokenIndex(doc: IndexedDocument): void {
+  private addToTokenIndex(
+    doc: IndexedDocument,
+    tokenIndex: Map<string, Set<string>> = this.tokenIndex,
+    tokenVocabulary: Set<string> = this.tokenVocabulary
+  ): void {
     for (const token of doc.tokens) {
-      this.tokenVocabulary.add(token);
-      let paths = this.tokenIndex.get(token);
+      tokenVocabulary.add(token);
+      let paths = tokenIndex.get(token);
       if (!paths) {
         paths = new Set();
-        this.tokenIndex.set(token, paths);
+        tokenIndex.set(token, paths);
       }
       paths.add(doc.path);
     }
   }
 
-  private removeFromTokenIndex(doc: IndexedDocument): void {
+  private removeFromTokenIndex(
+    doc: IndexedDocument,
+    tokenIndex: Map<string, Set<string>> = this.tokenIndex,
+    tokenVocabulary: Set<string> = this.tokenVocabulary
+  ): void {
     for (const token of doc.tokens) {
-      const paths = this.tokenIndex.get(token);
+      const paths = tokenIndex.get(token);
       if (!paths) continue;
       paths.delete(doc.path);
       if (paths.size === 0) {
-        this.tokenIndex.delete(token);
-        this.tokenVocabulary.delete(token);
+        tokenIndex.delete(token);
+        tokenVocabulary.delete(token);
       }
     }
   }
@@ -569,6 +760,9 @@ export class SystemSculptSearchEngine {
       if (value.length >= 3) {
         for (const token of this.tokenVocabulary) {
           if (token === value) continue;
+          if (value.length >= 5 && Math.abs(token.length - value.length) > Math.max(2, Math.floor(value.length * 0.45))) {
+            continue;
+          }
           if (token.startsWith(value) || value.startsWith(token)) {
             prefix.add(token);
             continue;
@@ -611,6 +805,129 @@ export class SystemSculptSearchEngine {
     }
 
     return candidates.slice(0, Math.max(limit * 8, this.CANDIDATE_LIMIT));
+  }
+
+  private collectDirectMetadataDocs(queryTerms: QueryTerm[], phrase: string, limit: number): IndexedDocument[] {
+    const scored: Array<{ doc: IndexedDocument; score: number }> = [];
+    for (const doc of this.index.values()) {
+      const score = this.scoreMetadata(doc, queryTerms, phrase);
+      if (score > 0) {
+        scored.push({ doc, score });
+      }
+    }
+
+    return scored
+      .sort((a, b) => b.score - a.score || (b.doc.mtime || 0) - (a.doc.mtime || 0))
+      .slice(0, Math.max(limit * 4, this.CANDIDATE_LIMIT))
+      .map((entry) => entry.doc);
+  }
+
+  private runMetadataSearch(terms: string[], phrase: string, limit: number, sort: SortMode): SearchHit[] {
+    const queryTerms = terms.map((value) => ({
+      value,
+      exact: new Set([value]),
+      prefix: new Set<string>(),
+      fuzzy: new Set<string>(),
+    }));
+
+    const hits = this.getEligibleFiles()
+      .map((file) => this.scoreMetadataFile(file, queryTerms, phrase))
+      .filter((hit): hit is SearchHit => hit !== null)
+      .sort((a, b) => b.score - a.score || (b.updatedAt || 0) - (a.updatedAt || 0))
+      .slice(0, limit);
+
+    if (sort === "recency") {
+      hits.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0) || b.score - a.score);
+    }
+
+    return hits;
+  }
+
+  private scoreMetadataFile(file: TFile, queryTerms: QueryTerm[], phrase: string): SearchHit | null {
+    const title = file.basename;
+    const path = file.path;
+    const doc: IndexedDocument = {
+      path,
+      title,
+      lowerTitle: title.toLowerCase(),
+      lowerPath: path.toLowerCase(),
+      titleTokens: this.tokenizeSearchText(title),
+      pathTokens: this.tokenizeSearchText(path),
+      bodyTokens: new Set(),
+      tokens: new Set(),
+      body: "",
+      rawBody: "",
+      preview: "",
+      mtime: file.stat?.mtime || 0,
+      size: file.stat?.size || 0,
+    };
+    const metadataScore = this.scoreMetadata(doc, queryTerms, phrase);
+    if (metadataScore <= 0) return null;
+
+    const maxPossible = Math.max(24, queryTerms.length * 20 + 24);
+    const score = Math.min(1, metadataScore / maxPossible);
+    return {
+      path,
+      title,
+      score,
+      lexScore: score,
+      origin: "lexical",
+      updatedAt: file.stat?.mtime || 0,
+      size: file.stat?.size || 0,
+    };
+  }
+
+  private scoreMetadata(doc: IndexedDocument, queryTerms: QueryTerm[], phrase: string): number {
+    if (queryTerms.length === 0) return 0;
+    let score = 0;
+    let matchedTerms = 0;
+
+    for (const term of queryTerms) {
+      const value = term.value;
+      if (doc.lowerTitle === value) {
+        score += 20;
+        matchedTerms += 1;
+        continue;
+      }
+      if (doc.lowerTitle.includes(value)) {
+        score += 14;
+        matchedTerms += 1;
+        continue;
+      }
+      if (doc.lowerPath.includes(value)) {
+        score += 8;
+        matchedTerms += 1;
+        continue;
+      }
+
+      const fuzzyTitle = value.length >= 5
+        ? Array.from(doc.titleTokens).some((token) => {
+          const fuzzyScore = fuzzyMatchScore(value, token);
+          return fuzzyScore !== null && fuzzyScore <= Math.max(2, Math.floor(value.length * 0.45));
+        })
+        : false;
+      if (fuzzyTitle) {
+        score += 9;
+        matchedTerms += 1;
+      }
+    }
+
+    let phraseMatched = false;
+    if (phrase) {
+      if (doc.lowerTitle.includes(phrase)) {
+        score += 24;
+        phraseMatched = true;
+      }
+      if (doc.lowerPath.includes(phrase)) {
+        score += 10;
+        phraseMatched = true;
+      }
+    }
+
+    if (matchedTerms === 0 && !phraseMatched) return 0;
+    score += (matchedTerms / queryTerms.length) * 10;
+    score += this.computeRecencyBoost(doc.mtime) * 0.15;
+    return score;
   }
 
   private pathsForQueryTerm(term: QueryTerm): Set<string> {
@@ -679,38 +996,62 @@ export class SystemSculptSearchEngine {
     return `${prefix}${slice}${suffix}`;
   }
 
-  private async runSemanticSearch(query: string, limit: number): Promise<SearchHit[]> {
+  private async runSemanticSearch(query: string, limit: number, signal?: AbortSignal): Promise<SearchHit[]> {
     try {
-      const manager = this.plugin.getOrCreateEmbeddingsManager();
+      const manager = this.getExistingEmbeddingsManager();
+      if (!manager || signal?.aborted) return [];
       const semanticPromise = (async () => {
         // @ts-ignore awaitReady is public but not in types
         if (typeof (manager as any).awaitReady === "function") {
           await (manager as any).awaitReady();
         }
+        if (signal?.aborted) return [];
         const rawResults = await manager.searchSimilar(query, limit);
-        return rawResults.map((item: any) => ({
-          path: item.path,
-          title: this.extractTitle(item.path, item?.metadata?.title),
-          excerpt: item?.metadata?.excerpt,
-          score: Math.max(0, Math.min(1, item.score ?? 0)),
-          semScore: Math.max(0, Math.min(1, item.score ?? 0)),
-          origin: "semantic",
-          updatedAt: item?.metadata?.lastModified ?? 0,
-        } as SearchHit));
+        if (signal?.aborted) return [];
+        return rawResults
+          .map((item: any) => {
+            const file = this.app.vault.getAbstractFileByPath(item.path);
+            if (!(file instanceof TFile) || !this.isEligible(file)) return null;
+            const score = Math.max(0, Math.min(1, item.score ?? 0));
+            return {
+              path: item.path,
+              title: this.extractTitle(item.path, item?.metadata?.title),
+              excerpt: item?.metadata?.excerpt,
+              score,
+              semScore: score,
+              origin: "semantic",
+              updatedAt: item?.metadata?.lastModified ?? file.stat?.mtime ?? 0,
+              size: file.stat?.size || 0,
+            } as SearchHit;
+          })
+          .filter((hit: SearchHit | null): hit is SearchHit => hit !== null);
       })();
 
       // Avoid long stalls; apply a timeout without leaking a dangling timer.
       return await new Promise<SearchHit[]>((resolve, reject) => {
-        const timer = window.setTimeout(() => resolve([]), this.SEMANTIC_TIMEOUT_MS);
+        let settled = false;
+        const cleanup = () => {
+          window.clearTimeout(timer);
+          signal?.removeEventListener("abort", onAbort);
+        };
+        const finish = (results: SearchHit[]) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          resolve(results);
+        };
+        const fail = (error: unknown) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          reject(error);
+        };
+        const onAbort = () => finish([]);
+        const timer = window.setTimeout(() => finish([]), this.SEMANTIC_TIMEOUT_MS);
+        signal?.addEventListener("abort", onAbort, { once: true });
         semanticPromise.then(
-          (results) => {
-            window.clearTimeout(timer);
-            resolve(results);
-          },
-          (error) => {
-            window.clearTimeout(timer);
-            reject(error);
-          }
+          (results) => finish(results),
+          (error) => fail(error)
         );
       });
     } catch {
@@ -791,7 +1132,10 @@ export class SystemSculptSearchEngine {
     }
 
     try {
-      const manager = this.plugin.getOrCreateEmbeddingsManager();
+      const manager = this.getExistingEmbeddingsManager();
+      if (!manager) {
+        return { enabled, ready: false, available: false, reason: "Embeddings not initialized" };
+      }
       const ready = typeof (manager as any).isReady === "function" ? (manager as any).isReady() : true;
       const stats = typeof manager.getStats === "function" ? manager.getStats() : { total: 0, processed: 0, present: 0, needsProcessing: 0 };
       const available = typeof (manager as any).hasAnyEmbeddings === "function" ? (manager as any).hasAnyEmbeddings() : stats.present > 0;
@@ -800,13 +1144,21 @@ export class SystemSculptSearchEngine {
         enabled,
         ready,
         available,
-        processed: stats.present,
+        processed: stats.processed ?? stats.present ?? 0,
         total: stats.total,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Embeddings unavailable";
       return { enabled, ready: false, available: false, reason: message };
     }
+  }
+
+  private getPassiveEmbeddingsIndicator(): EmbeddingsIndicator {
+    return this.getEmbeddingsIndicator();
+  }
+
+  private getExistingEmbeddingsManager(): any | null {
+    return (this.plugin as any).embeddingsManager ?? null;
   }
 
   private extractTitle(path: string, fallback?: string | null): string {

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -1042,6 +1042,11 @@ export class SystemSculptSearchEngine {
     // `pathsForQueryTerm(...).size === 0` gate in the caller still avoids
     // running a substring scan when the term has exact token coverage.
     if (value.length < 3) return true;
+    // Token index stores punctuation-stripped tokens, so a query term
+    // containing separators (e.g. "orange-juice", "don't") can never hit the
+    // token index directly — the body still contains the substring, so fall
+    // back to the substring scan to recover the match.
+    if (/[^\p{L}\p{N}\p{M}]/u.test(value)) return true;
     return /[^\x00-\x7F]/.test(value) || this.tokenizeSearchText(value).size === 0;
   }
 

--- a/src/services/search/SystemSculptSearchEngine.ts
+++ b/src/services/search/SystemSculptSearchEngine.ts
@@ -836,6 +836,19 @@ export class SystemSculptSearchEngine {
     if (fuzzyPath) total += 4;
     if (fuzzyBody) total += 2.5;
 
+    if (total > 0) return total;
+
+    // Non-tokenizable terms (e.g. emoji, single characters, symbol-only) have
+    // empty exact/prefix/fuzzy sets, so token-based scoring always returns 0
+    // even when the candidate pool added the doc via substring fallback. Score
+    // these by substring so mixed queries like "launch 🚀" still credit docs
+    // that only contain the non-tokenizable portion.
+    if (term.exact.size === 0 && term.prefix.size === 0 && term.fuzzy.size === 0 && term.value.length > 0) {
+      if (doc.lowerTitle.includes(term.value)) total += 9;
+      if (doc.lowerPath.includes(term.value)) total += 4;
+      if (doc.body.includes(term.value)) total += 3;
+    }
+
     return total;
   }
 

--- a/src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts
@@ -66,7 +66,7 @@ describe("SystemSculptSearchEngine semantic mode", () => {
 
       await engine.search("artificial intelligence", { mode: "semantic", limit: 10 });
 
-      expect(mockManager.searchSimilar).toHaveBeenCalledWith("artificial intelligence", 10);
+      expect(mockManager.searchSimilar).toHaveBeenCalledWith("artificial intelligence", 10, undefined);
     });
 
     it("returns results with origin='semantic'", async () => {

--- a/src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts
@@ -361,6 +361,32 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       expect(res.embeddings.reason).toContain("not initialized");
       expect(plugin.getOrCreateEmbeddingsManager).not.toHaveBeenCalled();
     });
+
+    it("lazily bootstraps the embeddings manager for explicit semantic mode", async () => {
+      const { app } = buildFixture();
+      const manager = createMockManager({
+        searchSimilar: jest.fn().mockResolvedValue([
+          { path: "notes/machine-learning.md", score: 0.9, metadata: { title: "ML" } },
+        ]),
+      });
+      const plugin: any = {
+        app,
+        settings: { embeddingsEnabled: true, embeddingsExclusions: {} },
+        vaultFileCache: undefined,
+        embeddingsManager: undefined,
+        getOrCreateEmbeddingsManager: jest.fn(() => {
+          plugin.embeddingsManager = manager;
+          return manager;
+        }),
+      };
+      const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+      const res = await engine.search("artificial intelligence", { mode: "semantic", limit: 10 });
+
+      expect(plugin.getOrCreateEmbeddingsManager).toHaveBeenCalled();
+      expect(manager.searchSimilar).toHaveBeenCalledWith("artificial intelligence", 10, undefined);
+      expect(res.results.map((r) => r.path)).toContain("notes/machine-learning.md");
+    });
   });
 
   describe("empty query handling", () => {

--- a/src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts
@@ -22,6 +22,7 @@ const makePlugin = (app: App, options: { embeddingsEnabled?: boolean; manager?: 
       },
     },
     vaultFileCache: undefined,
+    embeddingsManager: manager,
     getOrCreateEmbeddingsManager: jest.fn().mockReturnValue(manager),
   } as any;
 };
@@ -146,6 +147,7 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       });
       const { app, plugin } = buildFixture({ manager: mockManager });
       const engine = new SystemSculptSearchEngine(app as any, plugin);
+      await engine.startIndexing();
 
       const res = await engine.search("learning", { mode: "smart", limit: 10 });
 
@@ -162,6 +164,7 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       });
       const { app, plugin } = buildFixture({ manager: mockManager });
       const engine = new SystemSculptSearchEngine(app as any, plugin);
+      await engine.startIndexing();
 
       const res = await engine.search("machine learning", { mode: "smart", limit: 10 });
 
@@ -177,6 +180,7 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       });
       const { app, plugin } = buildFixture({ manager: mockManager });
       const engine = new SystemSculptSearchEngine(app as any, plugin);
+      await engine.startIndexing();
 
       const res = await engine.search("machine", { mode: "smart", limit: 10 });
 
@@ -194,6 +198,7 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       });
       const { app, plugin } = buildFixture({ manager: mockManager });
       const engine = new SystemSculptSearchEngine(app as any, plugin);
+      await engine.startIndexing();
 
       const res = await engine.search("machine learning", { mode: "smart", limit: 10 });
 
@@ -211,6 +216,7 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       });
       const { app, plugin } = buildFixture({ manager: mockManager });
       const engine = new SystemSculptSearchEngine(app as any, plugin);
+      await engine.startIndexing();
 
       const res = await engine.search("machine learning", { mode: "smart", limit: 10 });
 
@@ -228,6 +234,7 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       });
       const { app, plugin } = buildFixture({ manager: mockManager });
       const engine = new SystemSculptSearchEngine(app as any, plugin);
+      await engine.startIndexing();
 
       const res = await engine.search("learning", { mode: "smart", limit: 10 });
 
@@ -245,6 +252,7 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       });
       const { app, plugin } = buildFixture({ manager: mockManager });
       const engine = new SystemSculptSearchEngine(app as any, plugin);
+      await engine.startIndexing();
 
       const res = await engine.search("learning", { mode: "smart", limit: 10 });
 
@@ -334,7 +342,7 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       expect(res.embeddings.total).toBe(200);
     });
 
-    it("handles manager errors and returns reason", async () => {
+    it("does not instantiate embeddings just to report readiness", async () => {
       const { app } = buildFixture();
       const plugin = {
         app,
@@ -350,7 +358,8 @@ describe("SystemSculptSearchEngine semantic mode", () => {
 
       expect(res.embeddings.ready).toBe(false);
       expect(res.embeddings.available).toBe(false);
-      expect(res.embeddings.reason).toContain("Manager initialization failed");
+      expect(res.embeddings.reason).toContain("not initialized");
+      expect(plugin.getOrCreateEmbeddingsManager).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts
@@ -185,6 +185,40 @@ describe("SystemSculptSearchEngine semantic mode", () => {
       expect(lexicalResults.length).toBeGreaterThan(0);
     });
 
+    it("does not use embeddings in smart mode until the index is at least 75% complete", async () => {
+      const mockManager = createMockManager({
+        getStats: jest.fn().mockReturnValue({ total: 100, processed: 60, present: 60, needsProcessing: 40 }),
+        searchSimilar: jest.fn().mockResolvedValue([
+          { path: "notes/machine-learning.md", score: 0.95, metadata: { title: "Machine Learning" } },
+        ]),
+      });
+      const { app, plugin } = buildFixture({ manager: mockManager });
+      const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+      const res = await engine.search("machine learning", { mode: "smart", limit: 10 });
+
+      expect(mockManager.searchSimilar).not.toHaveBeenCalled();
+      expect(res.stats.usedEmbeddings).toBe(false);
+      expect(res.stats.embeddingsEligible).toBe(false);
+    });
+
+    it("uses embeddings in smart mode once the index is at least 75% complete", async () => {
+      const mockManager = createMockManager({
+        getStats: jest.fn().mockReturnValue({ total: 100, processed: 80, present: 80, needsProcessing: 20 }),
+        searchSimilar: jest.fn().mockResolvedValue([
+          { path: "notes/machine-learning.md", score: 0.95, metadata: { title: "Machine Learning" } },
+        ]),
+      });
+      const { app, plugin } = buildFixture({ manager: mockManager });
+      const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+      const res = await engine.search("machine learning", { mode: "smart", limit: 10 });
+
+      expect(mockManager.searchSimilar).toHaveBeenCalled();
+      expect(res.stats.usedEmbeddings).toBe(true);
+      expect(res.stats.embeddingsEligible).toBe(true);
+    });
+
     it("deduplicates results by path", async () => {
       const mockManager = createMockManager({
         searchSimilar: jest.fn().mockResolvedValue([

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -216,6 +216,72 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     jest.useRealTimers();
   });
 
+  it("bootstraps the embeddings manager on smart searches so lazy autostart still runs semantic retrieval", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    plugin.settings.embeddingsEnabled = true;
+    const getOrCreateEmbeddingsManager = jest.fn(() => {
+      plugin.embeddingsManager = {
+        searchSimilar: jest.fn(() => Promise.resolve([])),
+        isReady: () => true,
+        hasAnyEmbeddings: () => false,
+        getStats: () => ({ total: 0, processed: 0, present: 0, needsProcessing: 0 }),
+      };
+      return plugin.embeddingsManager;
+    });
+    plugin.getOrCreateEmbeddingsManager = getOrCreateEmbeddingsManager;
+
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    // First warm the full content index via a lexical search so smart mode
+    // bypasses the metadata fast path (which never reaches the embeddings
+    // bootstrap) and runs the full search path where the bug lives.
+    await engine.search("orange", { mode: "lexical", limit: 10 });
+    await engine.search("orange", { mode: "smart", limit: 10 });
+    expect(getOrCreateEmbeddingsManager).toHaveBeenCalled();
+  });
+
+  it("refreshes dirty index entries before serving recents so modified notes get fresh previews", async () => {
+    const { app, files } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const target = files.find((f) => f.path === "notes/orange-juice.md")!;
+
+    // Warm the full content index so indexed.preview is populated.
+    await engine.search("orange", { mode: "lexical", limit: 10 });
+
+    const initial = await engine.getRecent(10);
+    const initialExcerpt = initial.find((r) => r.path === target.path)?.excerpt ?? "";
+    expect(initialExcerpt.toLowerCase()).toContain("orange");
+
+    // Simulate an external edit: update the mocked content and fire modify.
+    (app.vault.cachedRead as jest.Mock).mockImplementation((file: any) => {
+      if (file.path === target.path) {
+        return Promise.resolve("Totally new body text about automation checklists.");
+      }
+      // Defer to the original fixture mapping for other files.
+      const defaults: Record<string, string> = {
+        "notes/fresh-orange.md": "Orange harvest note with no juice details.",
+        "notes/research.canvas": "",
+        "notes/unrelated.md": "Nothing about fruit here.",
+        "notes/東京.md": "これは東京の会議メモです。京都ではありません。",
+        "notes/emoji-launch.md": "Release mood 🚀 and notes for a symbol-only query.",
+        "notes/cyrillic.md": "Привет мир from the multilingual search fixture.",
+      };
+      return Promise.resolve(defaults[file.path] ?? "");
+    });
+
+    const modifyListener = (app.vault.on as jest.Mock).mock.calls.find(([event]) => event === "modify")?.[1];
+    expect(modifyListener).toBeDefined();
+    modifyListener(target);
+
+    const refreshed = await engine.getRecent(10);
+    const refreshedExcerpt = refreshed.find((r) => r.path === target.path)?.excerpt ?? "";
+    expect(refreshedExcerpt.toLowerCase()).toContain("automation");
+    expect(refreshedExcerpt.toLowerCase()).not.toContain("orange juice");
+  });
+
   it("drops cached recents when userIgnoreFilters change between empty-query loads", async () => {
     const { app } = buildFixture();
     const plugin = makePlugin(app);

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -21,12 +21,14 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     const app = new App();
     const files = [
       new TFile({ path: "notes/orange-juice.md", stat: { mtime: NOW - 1_000 } }),
+      new TFile({ path: "notes/fresh-orange.md", stat: { mtime: NOW - 100 } }),
       new TFile({ path: "notes/research.canvas", stat: { mtime: NOW - 1_500 } }),
       new TFile({ path: "notes/unrelated.md", stat: { mtime: NOW - 2_000 } }),
     ];
 
     const contents: Record<string, string> = {
       "notes/orange-juice.md": "Orange juice is delicious and bright. Fresh squeezed orange juice every day.",
+      "notes/fresh-orange.md": "Orange harvest note with no juice details.",
       "notes/research.canvas": JSON.stringify({
         nodes: [
           { id: "n1", type: "text", text: "Canvas note: yellow submarine" },
@@ -59,6 +61,16 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     expect(res.stats.usedEmbeddings).toBe(false);
   });
 
+  it("prefers full term coverage over recent one-term matches", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("orange juice", { mode: "lexical", limit: 10 });
+
+    expect(res.results[0]?.path).toBe("notes/orange-juice.md");
+  });
+
   it("indexes .canvas text nodes and finds matches", async () => {
     const { app } = buildFixture();
     const plugin = makePlugin(app);
@@ -68,6 +80,16 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     const paths = res.results.map((r) => r.path);
 
     expect(paths).toContain("notes/research.canvas");
+  });
+
+  it("uses fuzzy token candidates for minor query typos", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("yelow submarine", { mode: "lexical", limit: 10 });
+
+    expect(res.results[0]?.path).toBe("notes/research.canvas");
   });
 
   it("does not index JSON keys from .canvas files", async () => {

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -234,6 +234,29 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     expect(after.results.map((r) => r.path)).not.toContain("notes/orange-juice.md");
   });
 
+  it("keeps detecting further userIgnoreFilters changes after the first prune", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    plugin.settings.embeddingsExclusions.respectObsidianExclusions = true;
+    let ignoreFilters: string[] = [];
+    (app.vault as any).getConfig = jest.fn((key: string) => (key === "userIgnoreFilters" ? ignoreFilters : null));
+
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    await engine.search("orange", { mode: "lexical", limit: 10 });
+
+    ignoreFilters = ["orange-juice"];
+    const afterFirst = await engine.search("orange", { mode: "lexical", limit: 10 });
+    expect(afterFirst.results.map((r) => r.path)).not.toContain("notes/orange-juice.md");
+    expect(afterFirst.results.map((r) => r.path)).toContain("notes/fresh-orange.md");
+
+    ignoreFilters = ["fresh-orange"];
+    const afterSecond = await engine.search("orange", { mode: "lexical", limit: 10 });
+    expect(afterSecond.results.map((r) => r.path)).not.toContain("notes/fresh-orange.md");
+    // Removing the previous filter should let orange-juice.md become searchable again.
+    expect(afterSecond.results.map((r) => r.path)).toContain("notes/orange-juice.md");
+  });
+
   it("invalidates the eligible file snapshot when files are created", async () => {
     jest.useFakeTimers();
     const { app, files } = buildFixture();
@@ -338,6 +361,23 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     const res = await engine.search("🚀", { mode: "lexical", limit: 10 });
 
     expect(res.results.map((r) => r.path)).toContain("notes/emoji-launch.md");
+  });
+
+  it("falls back to substring matching for 2-character prefix queries after indexing", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    // Warm the full content index so subsequent searches use the token path.
+    await engine.search("orange", { mode: "lexical", limit: 10 });
+
+    // "fr" is ASCII and tokenizable at length 2, but prefix expansion starts
+    // at length 3 — without the short-term substring fallback, fresh-* notes
+    // would disappear once the content index is ready.
+    const res = await engine.search("fr", { mode: "lexical", limit: 10 });
+    const paths = res.results.map((r) => r.path);
+    expect(paths).toContain("notes/fresh-orange.md");
+    expect(paths).toContain("notes/orange-juice.md");
   });
 
   it("scores non-tokenizable terms in mixed queries so emoji-only docs still hit", async () => {

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -24,6 +24,9 @@ describe("SystemSculptSearchEngine lexical mode", () => {
       new TFile({ path: "notes/fresh-orange.md", stat: { mtime: NOW - 100 } }),
       new TFile({ path: "notes/research.canvas", stat: { mtime: NOW - 1_500 } }),
       new TFile({ path: "notes/unrelated.md", stat: { mtime: NOW - 2_000 } }),
+      new TFile({ path: "notes/東京.md", stat: { mtime: NOW - 3_000 } }),
+      new TFile({ path: "notes/emoji-launch.md", stat: { mtime: NOW - 3_100 } }),
+      new TFile({ path: "notes/cyrillic.md", stat: { mtime: NOW - 3_200 } }),
     ];
 
     const contents: Record<string, string> = {
@@ -38,6 +41,9 @@ describe("SystemSculptSearchEngine lexical mode", () => {
         edges: [{ id: "e1", fromNode: "n1", toNode: "n2", label: "references" }],
       }),
       "notes/unrelated.md": "Nothing about fruit here. This sentence mentions nodes for a targeted test.",
+      "notes/東京.md": "これは東京の会議メモです。京都ではありません。",
+      "notes/emoji-launch.md": "Release mood 🚀 and notes for a symbol-only query.",
+      "notes/cyrillic.md": "Привет мир from the multilingual search fixture.",
     };
 
     app.vault.getFiles.mockReturnValue(files);
@@ -170,6 +176,9 @@ describe("SystemSculptSearchEngine lexical mode", () => {
       "notes/fresh-orange.md",
       "notes/research.canvas",
       "notes/unrelated.md",
+      "notes/東京.md",
+      "notes/emoji-launch.md",
+      "notes/cyrillic.md",
     ]);
   });
 
@@ -278,6 +287,52 @@ describe("SystemSculptSearchEngine lexical mode", () => {
 
     expect(res.stats.metadataOnly).toBe(true);
     expect(res.results.map((r) => r.path)).toContain("notes/fresh-orange.md");
+
+    engine.destroy();
+    jest.useRealTimers();
+  });
+
+  it("finds CJK body matches after the content index is ready", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("東京", { mode: "lexical", limit: 10 });
+
+    expect(res.results.map((r) => r.path)).toContain("notes/東京.md");
+  });
+
+  it("finds Cyrillic body matches with Unicode tokens", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("привет", { mode: "lexical", limit: 10 });
+
+    expect(res.results.map((r) => r.path)).toContain("notes/cyrillic.md");
+  });
+
+  it("finds symbol-only body matches through substring fallback", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("🚀", { mode: "lexical", limit: 10 });
+
+    expect(res.results.map((r) => r.path)).toContain("notes/emoji-launch.md");
+  });
+
+  it("finds non-ASCII metadata matches before reading note bodies", async () => {
+    jest.useFakeTimers();
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("東京", { mode: "smart", limit: 10 });
+
+    expect(res.stats.metadataOnly).toBe(true);
+    expect(res.results.map((r) => r.path)).toContain("notes/東京.md");
+    expect(app.vault.cachedRead).not.toHaveBeenCalled();
 
     engine.destroy();
     jest.useRealTimers();

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -72,6 +72,28 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     expect(app.vault.cachedRead).not.toHaveBeenCalled();
   });
 
+  it("returns only the requested number of recent files", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const recents = await engine.getRecent(2);
+
+    expect(recents.map((r) => r.path)).toEqual(["notes/fresh-orange.md", "notes/orange-juice.md"]);
+    expect(app.vault.cachedRead).not.toHaveBeenCalled();
+  });
+
+  it("hydrates previews only for requested recent paths", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const previews = await engine.getRecentPreviews(["notes/fresh-orange.md"]);
+
+    expect(app.vault.cachedRead).toHaveBeenCalledTimes(1);
+    expect(previews.get("notes/fresh-orange.md")).toContain("Orange harvest note");
+  });
+
   it("prefers full term coverage over recent one-term matches", async () => {
     const { app } = buildFixture();
     const plugin = makePlugin(app);

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -340,6 +340,19 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     expect(res.results.map((r) => r.path)).toContain("notes/emoji-launch.md");
   });
 
+  it("scores non-tokenizable terms in mixed queries so emoji-only docs still hit", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    // "orange" doesn't appear in emoji-launch.md at all; "🚀" has no tokenized
+    // form and the phrase "orange 🚀" never appears verbatim. The doc should
+    // still be returned because the non-tokenizable term matches its body.
+    const res = await engine.search("orange 🚀", { mode: "lexical", limit: 10 });
+
+    expect(res.results.map((r) => r.path)).toContain("notes/emoji-launch.md");
+  });
+
   it("finds non-ASCII metadata matches before reading note bodies", async () => {
     jest.useFakeTimers();
     const { app } = buildFixture();

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -216,6 +216,24 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     jest.useRealTimers();
   });
 
+  it("invalidates the eligible file snapshot when userIgnoreFilters change", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    plugin.settings.embeddingsExclusions.respectObsidianExclusions = true;
+    let ignoreFilters: string[] = [];
+    (app.vault as any).getConfig = jest.fn((key: string) => (key === "userIgnoreFilters" ? ignoreFilters : null));
+
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const before = await engine.search("orange", { mode: "lexical", limit: 10 });
+    expect(before.results.map((r) => r.path)).toContain("notes/orange-juice.md");
+
+    ignoreFilters = ["orange-juice"];
+
+    const after = await engine.search("orange", { mode: "lexical", limit: 10 });
+    expect(after.results.map((r) => r.path)).not.toContain("notes/orange-juice.md");
+  });
+
   it("invalidates the eligible file snapshot when files are created", async () => {
     jest.useFakeTimers();
     const { app, files } = buildFixture();

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -412,6 +412,39 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     expect(paths).toContain("notes/orange-juice.md");
   });
 
+  it("falls back to substring matching for punctuated query terms after indexing", async () => {
+    // Purpose-built fixture: the punctuated query "co-op" has no prefix of
+    // length >= 3 that exists as an indexed token ("co-o" and "co-" never
+    // survive the tokenizer), and "co"/"op" alone are below the 3-char
+    // prefix-expansion floor. Without the substring fallback trigger for
+    // punctuated terms, the note drops out of results entirely after the
+    // content index is ready.
+    const app = new App();
+    const files = [
+      new TFile({ path: "notes/co-op.md", stat: { mtime: NOW - 500 } }),
+      new TFile({ path: "notes/unrelated.md", stat: { mtime: NOW - 2_000 } }),
+    ];
+    const contents: Record<string, string> = {
+      "notes/co-op.md": "The co-op meeting is tomorrow.",
+      "notes/unrelated.md": "Nothing relevant here.",
+    };
+    app.vault.getFiles.mockReturnValue(files);
+    // @ts-expect-error mock injected for tests
+    app.vault.cachedRead = jest.fn((file) => Promise.resolve(contents[file.path] ?? ""));
+    app.vault.read.mockImplementation(app.vault.cachedRead);
+    app.vault.getAbstractFileByPath.mockImplementation((p) => files.find((f) => f.path === p) ?? null);
+
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    // Warm the full content index so the next search uses the token path.
+    await engine.search("co", { mode: "lexical", limit: 10 });
+
+    const res = await engine.search("co-op", { mode: "lexical", limit: 10 });
+
+    expect(res.results.map((r) => r.path)).toContain("notes/co-op.md");
+  });
+
   it("scores non-tokenizable terms in mixed queries so emoji-only docs still hit", async () => {
     const { app } = buildFixture();
     const plugin = makePlugin(app);

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -173,6 +173,60 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     ]);
   });
 
+  it("reuses the eligible file snapshot across metadata searches", async () => {
+    jest.useFakeTimers();
+    const { app, files } = buildFixture();
+    const plugin = makePlugin(app);
+    const getAllFilesView = jest.fn(() => files);
+    plugin.vaultFileCache = { getAllFilesView };
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    await engine.search("fresh", { mode: "smart", limit: 10 });
+    await engine.search("orange", { mode: "smart", limit: 10 });
+
+    expect(getAllFilesView).toHaveBeenCalledTimes(1);
+
+    engine.destroy();
+    jest.useRealTimers();
+  });
+
+  it("reuses cached title and path tokens across metadata searches", async () => {
+    jest.useFakeTimers();
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+    const tokenizeSpy = jest.spyOn(engine as any, "tokenizeSearchText");
+
+    await engine.search("fresh", { mode: "smart", limit: 10 });
+    const firstSearchTokenizations = tokenizeSpy.mock.calls.length;
+    await engine.search("orange", { mode: "smart", limit: 10 });
+
+    expect(tokenizeSpy).toHaveBeenCalledTimes(firstSearchTokenizations);
+
+    engine.destroy();
+    jest.useRealTimers();
+  });
+
+  it("invalidates the eligible file snapshot when files are created", async () => {
+    jest.useFakeTimers();
+    const { app, files } = buildFixture();
+    const plugin = makePlugin(app);
+    const getAllFilesView = jest.fn(() => files);
+    plugin.vaultFileCache = { getAllFilesView };
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    await engine.search("fresh", { mode: "smart", limit: 10 });
+    const createListener = (app.vault.on as jest.Mock).mock.calls.find(([event]) => event === "create")?.[1];
+    expect(createListener).toBeDefined();
+    createListener(new TFile({ path: "notes/new.md", stat: { mtime: NOW } }));
+    await engine.search("orange", { mode: "smart", limit: 10 });
+
+    expect(getAllFilesView).toHaveBeenCalledTimes(2);
+
+    engine.destroy();
+    jest.useRealTimers();
+  });
+
   it("prefers full term coverage over recent one-term matches", async () => {
     const { app } = buildFixture();
     const plugin = makePlugin(app);
@@ -202,6 +256,31 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     const res = await engine.search("yelow submarine", { mode: "lexical", limit: 10 });
 
     expect(res.results[0]?.path).toBe("notes/research.canvas");
+  });
+
+  it("matches longer query terms against shorter indexed tokens", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("oranges", { mode: "lexical", limit: 10 });
+
+    expect(res.results.map((r) => r.path)).toContain("notes/fresh-orange.md");
+  });
+
+  it("uses shorter title tokens for longer metadata queries before the content index is ready", async () => {
+    jest.useFakeTimers();
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("oranges", { mode: "smart", limit: 10 });
+
+    expect(res.stats.metadataOnly).toBe(true);
+    expect(res.results.map((r) => r.path)).toContain("notes/fresh-orange.md");
+
+    engine.destroy();
+    jest.useRealTimers();
   });
 
   it("does not index JSON keys from .canvas files", async () => {

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -216,6 +216,29 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     jest.useRealTimers();
   });
 
+  it("drops cached recents when userIgnoreFilters change between empty-query loads", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    plugin.settings.embeddingsExclusions.respectObsidianExclusions = true;
+    let ignoreFilters: string[] = [];
+    (app.vault as any).getConfig = jest.fn((key: string) => (key === "userIgnoreFilters" ? ignoreFilters : null));
+
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    // First empty-query load populates the recent-hits cache via getRecent.
+    const before = await engine.getRecent(10);
+    expect(before.map((r) => r.path)).toContain("notes/orange-juice.md");
+
+    // User edits Obsidian's "Excluded files". Without eligibility refresh in
+    // getRecent, the cached recents would still include the excluded note
+    // until a non-empty search or vault event invalidates the cache.
+    ignoreFilters = ["orange-juice"];
+
+    const after = await engine.getRecent(10);
+    expect(after.map((r) => r.path)).not.toContain("notes/orange-juice.md");
+    expect(after.map((r) => r.path)).toContain("notes/fresh-orange.md");
+  });
+
   it("invalidates the eligible file snapshot when userIgnoreFilters change", async () => {
     const { app } = buildFixture();
     const plugin = makePlugin(app);

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -277,6 +277,38 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     jest.useRealTimers();
   });
 
+  it("refreshes eligibility on the smart metadata fast path so in-flight indexes can't go stale", async () => {
+    jest.useFakeTimers();
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    plugin.settings.embeddingsExclusions.respectObsidianExclusions = true;
+    let ignoreFilters: string[] = [];
+    (app.vault as any).getConfig = jest.fn((key: string) => (key === "userIgnoreFilters" ? ignoreFilters : null));
+
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+    const clearSpy = jest.spyOn(engine as any, "clearIndexes");
+
+    // First smart search while the content index isn't ready yet → metadata fast path.
+    // Fake timers keep the scheduled background indexing from running.
+    const first = await engine.search("orange", { mode: "smart", limit: 10 });
+    expect(first.stats.metadataOnly).toBe(true);
+    expect(clearSpy).not.toHaveBeenCalled();
+
+    // Simulate the user editing Obsidian's "Excluded files" between searches.
+    ignoreFilters = ["orange-juice"];
+
+    // Second smart search, still cold → metadata fast path again. Without the
+    // refresh-before-metadata call, the signature would be updated silently and
+    // a later lexical pass would reuse the stale (pre-filter) content index.
+    const second = await engine.search("orange", { mode: "smart", limit: 10 });
+    expect(second.stats.metadataOnly).toBe(true);
+    expect(second.results.map((r) => r.path)).not.toContain("notes/orange-juice.md");
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+
+    engine.destroy();
+    jest.useRealTimers();
+  });
+
   it("prefers full term coverage over recent one-term matches", async () => {
     const { app } = buildFixture();
     const plugin = makePlugin(app);

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -61,6 +61,17 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     expect(res.stats.usedEmbeddings).toBe(false);
   });
 
+  it("returns recent files without building the content index", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const recents = await engine.getRecent(10);
+
+    expect(recents.map((r) => r.path)).toContain("notes/fresh-orange.md");
+    expect(app.vault.cachedRead).not.toHaveBeenCalled();
+  });
+
   it("prefers full term coverage over recent one-term matches", async () => {
     const { app } = buildFixture();
     const plugin = makePlugin(app);

--- a/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
+++ b/src/services/search/__tests__/SystemSculptSearchEngine.test.ts
@@ -94,6 +94,85 @@ describe("SystemSculptSearchEngine lexical mode", () => {
     expect(previews.get("notes/fresh-orange.md")).toContain("Orange harvest note");
   });
 
+  it("caches recent previews by path, mtime, and size", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    await engine.getRecentPreviews(["notes/fresh-orange.md"]);
+    await engine.getRecentPreviews(["notes/fresh-orange.md"]);
+
+    expect(app.vault.cachedRead).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns metadata hits for the first smart query without reading note bodies", async () => {
+    jest.useFakeTimers();
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("fresh", { mode: "smart", limit: 10 });
+
+    expect(res.results.map((r) => r.path)).toContain("notes/fresh-orange.md");
+    expect(res.stats.metadataOnly).toBe(true);
+    expect(res.stats.indexingPending).toBe(true);
+    expect(app.vault.cachedRead).not.toHaveBeenCalled();
+
+    engine.destroy();
+    jest.useRealTimers();
+  });
+
+  it("does not return unrelated recent notes for no-match lexical queries", async () => {
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    const res = await engine.search("zzzz-not-a-note", { mode: "lexical", limit: 10 });
+
+    expect(res.results).toEqual([]);
+  });
+
+  it("clears the content index when search-affecting settings change", async () => {
+    jest.useFakeTimers();
+    const { app } = buildFixture();
+    const plugin = makePlugin(app);
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    await engine.search("orange", { mode: "lexical", limit: 10 });
+    expect(app.vault.cachedRead).toHaveBeenCalled();
+
+    const settingsListener = (app.workspace.on as jest.Mock).mock.calls.find(([event]) => event === "systemsculpt:settings-updated")?.[1];
+    expect(settingsListener).toBeDefined();
+    settingsListener();
+
+    (app.vault.cachedRead as jest.Mock).mockClear();
+    const res = await engine.search("fresh", { mode: "smart", limit: 10 });
+
+    expect(res.stats.metadataOnly).toBe(true);
+    expect(app.vault.cachedRead).not.toHaveBeenCalled();
+
+    engine.destroy();
+    jest.useRealTimers();
+  });
+
+  it("does not mutate the cached vault file array when selecting recents", async () => {
+    const { app, files } = buildFixture();
+    const plugin = makePlugin(app);
+    plugin.vaultFileCache = {
+      getAllFilesView: jest.fn(() => files),
+    };
+    const engine = new SystemSculptSearchEngine(app as any, plugin);
+
+    await engine.getRecent(2);
+
+    expect(files.map((file) => file.path)).toEqual([
+      "notes/orange-juice.md",
+      "notes/fresh-orange.md",
+      "notes/research.canvas",
+      "notes/unrelated.md",
+    ]);
+  });
+
   it("prefers full term coverage over recent one-term matches", async () => {
     const { app } = buildFixture();
     const plugin = makePlugin(app);


### PR DESCRIPTION
## Summary

- Replaces the old multi-mode SystemSculpt Search surface with one fast, unified search flow.
- Speeds up cold recents and metadata-first search by caching eligible file snapshots, title/path tokenization, and bounded token lookup structures.
- Uses embeddings opportunistically when available without blocking initial results.
- Stabilizes result ordering during metadata-to-index refreshes so a note the user is looking at does not suddenly disappear.
- Fixes the live Obsidian modal layout so recent-note previews no longer overlap or compress into each other.
- Preserves multilingual and symbol-only search matches with Unicode tokenization plus a bounded substring fallback for non-tokenizable queries.

## Verification

- `npm run check:all`
- `npm run test -- --runInBand src/services/search/__tests__/SystemSculptSearchEngine.test.ts src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts src/mcp-tools/filesystem/__tests__/utils-pure.test.ts`
- `npm run test -- --runInBand src/modals/__tests__/SystemSculptSearchModal.test.ts`
- `npm run check:plugin -- --summary`
- `git diff --check HEAD~2..HEAD`
- `gitleaks` staged-patch scans and final two-commit diff scan
- Review-fix focused rerun: `npm run test -- --runInBand src/services/search/__tests__/SystemSculptSearchEngine.test.ts src/services/search/__tests__/SystemSculptSearchEngine.semantic.test.ts`
- Review-fix full rerun: `npm run check:all`
- Review-fix staged scan: `gitleaks protect --no-banner --redact --staged`
- Live Obsidian screenshot after reload: `/tmp/systemsculpt-search-ui/search-after-simplify-final.png`
- CI: GitHub `unit` and `desktop-baselines` checks passed on PR #199
- macOS: `npm run test:native:desktop:baselines`
- Windows: `SYSTEMSCULPT_WINDOWS_SSH_HOST=tickblaze-utm npm run test:native:windows:clean-install`
- Windows: `SYSTEMSCULPT_WINDOWS_SSH_HOST=tickblaze-utm npm run test:native:windows:baselines`
- Android prepare/sync: `npm run test:native:android:debug:open -- --config ./systemsculpt-sync.android.json --headless --sync --reset-vault`
- Android runtime: `npm run test:native:android:extended`

## Notes

Native release-matrix testing passed for macOS desktop, Windows desktop, and Android emulator. iPad/iOS validation is intentionally skipped for this pass. Codex's P1 multilingual-tokenization finding is fixed in `28ef8e3` and the review thread is resolved.