### PR TITLE
feat: hydrate managed model metadata from server

### DIFF
--- a/src/services/ModelManagementService.ts
+++ b/src/services/ModelManagementService.ts
@@ -3,6 +3,7 @@ import type { SystemSculptModel } from "../types";
 import type { SystemSculptTextModelSourceMode } from "../types/llm";
 import { SYSTEMSCULPT_PI_EXECUTION_MODEL_ID } from "./pi/PiCanonicalIds";
 import { buildManagedSystemSculptModel, isManagedSystemSculptModelId } from "./systemsculpt/ManagedSystemSculptModel";
+import { resolveManagedSystemSculptModelContract } from "./systemsculpt/ManagedSystemSculptRemoteConfig";
 
 async function loadPiTextCatalogModule(): Promise<typeof import("./pi-native/PiTextCatalog")> {
   return await import("./pi-native/PiTextCatalog");
@@ -71,7 +72,8 @@ export class ModelManagementService {
     }
 
     // Default: route through the managed SystemSculpt hosted model
-    const managedModel = buildManagedSystemSculptModel(this.plugin);
+    const managedContract = await resolveManagedSystemSculptModelContract(this.plugin);
+    const managedModel = buildManagedSystemSculptModel(this.plugin, managedContract);
     const baseModel = resolvedModel || managedModel;
 
     return {

--- a/src/services/pi-native/PiTextCatalog.ts
+++ b/src/services/pi-native/PiTextCatalog.ts
@@ -1,6 +1,7 @@
 import type SystemSculptPlugin from "../../main";
 import type { SystemSculptModel } from "../../types/llm";
 import { buildManagedSystemSculptModel } from "../systemsculpt/ManagedSystemSculptModel";
+import { resolveManagedSystemSculptModelContract } from "../systemsculpt/ManagedSystemSculptRemoteConfig";
 import { PlatformContext } from "../PlatformContext";
 import { listConfiguredRemoteProviderModels } from "../providerRuntime/RemoteProviderCatalog";
 
@@ -22,7 +23,8 @@ function logPiCatalogFailure(
 export async function listPiTextCatalogModels(
   plugin: SystemSculptPlugin
 ): Promise<SystemSculptModel[]> {
-  const models: SystemSculptModel[] = [buildManagedSystemSculptModel(plugin)];
+  const managedContract = await resolveManagedSystemSculptModelContract(plugin);
+  const models: SystemSculptModel[] = [buildManagedSystemSculptModel(plugin, managedContract)];
   const existingIds = new Set(models.map((m) => m.id));
 
   const remoteProviderModels = listConfiguredRemoteProviderModels(plugin);

--- a/src/services/pi-native/__tests__/PiTextCatalog.test.ts
+++ b/src/services/pi-native/__tests__/PiTextCatalog.test.ts
@@ -1,10 +1,20 @@
 import { listPiTextCatalogModels } from "../PiTextCatalog";
 import { PlatformContext } from "../../PlatformContext";
+import { MANAGED_SYSTEMSCULPT_MODEL_CONTRACT } from "../../systemsculpt/ManagedSystemSculptContract";
+import { clearManagedSystemSculptModelContractCacheForTests } from "../../systemsculpt/ManagedSystemSculptRemoteConfig";
+
+const mockPlatformRequest = jest.fn();
 
 jest.mock("../../PlatformContext", () => ({
   PlatformContext: {
     get: jest.fn(),
   },
+}));
+
+jest.mock("../../PlatformRequestClient", () => ({
+  PlatformRequestClient: jest.fn().mockImplementation(() => ({
+    request: mockPlatformRequest,
+  })),
 }));
 
 jest.mock("../../pi/PiTextModels", () => ({
@@ -21,6 +31,12 @@ const { listConfiguredRemoteProviderModels } = jest.requireMock("../../providerR
 describe("PiTextCatalog", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    clearManagedSystemSculptModelContractCacheForTests();
+    mockPlatformRequest.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
     (PlatformContext.get as jest.Mock).mockReturnValue({
       supportsDesktopOnlyFeatures: () => true,
     });
@@ -43,6 +59,12 @@ describe("PiTextCatalog", () => {
       piAuthMode: "hosted",
       piRemoteAvailable: true,
       piLocalAvailable: false,
+      context_length: MANAGED_SYSTEMSCULPT_MODEL_CONTRACT.contextLength,
+      capabilities: [...MANAGED_SYSTEMSCULPT_MODEL_CONTRACT.capabilities],
+      top_provider: expect.objectContaining({
+        context_length: MANAGED_SYSTEMSCULPT_MODEL_CONTRACT.contextLength,
+        max_completion_tokens: MANAGED_SYSTEMSCULPT_MODEL_CONTRACT.maxCompletionTokens,
+      }),
     });
   });
 
@@ -89,6 +111,7 @@ describe("PiTextCatalog", () => {
       id: "systemsculpt@@systemsculpt/ai-agent",
       description: "Add an active SystemSculpt license in Setup to use SystemSculpt.",
     });
+    expect(mockPlatformRequest).not.toHaveBeenCalled();
   });
 
   it("keeps mobile limited to the managed SystemSculpt model", async () => {
@@ -139,5 +162,42 @@ describe("PiTextCatalog", () => {
       "openrouter@@openai/gpt-5.4-mini",
     ]);
     expect(listLocalPiTextModelsAsSystemModels).not.toHaveBeenCalled();
+  });
+
+  it("hydrates managed model metadata from the website plugin config when available", async () => {
+    mockPlatformRequest.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        api: {
+          configured_managed_model: {
+            context_window: 196_608,
+            max_completion_tokens: 24_576,
+            capabilities: ["chat", "reasoning", "vision", "tools"],
+            modality: "text+image->text",
+          },
+        },
+      }),
+    });
+    listLocalPiTextModelsAsSystemModels.mockResolvedValue([]);
+
+    const models = await listPiTextCatalogModels({
+      manifest: { version: "5.1.0" },
+      settings: { serverUrl: "http://localhost:3000", licenseKey: "license_test", licenseValid: true },
+    } as any);
+
+    expect(mockPlatformRequest).toHaveBeenCalledWith(expect.objectContaining({
+      url: expect.stringContaining("/api/plugin/config"),
+      method: "GET",
+      licenseKey: "license_test",
+    }));
+    expect(models[0]).toMatchObject({
+      context_length: 196_608,
+      capabilities: ["chat", "reasoning", "vision", "tools"],
+      top_provider: expect.objectContaining({
+        context_length: 196_608,
+        max_completion_tokens: 24_576,
+      }),
+    });
   });
 });

