### PR TITLE
feat(studio): support pasting and dropping media files

### DIFF
--- a/src/views/studio/SystemSculptStudioView.ts
+++ b/src/views/studio/SystemSculptStudioView.ts
@@ -137,11 +137,14 @@ import {
 } from "./systemsculpt-studio-view/StudioGraphHistoryState";
 import { materializeGraphClipboardPaste } from "./systemsculpt-studio-view/StudioGraphClipboardPasteMaterializer";
 import {
-  extractClipboardImageFiles,
+  extractClipboardMediaFiles,
   extractClipboardText,
-  normalizePastedImageMimeType,
+  isMediaIngestableExtension,
+  isMediaMimeType,
+  normalizePastedMediaMimeType,
 } from "./systemsculpt-studio-view/StudioClipboardData";
 import {
+  buildMediaIngestNode,
   buildPastedTextNode,
   materializePastedMediaNodes,
 } from "./systemsculpt-studio-view/StudioClipboardPasteNodes";
@@ -867,12 +870,12 @@ export class SystemSculptStudioView extends ItemView {
       return;
     }
 
-    const imageFiles = extractClipboardImageFiles(event);
-    if (imageFiles.length > 0) {
+    const mediaFiles = extractClipboardMediaFiles(event);
+    if (mediaFiles.length > 0) {
       event.preventDefault();
       event.stopPropagation();
       try {
-        await this.pasteClipboardImages(imageFiles);
+        await this.pasteClipboardMedia(mediaFiles);
       } catch (error) {
         this.setError(error);
       }
@@ -935,7 +938,7 @@ export class SystemSculptStudioView extends ItemView {
     new Notice("Pasted text as a Text node.");
   }
 
-  private async pasteClipboardImages(imageFiles: File[]): Promise<void> {
+  private async pasteClipboardMedia(mediaFiles: File[]): Promise<void> {
     if (!this.currentProject || !this.currentProjectPath) {
       return;
     }
@@ -950,13 +953,13 @@ export class SystemSculptStudioView extends ItemView {
     const studio = this.plugin.getStudioService();
     const project = this.currentProject;
     const nodes = await materializePastedMediaNodes({
-      imageFiles,
+      mediaFiles,
       mediaDefinition,
       anchor: this.resolvePasteAnchorPosition(),
       projectPath: this.currentProjectPath,
       nextNodeId: () => randomId("node"),
       normalizeNodePosition: (position) => this.normalizeNodePosition(position),
-      normalizeMimeType: normalizePastedImageMimeType,
+      normalizeMimeType: normalizePastedMediaMimeType,
       storeAsset: async (projectPath, bytes, mimeType) =>
         await studio.storeAsset(projectPath, bytes, mimeType),
       prettifyNodeKind,
@@ -980,8 +983,8 @@ export class SystemSculptStudioView extends ItemView {
     this.render();
     new Notice(
       createdNodeIds.length === 1
-        ? "Pasted 1 image as a Media node."
-        : `Pasted ${createdNodeIds.length} images as Media nodes.`
+        ? "Pasted 1 media file as a Media node."
+        : `Pasted ${createdNodeIds.length} media files as Media nodes.`
     );
   }
 
@@ -3850,6 +3853,8 @@ export class SystemSculptStudioView extends ItemView {
     notePaths: string[];
     folderPaths: string[];
     unsupportedPaths: string[];
+    vaultMediaPaths: string[];
+    externalMediaFiles: File[];
   }> {
     const references = new Set<string>();
     const pushReference = (value: string): void => {
@@ -3867,6 +3872,18 @@ export class SystemSculptStudioView extends ItemView {
         return;
       }
       payloads.add(next);
+    };
+
+    const vaultMediaPaths = new Set<string>();
+    const externalMediaFiles: File[] = [];
+    const externalMediaSeenKeys = new Set<string>();
+    const pushExternalMediaFile = (file: File): void => {
+      const key = `${file.name}:${file.type}:${file.size}:${file.lastModified}`;
+      if (externalMediaSeenKeys.has(key)) {
+        return;
+      }
+      externalMediaSeenKeys.add(key);
+      externalMediaFiles.push(file);
     };
 
     for (const preferredType of ["text/plain", "text/uri-list", "application/json"]) {
@@ -3908,6 +3925,17 @@ export class SystemSculptStudioView extends ItemView {
         typeof (file as unknown as { path?: unknown }).path === "string"
           ? String((file as unknown as { path?: string }).path)
           : "";
+      if (isMediaMimeType(file.type)) {
+        const vaultPath = absolutePath
+          ? this.resolveVaultPathFromAbsoluteFilePath(absolutePath)
+          : "";
+        if (vaultPath) {
+          vaultMediaPaths.add(vaultPath);
+        } else {
+          pushExternalMediaFile(file);
+        }
+        continue;
+      }
       if (!absolutePath) {
         continue;
       }
@@ -3936,13 +3964,19 @@ export class SystemSculptStudioView extends ItemView {
         continue;
       }
       if (item instanceof TFile) {
-        unsupportedPaths.add(item.path);
+        if (isMediaIngestableExtension(item.extension)) {
+          vaultMediaPaths.add(item.path);
+        } else {
+          unsupportedPaths.add(item.path);
+        }
       }
     }
     return {
       notePaths: Array.from(notePaths),
       folderPaths: Array.from(folderPaths),
       unsupportedPaths: Array.from(unsupportedPaths),
+      vaultMediaPaths: Array.from(vaultMediaPaths),
+      externalMediaFiles,
     };
   }
 
@@ -3969,15 +4003,17 @@ export class SystemSculptStudioView extends ItemView {
     }
 
     const dropped = await this.collectDroppedVaultItems(event.dataTransfer);
-    if (
-      dropped.notePaths.length === 0 &&
-      dropped.folderPaths.length === 0 &&
-      dropped.unsupportedPaths.length === 0
-    ) {
+    const totalCollected =
+      dropped.notePaths.length +
+      dropped.folderPaths.length +
+      dropped.unsupportedPaths.length +
+      dropped.vaultMediaPaths.length +
+      dropped.externalMediaFiles.length;
+    if (totalCollected === 0) {
       const hasPayload =
         (event.dataTransfer.types?.length || 0) > 0 || (event.dataTransfer.files?.length || 0) > 0;
       if (hasPayload) {
-        new Notice("Drop a markdown note from your vault to create a Note node.");
+        new Notice("Drop a markdown note or media file to create a node.");
       }
       return;
     }
@@ -3985,19 +4021,109 @@ export class SystemSculptStudioView extends ItemView {
     if (dropped.folderPaths.length > 0) {
       new Notice("Dropping folders into Studio is not supported yet.");
     }
-    if (dropped.notePaths.length === 0) {
-      if (dropped.unsupportedPaths.length > 0) {
-        new Notice("Only markdown notes can be dropped into Studio.");
-      }
-      return;
-    }
 
     const anchor =
       this.resolveGraphPositionFromClientPoint(event.clientX, event.clientY) ||
       this.resolvePasteAnchorPosition();
-    await this.insertVaultNoteNodes(dropped.notePaths, anchor, {
-      source: "drop",
+
+    let handledSomething = false;
+
+    if (dropped.vaultMediaPaths.length > 0 || dropped.externalMediaFiles.length > 0) {
+      try {
+        await this.dropMediaIntoStudio({
+          vaultMediaPaths: dropped.vaultMediaPaths,
+          externalMediaFiles: dropped.externalMediaFiles,
+          anchor,
+        });
+        handledSomething = true;
+      } catch (error) {
+        this.setError(error);
+      }
+    }
+
+    if (dropped.notePaths.length > 0) {
+      await this.insertVaultNoteNodes(dropped.notePaths, anchor, {
+        source: "drop",
+      });
+      handledSomething = true;
+    }
+
+    if (!handledSomething && dropped.unsupportedPaths.length > 0) {
+      new Notice("Only markdown notes and media files can be dropped into Studio.");
+    }
+  }
+
+  private async dropMediaIntoStudio(options: {
+    vaultMediaPaths: string[];
+    externalMediaFiles: File[];
+    anchor: { x: number; y: number };
+  }): Promise<void> {
+    if (!this.currentProject || !this.currentProjectPath) {
+      return;
+    }
+    const mediaDefinition = this.nodeDefinitions.find(
+      (definition) => definition.kind === "studio.media_ingest"
+    );
+    if (!mediaDefinition) {
+      throw new Error("Media node definition is unavailable.");
+    }
+
+    const { vaultMediaPaths, externalMediaFiles, anchor } = options;
+    const project = this.currentProject;
+    const newNodes: StudioNodeInstance[] = [];
+
+    const pushNodeForPath = (sourcePath: string): void => {
+      newNodes.push(
+        buildMediaIngestNode({
+          mediaDefinition,
+          sourcePath,
+          anchor,
+          index: newNodes.length,
+          nextNodeId: () => randomId("node"),
+          normalizeNodePosition: (position) => this.normalizeNodePosition(position),
+          prettifyNodeKind,
+          cloneConfigDefaults: (definition) => cloneConfigDefaults(definition),
+        })
+      );
+    };
+
+    for (const vaultPath of vaultMediaPaths) {
+      pushNodeForPath(vaultPath);
+    }
+
+    if (externalMediaFiles.length > 0) {
+      const studio = this.plugin.getStudioService();
+      for (const file of externalMediaFiles) {
+        const mimeType = normalizePastedMediaMimeType(file.type);
+        const bytes = await file.arrayBuffer();
+        const asset = await studio.storeAsset(this.currentProjectPath, bytes, mimeType);
+        pushNodeForPath(asset.path);
+      }
+    }
+
+    if (newNodes.length === 0) {
+      return;
+    }
+
+    const changed = this.commitCurrentProjectMutation("graph.node.create", (currentProject) => {
+      currentProject.graph.nodes.push(...newNodes);
+      return true;
     });
+    if (!changed) {
+      return;
+    }
+
+    const lastNode = newNodes[newNodes.length - 1];
+    this.graphInteraction.selectOnlyNode(lastNode.id);
+    this.graphInteraction.clearPendingConnection();
+    this.recomputeEntryNodes(project);
+    this.render();
+
+    new Notice(
+      newNodes.length === 1
+        ? "Added 1 media file as a Media node."
+        : `Added ${newNodes.length} media files as Media nodes.`
+    );
   }
 
   private async revealPathInFinder(path: string): Promise<void> {

--- a/src/views/studio/systemsculpt-studio-view/StudioClipboardData.ts
+++ b/src/views/studio/systemsculpt-studio-view/StudioClipboardData.ts
@@ -1,12 +1,64 @@
-export function normalizePastedImageMimeType(rawMimeType: string): string {
+const MEDIA_MIME_PREFIXES = ["image/", "video/", "audio/"] as const;
+
+const IMAGE_EXTENSIONS_FOR_INGEST = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "webp",
+  "gif",
+  "bmp",
+  "tiff",
+  "avif",
+  "svg",
+]);
+const VIDEO_EXTENSIONS_FOR_INGEST = new Set([
+  "mp4",
+  "mov",
+  "mkv",
+  "webm",
+  "avi",
+  "m4v",
+  "mpeg",
+  "mpg",
+]);
+const AUDIO_EXTENSIONS_FOR_INGEST = new Set([
+  "mp3",
+  "wav",
+  "m4a",
+  "aac",
+  "ogg",
+  "oga",
+  "flac",
+  "opus",
+  "weba",
+]);
+
+export function isMediaMimeType(rawMimeType: string): boolean {
   const normalized = String(rawMimeType || "").trim().toLowerCase();
-  if (normalized.startsWith("image/")) {
+  return MEDIA_MIME_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+export function isMediaIngestableExtension(extension: string): boolean {
+  const normalized = String(extension || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\./, "");
+  return (
+    IMAGE_EXTENSIONS_FOR_INGEST.has(normalized) ||
+    VIDEO_EXTENSIONS_FOR_INGEST.has(normalized) ||
+    AUDIO_EXTENSIONS_FOR_INGEST.has(normalized)
+  );
+}
+
+export function normalizePastedMediaMimeType(rawMimeType: string): string {
+  const normalized = String(rawMimeType || "").trim().toLowerCase();
+  if (isMediaMimeType(normalized)) {
     return normalized;
   }
   return "image/png";
 }
 
-export function extractClipboardImageFiles(event: ClipboardEvent): File[] {
+export function extractClipboardMediaFiles(event: ClipboardEvent): File[] {
   const clipboard = event.clipboardData;
   if (!clipboard) {
     return [];
@@ -20,7 +72,7 @@ export function extractClipboardImageFiles(event: ClipboardEvent): File[] {
         continue;
       }
       const file = item.getAsFile();
-      if (!file || !String(file.type || "").toLowerCase().startsWith("image/")) {
+      if (!file || !isMediaMimeType(file.type)) {
         continue;
       }
       const key = `${file.name}:${file.type}:${file.size}:${file.lastModified}`;
@@ -38,7 +90,7 @@ export function extractClipboardImageFiles(event: ClipboardEvent): File[] {
 
   if (clipboard.files && clipboard.files.length > 0) {
     for (const file of Array.from(clipboard.files)) {
-      if (!file || !String(file.type || "").toLowerCase().startsWith("image/")) {
+      if (!file || !isMediaMimeType(file.type)) {
         continue;
       }
       const key = `${file.name}:${file.type}:${file.size}:${file.lastModified}`;

--- a/src/views/studio/systemsculpt-studio-view/StudioClipboardPasteNodes.ts
+++ b/src/views/studio/systemsculpt-studio-view/StudioClipboardPasteNodes.ts
@@ -36,8 +36,46 @@ export function buildPastedTextNode(options: {
   };
 }
 
+export function buildMediaIngestNode(options: {
+  mediaDefinition: StudioNodeDefinition;
+  sourcePath: string;
+  anchor: { x: number; y: number };
+  index: number;
+  nextNodeId: () => string;
+  normalizeNodePosition: (position: { x: number; y: number }) => { x: number; y: number };
+  prettifyNodeKind: (kind: string) => string;
+  cloneConfigDefaults: (definition: StudioNodeDefinition) => Record<string, unknown>;
+}): StudioNodeInstance {
+  const {
+    mediaDefinition,
+    sourcePath,
+    anchor,
+    index,
+    nextNodeId,
+    normalizeNodePosition,
+    prettifyNodeKind,
+    cloneConfigDefaults,
+  } = options;
+  return {
+    id: nextNodeId(),
+    kind: mediaDefinition.kind,
+    version: mediaDefinition.version,
+    title: prettifyNodeKind(mediaDefinition.kind),
+    position: normalizeNodePosition({
+      x: anchor.x + (index % 5) * 38,
+      y: anchor.y + Math.floor(index / 5) * 38,
+    }),
+    config: {
+      ...cloneConfigDefaults(mediaDefinition),
+      sourcePath,
+    },
+    continueOnError: false,
+    disabled: false,
+  };
+}
+
 export async function materializePastedMediaNodes(options: {
-  imageFiles: File[];
+  mediaFiles: File[];
   mediaDefinition: StudioNodeDefinition;
   anchor: { x: number; y: number };
   projectPath: string;
@@ -49,7 +87,7 @@ export async function materializePastedMediaNodes(options: {
   cloneConfigDefaults: (definition: StudioNodeDefinition) => Record<string, unknown>;
 }): Promise<StudioNodeInstance[]> {
   const {
-    imageFiles,
+    mediaFiles,
     mediaDefinition,
     anchor,
     projectPath,
@@ -62,27 +100,23 @@ export async function materializePastedMediaNodes(options: {
   } = options;
 
   const output: StudioNodeInstance[] = [];
-  for (let index = 0; index < imageFiles.length; index += 1) {
-    const imageFile = imageFiles[index];
-    const mimeType = normalizeMimeType(imageFile.type);
-    const bytes = await imageFile.arrayBuffer();
+  for (let index = 0; index < mediaFiles.length; index += 1) {
+    const mediaFile = mediaFiles[index];
+    const mimeType = normalizeMimeType(mediaFile.type);
+    const bytes = await mediaFile.arrayBuffer();
     const asset = await storeAsset(projectPath, bytes, mimeType);
-    output.push({
-      id: nextNodeId(),
-      kind: mediaDefinition.kind,
-      version: mediaDefinition.version,
-      title: prettifyNodeKind(mediaDefinition.kind),
-      position: normalizeNodePosition({
-        x: anchor.x + (index % 5) * 38,
-        y: anchor.y + Math.floor(index / 5) * 38,
-      }),
-      config: {
-        ...cloneConfigDefaults(mediaDefinition),
+    output.push(
+      buildMediaIngestNode({
+        mediaDefinition,
         sourcePath: asset.path,
-      },
-      continueOnError: false,
-      disabled: false,
-    });
+        anchor,
+        index,
+        nextNodeId,
+        normalizeNodePosition,
+        prettifyNodeKind,
+        cloneConfigDefaults,
+      })
+    );
   }
 
   return output;


### PR DESCRIPTION
## Summary

Pasting or dropping a video/audio file into a Studio view now creates a Media ingest node, matching the existing image-paste behavior. Previously both paths were filtered to image MIME types only and silently dropped everything else.

## What changed

- **Clipboard filter widened** (`StudioClipboardData.ts`) to accept `image/`, `video/`, and `audio/` MIME types. Adds `isMediaIngestableExtension` for vault `TFile` routing in the drop handler.
- **Drop handler** (`SystemSculptStudioView.ts`) now classifies media files separately from markdown:
  - **Vault media files** → media ingest nodes referencing the vault path directly (no copy).
  - **External media files** (Finder drag, etc.) → written via `studio.storeAsset()` into the hash-addressed asset blob (`SystemSculpt/Studio/.assets/blob/[hash].[ext]`), mirroring the existing paste flow exactly.
- **Helper extraction** (`StudioClipboardPasteNodes.ts`): pulled `buildMediaIngestNode` out so paste and drop share node construction.

## Compatibility

- Existing image paste/drop behavior unchanged.
- No node schema changes — `media_ingest` already declared `mediaKinds: ["image", "video", "audio"]`.
- No vault duplication for media files already in the vault.

## Test plan

- [x] `npm run check:plugin:fast` (tsc, bundle, script-tests, jest) — passes
- [ ] Manual: paste a clipboard mp4 in a Studio view → Media node appears with usable `sourcePath`
- [ ] Manual: drag an mp4 from Finder into a Studio view → Media node appears, asset stored in `.assets/blob/`
- [ ] Manual: drag an mp4 already in the vault into a Studio view → Media node appears with the vault path (no copy)
- [ ] Manual: regression — paste/drop image, drop markdown note still work