--- a/src/services/systemsculpt/ManagedSystemSculptContract.ts
+++ b/src/services/systemsculpt/ManagedSystemSculptContract.ts
@@ -1,0 +1,30 @@
+import {
+  SYSTEMSCULPT_PI_CANONICAL_MODEL_ID,
+  SYSTEMSCULPT_PI_EXECUTION_MODEL_ID,
+  SYSTEMSCULPT_PI_PROVIDER_ID,
+  SYSTEMSCULPT_PI_PROVIDER_MODEL_ID,
+} from "../pi/PiCanonicalIds";
+
+export type ManagedSystemSculptModelContract = {
+  id: string;
+  providerId: string;
+  providerModelId: string;
+  executionModelId: string;
+  name: string;
+  contextLength: number;
+  maxCompletionTokens: number;
+  capabilities: readonly string[];
+  modality: string;
+};
+
+export const MANAGED_SYSTEMSCULPT_MODEL_CONTRACT: ManagedSystemSculptModelContract = {
+  id: SYSTEMSCULPT_PI_CANONICAL_MODEL_ID,
+  providerId: SYSTEMSCULPT_PI_PROVIDER_ID,
+  providerModelId: SYSTEMSCULPT_PI_PROVIDER_MODEL_ID,
+  executionModelId: SYSTEMSCULPT_PI_EXECUTION_MODEL_ID,
+  name: "SystemSculpt",
+  contextLength: 262_144,
+  maxCompletionTokens: 32_768,
+  capabilities: ["chat", "reasoning", "vision", "tools"],
+  modality: "text+image->text",
+} as const;

--- a/src/services/systemsculpt/ManagedSystemSculptModel.ts
+++ b/src/services/systemsculpt/ManagedSystemSculptModel.ts
@@ -1,12 +1,11 @@
 import type SystemSculptPlugin from "../../main";
 import type { SystemSculptModel } from "../../types/llm";
 import { ensureCanonicalId } from "../../utils/modelUtils";
+import { SYSTEMSCULPT_PI_CANONICAL_MODEL_ID } from "../pi/PiCanonicalIds";
 import {
-  SYSTEMSCULPT_PI_CANONICAL_MODEL_ID,
-  SYSTEMSCULPT_PI_EXECUTION_MODEL_ID,
-  SYSTEMSCULPT_PI_PROVIDER_ID,
-  SYSTEMSCULPT_PI_PROVIDER_MODEL_ID,
-} from "../pi/PiCanonicalIds";
+  MANAGED_SYSTEMSCULPT_MODEL_CONTRACT,
+  type ManagedSystemSculptModelContract,
+} from "./ManagedSystemSculptContract";
 
 function hasActiveSystemSculptLicense(plugin: Pick<SystemSculptPlugin, "settings">): boolean {
   const settings = plugin?.settings || {};
@@ -28,33 +27,34 @@ export function hasManagedSystemSculptAccess(
 }
 
 export function buildManagedSystemSculptModel(
-  plugin: Pick<SystemSculptPlugin, "settings">
+  plugin: Pick<SystemSculptPlugin, "settings">,
+  contract: ManagedSystemSculptModelContract = MANAGED_SYSTEMSCULPT_MODEL_CONTRACT
 ): SystemSculptModel {
   const hasLicense = hasActiveSystemSculptLicense(plugin);
 
   return {
-    id: SYSTEMSCULPT_PI_CANONICAL_MODEL_ID,
-    name: "SystemSculpt",
+    id: contract.id,
+    name: contract.name,
     description: hasLicense
       ? "The managed SystemSculpt model for chat across desktop and mobile."
       : "Add an active SystemSculpt license in Setup to use SystemSculpt.",
-    provider: SYSTEMSCULPT_PI_PROVIDER_ID,
+    provider: contract.providerId,
     sourceMode: "systemsculpt",
-    sourceProviderId: SYSTEMSCULPT_PI_PROVIDER_ID,
+    sourceProviderId: contract.providerId,
     identifier: {
-      providerId: SYSTEMSCULPT_PI_PROVIDER_ID,
-      modelId: SYSTEMSCULPT_PI_PROVIDER_MODEL_ID,
-      displayName: "SystemSculpt",
+      providerId: contract.providerId,
+      modelId: contract.providerModelId,
+      displayName: contract.name,
     },
-    piExecutionModelId: SYSTEMSCULPT_PI_EXECUTION_MODEL_ID,
+    piExecutionModelId: contract.executionModelId,
     piAuthMode: "hosted",
     piRemoteAvailable: true,
     piLocalAvailable: false,
-    context_length: 256_000,
-    capabilities: ["chat", "reasoning"],
+    context_length: contract.contextLength,
+    capabilities: [...contract.capabilities],
     supported_parameters: ["tools"],
     architecture: {
-      modality: "text+image->text",
+      modality: contract.modality,
       tokenizer: "systemsculpt-managed",
       instruct_type: null,
     },
@@ -65,8 +65,8 @@ export function buildManagedSystemSculptModel(
       request: "0",
     },
     top_provider: {
-      context_length: 256_000,
-      max_completion_tokens: 32_768,
+      context_length: contract.contextLength,
+      max_completion_tokens: contract.maxCompletionTokens,
       is_moderated: false,
     },
   };

--- a/src/services/systemsculpt/ManagedSystemSculptRemoteConfig.ts
+++ b/src/services/systemsculpt/ManagedSystemSculptRemoteConfig.ts
@@ -1,0 +1,136 @@
+import type SystemSculptPlugin from "../../main";
+import { WEBSITE_API_BASE_URL } from "../../constants/api";
+import { PlatformRequestClient } from "../PlatformRequestClient";
+import {
+  MANAGED_SYSTEMSCULPT_MODEL_CONTRACT,
+  type ManagedSystemSculptModelContract,
+} from "./ManagedSystemSculptContract";
+
+type PluginConfigManagedModel = {
+  display_name?: unknown;
+  context_window?: unknown;
+  max_completion_tokens?: unknown;
+  capabilities?: unknown;
+  modality?: unknown;
+};
+
+type PluginConfigResponse = {
+  api?: {
+    configured_managed_model?: PluginConfigManagedModel | null;
+  };
+};
+
+type ContractCacheEntry = {
+  licenseKey: string;
+  expiresAt: number;
+  contract: ManagedSystemSculptModelContract;
+};
+
+const SUCCESS_CACHE_TTL_MS = 5 * 60 * 1000;
+const FALLBACK_CACHE_TTL_MS = 60 * 1000;
+
+let cachedContract: ContractCacheEntry | null = null;
+
+function toPositiveInteger(value: unknown): number | null {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return Math.floor(parsed);
+}
+
+function toStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => String(item || "").trim())
+    .filter((item) => item.length > 0);
+}
+
+function normalizeRemoteManagedModel(
+  remote: PluginConfigManagedModel | null | undefined
+): ManagedSystemSculptModelContract | null {
+  if (!remote || typeof remote !== "object") {
+    return null;
+  }
+
+  const contextLength = toPositiveInteger(remote.context_window);
+  const maxCompletionTokens = toPositiveInteger(remote.max_completion_tokens);
+  if (!contextLength || !maxCompletionTokens) {
+    return null;
+  }
+
+  const capabilities = toStringList(remote.capabilities);
+  const modality = String(remote.modality || "").trim();
+
+  return {
+    ...MANAGED_SYSTEMSCULPT_MODEL_CONTRACT,
+    contextLength,
+    maxCompletionTokens,
+    capabilities: capabilities.length > 0
+      ? capabilities
+      : MANAGED_SYSTEMSCULPT_MODEL_CONTRACT.capabilities,
+    modality: modality || MANAGED_SYSTEMSCULPT_MODEL_CONTRACT.modality,
+  };
+}
+
+async function fetchRemoteManagedModelContract(
+  plugin: Pick<SystemSculptPlugin, "settings" | "manifest">
+): Promise<ManagedSystemSculptModelContract | null> {
+  const licenseKey = String(plugin.settings?.licenseKey || "").trim();
+  if (!licenseKey || plugin.settings?.licenseValid !== true) {
+    return null;
+  }
+
+  const requestClient = new PlatformRequestClient();
+  const response = await requestClient.request({
+    url: `${WEBSITE_API_BASE_URL}/config`,
+    method: "GET",
+    licenseKey,
+    headers: {
+      "X-SystemSculpt-Client": "obsidian-plugin",
+      "x-plugin-version": String(plugin.manifest?.version || "0.0.0"),
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = (await response.json()) as PluginConfigResponse;
+  return normalizeRemoteManagedModel(payload?.api?.configured_managed_model);
+}
+
+export async function resolveManagedSystemSculptModelContract(
+  plugin: Pick<SystemSculptPlugin, "settings" | "manifest">
+): Promise<ManagedSystemSculptModelContract> {
+  const licenseKey = String(plugin.settings?.licenseKey || "").trim();
+  if (!licenseKey || plugin.settings?.licenseValid !== true) {
+    return MANAGED_SYSTEMSCULPT_MODEL_CONTRACT;
+  }
+
+  const now = Date.now();
+  if (
+    cachedContract &&
+    cachedContract.licenseKey === licenseKey &&
+    cachedContract.expiresAt > now
+  ) {
+    return cachedContract.contract;
+  }
+
+  const remoteContract = await fetchRemoteManagedModelContract(plugin).catch(() => null);
+  const contract = remoteContract || MANAGED_SYSTEMSCULPT_MODEL_CONTRACT;
+  cachedContract = {
+    licenseKey,
+    expiresAt: now + (remoteContract ? SUCCESS_CACHE_TTL_MS : FALLBACK_CACHE_TTL_MS),
+    contract,
+  };
+  return contract;
+}
+
+export function clearManagedSystemSculptModelContractCacheForTests(): void {
+  cachedContract = null;
+}


### PR DESCRIPTION
## Summary
- Keep the plugin routed through the stable `systemsculpt/ai-agent` alias
- Add a managed SystemSculpt model contract fallback for offline/no-license catalog states
- Hydrate managed model context, max output, capabilities, and modality from `/api/plugin/config` when a valid license can fetch server metadata

## Verification
- `npm test -- --runTestsByPath src/services/pi-native/__tests__/PiTextCatalog.test.ts`
- `npm run check:plugin:fast`
- `git diff --check`
