### PR TITLE
fix: harden ChatView continuation recovery

### DIFF
--- a/docs/design/chatview-continuation-session-rework-plan.md
+++ b/docs/design/chatview-continuation-session-rework-plan.md
@@ -1,0 +1,310 @@
+# ChatView Continuation And Session Rework Plan
+
+Date: 2026-04-26
+
+## Goal
+
+Make ChatView continuation boringly reliable.
+
+The user should always understand what is happening during a turn, especially when the assistant is thinking, calling tools, executing tools, waiting on a hosted continuation, retrying, or failing after partial work. A submitted user message must not randomly disappear after the system has accepted it. Completed local tool work must not vanish from the visible transcript because a later hosted continuation returned empty.
+
+## Live Failure Evidence
+
+- A realistic vault discovery prompt succeeded: ChatView listed a scenario folder, read relevant notes, ignored the unrelated note, and answered with the expected root cause, owner, due date, impact, and source files.
+- A follow-up realistic write/readback prompt failed with `The hosted agent returned an empty response.` The requested output file was not created.
+- A heavier live task listed and read files, kept the progress counter visible for the wait, then failed with `The hosted agent returned an empty continuation after tool execution.` The output report was not created.
+- Before progress plumbing changes, the visible UI could sit in a silent gap after tool rows completed. After progress plumbing changes, the visible status stayed attached as `Preparing... 0:50`, which confirms the status surface direction is right but the continuation/session contract is still broken.
+
+## Root Causes
+
+1. **Hosted continuation can be empty after valid tool results.**
+   The plugin shapes OpenAI-compatible history with assistant `tool_calls` and matching `tool` messages, but the active hosted Workers AI path can still proxy a successful empty stream. The website route does not currently enforce "content, another tool call, or typed error" for post-tool continuations.
+
+2. **ChatView uses preflight-style rollback for partially committed turns.**
+   `resetFailedAssistantTurn()` removes the submitted user message from memory/DOM and restores the prompt to the composer. That may be acceptable before the turn is committed, but it is wrong after assistant/tool work has been rendered or saved.
+
+3. **DOM, memory, and disk are not updated atomically on failure.**
+   The user message is saved before streaming. Tool results can be saved before continuation. The failure path can remove DOM without removing or saving the corresponding memory state, causing visible transcript drift.
+
+4. **Streaming completion classification is too coarse.**
+   `StreamingController` returns only `completed`, `aborted`, or `empty`. Reasoning-only, no-events, and empty-after-seed all collapse into `empty`, so the turn loop cannot make precise retry/recovery decisions.
+
+5. **Retries are blind repeats.**
+   Empty continuation retries change the UI status but do not change the server-visible request or prompt. If the backend/provider deterministically returns an empty continuation for a transcript, the client repeats the same failure.
+
+6. **Progress ownership was split across stream lifecycle and turn lifecycle.**
+   The new `ChatTurnProgressController` moves this in the right direction, but the final design should make turn progress the only owner for visible turn status.
+
+## Target State Model
+
+Every chat send should have an explicit turn transaction. The source of truth is `ChatView.messages`; DOM is rendered from that state, not manually patched as an alternate truth.
+
+States:
+
+- `composer_draft`: text only exists in the composer.
+- `submitted_user`: user message has been accepted, rendered, and saved. It should stay visible unless the failure happened before commit.
+- `assistant_draft`: streaming shell exists but has no committed visible content or tool call.
+- `assistant_committed`: assistant emitted visible content or a tool call. Preserve it.
+- `tool_execution_committed`: local tool result has completed and is durable evidence. Preserve it.
+- `continuing`: waiting for hosted continuation after one or more local tool results.
+- `retrying_continuation`: empty/no-events/reasoning-only continuation is being retried.
+- `failed_after_commit`: turn failed after the submitted user, assistant, or tool work committed. Keep committed transcript rows and append a compact failure status.
+- `completed`: final answer was emitted and the turn closed cleanly.
+
+## Ownership Boundaries
+
+### `InputHandler`
+
+Owns turn orchestration:
+
+- create a turn transaction
+- submit the user message
+- stream assistant rounds
+- execute local hosted tools
+- persist intermediate tool results
+- retry continuation
+- call failure recovery with enough metadata to distinguish preflight failure from post-commit failure
+
+### `StreamingController`
+
+Owns stream assembly and classification:
+
+- assemble reasoning/content/tool-call parts
+- preserve seeded parts during continuation
+- return richer completion states:
+  - `completed`
+  - `aborted`
+  - `no_events`
+  - `reasoning_only`
+  - `empty_after_seed`
+- never decide whether to remove committed user/tool state
+
+### `ChatTurnProgressController`
+
+Owns visible turn status:
+
+- one elapsed timer per turn
+- status labels for preparing, thinking, using tools, running tools, continuing, retrying, failed, completed
+- reattach across message rerenders
+- clear every old target indicator/footnote when the turn ends
+
+### `ChatView`
+
+Owns transcript state and recovery:
+
+- replace broad `resetFailedAssistantTurn()` usage with a commit-aware recovery path
+- keep submitted user messages after commit
+- keep completed tool rows after commit
+- remove only uncommitted assistant drafts
+- persist failure markers through `saveChat()`
+
+### `ContextFileService` And `toChatCompletionsMessages`
+
+Own transport correctness:
+
+- expand compact assistant/tool histories
+- synthesize missing tool result messages for completed local tool calls
+- remap tool-call ids and matching `tool_call_id`s together
+- provide debug validation that every assistant tool call has a following matching tool result before a continuation request is sent
+
+### Website `/api/v1/chat/completions`
+
+Own hosted continuation semantics:
+
+- if a transcript ends with assistant tool calls plus matching tool results, the next response must contain visible assistant content, another tool call, or a typed error
+- Workers AI path must track whether a stream emitted content/reasoning/tool-call payloads
+- empty successful streams must fail, retry with a fallback route, or return a typed continuation error
+- add a Workers AI continuation regression test
+
+## Implementation Task List
+
+### Phase 1: Freeze The Contract With Tests
+
+- Add deterministic InputHandler test for a two-tool, three-round hosted turn:
+  - round 1 emits reasoning + `mcp-filesystem_list_items` + `toolUse`
+  - local execution completes
+  - round 2 emits reasoning + `mcp-filesystem_read` + `toolUse`
+  - local execution completes
+  - round 3 emits final content
+  - assert one user message, one assistant message, completed tool calls, final content, no duplicate IDs, no blank assistant
+- Add deterministic failure test for empty continuation after completed tools:
+  - user message stays in transcript
+  - completed tool rows stay in transcript
+  - composer may optionally contain retry text, but transcript is not rolled back
+  - failure marker is visible/persisted
+- Add StreamingController tests for `no_events`, `reasoning_only`, and `empty_after_seed`.
+- Add progress tests for reattachment and cleanup across multiple message targets.
+- Add SystemSculptService request-preview validation for generated continuation transcripts:
+  - assistant `tool_calls` are followed by matching `tool` messages
+  - remapped IDs stay consistent
+
+### Phase 2: Turn Transaction Model
+
+- Introduce a small `ChatTurnTransaction` or equivalent internal object.
+- Track:
+  - `turnId`
+  - submitted user message ID/text
+  - assistant message ID
+  - committed phase
+  - completed tool count
+  - latest stream completion classification
+  - failure reason
+- InputHandler should pass transaction metadata into ChatView failure recovery.
+- Avoid adding broad framework abstractions; keep it close to ChatView/InputHandler.
+
+### Phase 3: Commit-Aware Failure Recovery
+
+- Replace default catch-all `resetFailedAssistantTurn()` with `recoverFailedTurn(transaction, error)`.
+- Pre-commit failures:
+  - restore composer
+  - remove transient user draft if it was never saved
+- Post-user-commit failures:
+  - keep the user message
+  - remove only uncommitted empty assistant shell
+  - show a compact error status
+- Post-tool-commit failures:
+  - keep the user message
+  - keep assistant tool rows and completed results
+  - append/update failure status on the assistant turn
+  - do not visually erase tool evidence
+- Save after recovery so disk matches memory/DOM.
+
+### Phase 4: Rich Stream Classification
+
+- Change `StreamCompletionState` from `completed | aborted | empty` to include:
+  - `no_events`
+  - `reasoning_only`
+  - `empty_after_seed`
+- Track `eventCount`, reasoning output, content output, and tool output in StreamingController.
+- InputHandler retry policy:
+  - retry `no_events`
+  - retry `reasoning_only` only when no content/tool output arrived
+  - after tools, convert exhausted retries into `failed_after_commit`, not rollback
+  - log classification metadata for debug snapshots
+
+### Phase 5: Continuation Prompt Guardrail
+
+- When retrying after a post-tool empty continuation, add a minimal server-visible continuation hint rather than blindly repeating the exact transcript.
+- Keep this hint transport-local; do not pollute visible user transcript.
+- Example intent:
+  - "The previous continuation produced no assistant content after tool results. Continue from the provided tool results and either call the next tool or provide the final answer."
+- Add a test proving the retry request differs from the first continuation request.
+
+### Phase 6: Website Hosted Contract
+
+In `/Users/systemsculpt/gits/systemsculpt-website`:
+
+- Add Workers AI regression coverage for:
+  - assistant tool call history + matching tool result -> final content
+  - empty Workers AI stream after tool result -> typed error or fallback
+- Track streamed payload classes on the Workers AI branch:
+  - role only
+  - content
+  - reasoning
+  - tool call
+  - finish only
+- Treat role-only/finish-only success as a contract failure.
+- For tool-result continuations, prefer one of:
+  - fallback to the Pi/OpenAI-compatible path
+  - retry with explicit continuation instruction
+  - return typed `EMPTY_TOOL_CONTINUATION` error
+- Do not charge credits for empty contract-failure completions.
+
+### Phase 7: Native And Live Proof
+
+- Run deterministic Jest first; native/live model tests are proof, not the main gate.
+- Run `chatview-stress` after code-level tests pass.
+- Run live private-vault scenarios:
+  - find/read folder notes
+  - write handoff file and read it back
+  - multi-tool report with list/read/write/readback
+- Use Computer Use screenshots during a long turn to confirm the progress surface remains visible.
+
+## Acceptance Criteria
+
+- Submitted user message never disappears after it has been accepted into the transcript.
+- Completed tool calls and results remain visible after a later continuation failure.
+- Empty/reasoning-only continuations do not create persisted blank assistant messages.
+- Progress status remains visible through preparing, thinking, running tools, continuation wait, retry, and failure.
+- The elapsed timer does not reset between tool execution and hosted continuation in a single turn.
+- The transcript, DOM, and saved markdown agree after both success and failure.
+- Transport preview proves every assistant tool call has a matching tool result before hosted continuation.
+- Website hosted route cannot silently proxy an empty successful continuation after tool results.
+- Live write/readback task creates the requested output file and verifies it.
+
+## Verification Commands
+
+Plugin focused tests:
+
+```bash
+npm test -- --runInBand \
+  src/views/chatview/__tests__/input-handler-tool-loop.test.ts \
+  src/views/chatview/__tests__/streaming-controller.test.ts \
+  src/views/chatview/controllers/__tests__/ChatTurnProgressController.test.ts \
+  src/views/chatview/handlers/__tests__/MessageElements.test.ts \
+  src/services/__tests__/SystemSculptService.test.ts \
+  src/services/__tests__/ContextFileService.test.ts
+```
+
+Plugin full ChatView slice:
+
+```bash
+npm test -- src/views/chatview
+```
+
+Plugin build and live reload:
+
+```bash
+npm run build
+npm run sync:local
+node scripts/reload-local-obsidian-plugin.mjs
+```
+
+## Implementation Notes
+
+Implemented on 2026-04-26:
+
+- `StreamingController` now distinguishes `no_events`, `reasoning_only`, and `empty_after_seed` instead of collapsing every non-renderable stream into `empty`.
+- `InputHandler` now tracks hosted turn transaction metadata, retries empty continuations with a transport-only continuation hint, and marks post-commit failures as recoverable transcript failures.
+- `ChatView` now has committed-turn recovery: submitted user messages remain visible, completed tool rows remain visible, transient empty assistant drafts are removed, and a compact failure marker is persisted on the assistant turn.
+- `ChatTurnProgressController` owns the visible turn status for the whole hosted loop, including retrying and local tool execution phases.
+- The website Workers AI stream path now checks that a stream contains assistant content, reasoning, or tool calls before forwarding final success and charging credits. Empty Workers AI tool continuations return a typed `EMPTY_TOOL_CONTINUATION` stream error instead.
+
+Verification completed:
+
+- Plugin focused continuation tests: `47` tests passed across `StreamingController`, `InputHandler`, committed-turn recovery, and `SystemSculptService`.
+- Full ChatView slice: `57` suites / `395` tests passed.
+- Plugin checker: TypeScript, bundle, script tests, and unit tests passed through `npm run check:plugin`.
+- Website route regression: `tests/plugin/chat-completions-api.test.ts` passed with the new empty Workers AI continuation case.
+- Website type check: `npm run type-check` passed.
+- Native desktop ChatView stress: `5/5` passes against the reloaded `private-vault` Obsidian instance.
+- Live local Pi/Codex tool task: completed `3` filesystem tool calls, wrote the output file, and replied with the exact token.
+- Live managed SystemSculpt tool task: completed `2` filesystem tool calls, wrote the output file, and replied with the exact token.
+
+Known environment warning:
+
+- `npm run sync:local` updated the macOS vaults and reloaded `private-vault`, but the Windows UTM mirror target timed out over SSH at `192.168.64.2:22`.
+
+Native proof:
+
+```bash
+node testing/native/desktop-automation/run.mjs \
+  --case chatview-stress \
+  --repeat 3 \
+  --pause-ms 750 \
+  --no-reload
+```
+
+Website route tests:
+
+```bash
+pnpm vitest --run tests/plugin/chat-completions-api.test.ts
+```
+
+## Non-Goals
+
+- Do not redesign the whole ChatView visual language in this pass.
+- Do not add another parallel transcript format.
+- Do not hide backend/provider empty continuation failures behind fake success.
+- Do not make live model behavior the only regression gate.
+- Do not preserve local/custom-provider compatibility branches that conflict with the hosted SystemSculpt path.

--- a/src/services/SystemSculptService.ts
+++ b/src/services/SystemSculptService.ts
@@ -365,6 +365,7 @@ export class SystemSculptService {
     model: string;
     contextFiles?: Set<string>;
     systemPromptOverride?: string;
+    transientSystemPromptSuffix?: string;
     emitNotices?: boolean;
     allowTools?: boolean;
   }): Promise<PreparedChatRequest> {
@@ -375,6 +376,7 @@ export class SystemSculptService {
 	      model,
 	      contextFiles,
 	      systemPromptOverride,
+	      transientSystemPromptSuffix,
 	      emitNotices = false,
 	    } = options;
 
@@ -458,6 +460,16 @@ export class SystemSculptService {
       finalSystemPrompt = AGENT_TOOL_INSTRUCTIONS;
     }
     // else: no custom prompt, agent mode OFF: no system prompt (undefined)
+
+    const transientPromptSuffix =
+      typeof transientSystemPromptSuffix === "string"
+        ? transientSystemPromptSuffix.trim()
+        : "";
+    if (transientPromptSuffix.length > 0) {
+      finalSystemPrompt = finalSystemPrompt
+        ? `${finalSystemPrompt.trim()}\n\n${transientPromptSuffix}`
+        : transientPromptSuffix;
+    }
 
     let tools: OpenAITool[] = [];
     if (
@@ -1103,6 +1115,7 @@ export class SystemSculptService {
     onError,
     contextFiles,
     systemPromptOverride,
+    transientSystemPromptSuffix,
     signal,
     forcedToolName,
     maxTokens,
@@ -1120,6 +1133,7 @@ export class SystemSculptService {
     onError?: (error: string) => void;
     contextFiles?: Set<string>;
     systemPromptOverride?: string;
+    transientSystemPromptSuffix?: string;
     signal?: AbortSignal;
     forcedToolName?: string;
     maxTokens?: number;
@@ -1146,6 +1160,7 @@ export class SystemSculptService {
         model,
         contextFiles,
         systemPromptOverride,
+        transientSystemPromptSuffix,
         emitNotices: true,
         allowTools,
       });

--- a/src/services/__tests__/SystemSculptService.test.ts
+++ b/src/services/__tests__/SystemSculptService.test.ts
@@ -583,6 +583,40 @@ describe("SystemSculptService", () => {
     expect(mcpService.getAvailableTools).toHaveBeenCalledTimes(1);
   });
 
+  it("adds transient continuation hints to the prepared system prompt without storing them as chat messages", async () => {
+    const plugin = createPlugin();
+    const service = SystemSculptService.getInstance(plugin);
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response('data: {"choices":[{"delta":{"content":"continued"}}]}\n\ndata: [DONE]\n\n', {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })
+    ) as any;
+
+    await collectEvents(
+      service.streamMessage({
+        messages: [{ role: "user", content: "Continue", message_id: "msg_1" } as any],
+        model: "systemsculpt@@systemsculpt/ai-agent",
+        transientSystemPromptSuffix: "Previous continuation was empty. Continue with final content.",
+      })
+    );
+
+    expect(contextFileService.prepareMessagesWithContext).toHaveBeenCalledWith(
+      [{ role: "user", content: "Continue", message_id: "msg_1" }],
+      new Set(),
+      true,
+      `${AGENT_PRESET.systemPrompt}\n\nPrevious continuation was empty. Continue with final content.`
+    );
+    const [url, fetchOptions] = (global.fetch as jest.Mock).mock.calls[0] || [];
+    expect(url).toBe("https://api.systemsculpt.test/api/v1/chat/completions");
+    expect(JSON.parse(fetchOptions.body)).toEqual({
+      model: "systemsculpt/ai-agent",
+      messages: [{ role: "user", content: "Continue" }],
+      stream: true,
+      tools: expect.any(Array),
+    });
+  });
+
   it("routes remote provider models through the remote provider stream executor", async () => {
     const plugin = createPlugin();
     const service = SystemSculptService.getInstance(plugin);

--- a/src/services/__tests__/pi-text-models.test.ts
+++ b/src/services/__tests__/pi-text-models.test.ts
@@ -2,6 +2,7 @@ import {
   buildLocalPiCanonicalModelId,
   buildLocalPiExecutionModelId,
   collectSharedPiProviderHints,
+  isSupportedOpenAiCodexChatModel,
   resolveLocalPiExecutionModelIdFromCanonical,
   toLocalPiSystemSculptModel,
 } from "../pi/PiTextModels";
@@ -67,5 +68,16 @@ describe("PiTextModels", () => {
       context_length: 1_000_000,
     });
     expect(model.supported_parameters).toEqual(["tools"]);
+  });
+
+  it("filters OpenAI Codex models that ChatGPT accounts cannot run", () => {
+    expect(isSupportedOpenAiCodexChatModel("openai-codex", "gpt-5.1")).toBe(false);
+    expect(isSupportedOpenAiCodexChatModel("openai-codex", "gpt-5.1-codex-max")).toBe(false);
+    expect(isSupportedOpenAiCodexChatModel("openai-codex", "gpt-5.2-codex")).toBe(false);
+    expect(isSupportedOpenAiCodexChatModel("openai-codex", "gpt-5.3-codex-spark")).toBe(false);
+    expect(isSupportedOpenAiCodexChatModel("openai-codex", "gpt-5.2")).toBe(true);
+    expect(isSupportedOpenAiCodexChatModel("openai-codex", "gpt-5.3-codex")).toBe(true);
+    expect(isSupportedOpenAiCodexChatModel("openai-codex", "gpt-5.4-mini")).toBe(true);
+    expect(isSupportedOpenAiCodexChatModel("openrouter", "openai/gpt-5.1")).toBe(true);
   });
 });

--- a/src/services/pi-native/PiTextCatalog.ts
+++ b/src/services/pi-native/PiTextCatalog.ts
@@ -38,11 +38,22 @@ export async function listPiTextCatalogModels(
   // On desktop, include all models from authenticated Pi providers
   if (PlatformContext.get().supportsDesktopOnlyFeatures()) {
     try {
-      const { listLocalPiTextModelsAsSystemModels } = await import("../pi/PiTextModels");
+      const {
+        isSupportedOpenAiCodexChatModel,
+        listLocalPiTextModelsAsSystemModels,
+      } = await import("../pi/PiTextModels");
       const localModels = await listLocalPiTextModelsAsSystemModels(plugin);
 
       // Deduplicate: skip any local model whose id already matches the managed model
       for (const model of localModels) {
+        if (
+          !isSupportedOpenAiCodexChatModel(
+            String(model.sourceProviderId || model.provider || ""),
+            String(model.piExecutionModelId || "").split("/").slice(1).join("/")
+          )
+        ) {
+          continue;
+        }
         if (!existingIds.has(model.id)) {
           models.push(model);
           existingIds.add(model.id);

--- a/src/services/pi-native/__tests__/PiTextCatalog.test.ts
+++ b/src/services/pi-native/__tests__/PiTextCatalog.test.ts
@@ -18,6 +18,12 @@ jest.mock("../../PlatformRequestClient", () => ({
 }));
 
 jest.mock("../../pi/PiTextModels", () => ({
+  isSupportedOpenAiCodexChatModel: jest.fn((providerId: string, modelId: string) => {
+    if (providerId !== "openai-codex") {
+      return true;
+    }
+    return !["gpt-5.1", "gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2-codex", "gpt-5.3-codex-spark"].includes(modelId);
+  }),
   listLocalPiTextModelsAsSystemModels: jest.fn(),
 }));
 
@@ -96,6 +102,47 @@ describe("PiTextCatalog", () => {
     expect(models.map((model) => model.id)).toEqual([
       "systemsculpt@@systemsculpt/ai-agent",
       "local-pi-openai@@gpt-4.1",
+    ]);
+  });
+
+  it("omits OpenAI Codex models rejected by ChatGPT-account Codex auth", async () => {
+    listLocalPiTextModelsAsSystemModels.mockResolvedValue([
+      {
+        id: "local-pi-openai-codex@@gpt-5.1",
+        name: "GPT-5.1",
+        provider: "openai-codex",
+        sourceMode: "pi_local",
+        sourceProviderId: "openai-codex",
+        piExecutionModelId: "openai-codex/gpt-5.1",
+        piLocalAvailable: true,
+      },
+      {
+        id: "local-pi-openai-codex@@gpt-5.4-mini",
+        name: "GPT-5.4 Mini",
+        provider: "openai-codex",
+        sourceMode: "pi_local",
+        sourceProviderId: "openai-codex",
+        piExecutionModelId: "openai-codex/gpt-5.4-mini",
+        piLocalAvailable: true,
+      },
+      {
+        id: "local-pi-openai-codex@@gpt-5.3-codex-spark",
+        name: "GPT-5.3 Codex Spark",
+        provider: "openai-codex",
+        sourceMode: "pi_local",
+        sourceProviderId: "openai-codex",
+        piExecutionModelId: "openai-codex/gpt-5.3-codex-spark",
+        piLocalAvailable: true,
+      },
+    ]);
+
+    const models = await listPiTextCatalogModels({
+      settings: { serverUrl: "http://localhost:3000", licenseKey: "license_test", licenseValid: true },
+    } as any);
+
+    expect(models.map((model) => model.id)).toEqual([
+      "systemsculpt@@systemsculpt/ai-agent",
+      "local-pi-openai-codex@@gpt-5.4-mini",
     ]);
   });
 

--- a/src/services/pi/PiTextModels.ts
+++ b/src/services/pi/PiTextModels.ts
@@ -60,6 +60,13 @@ export type LocalPiListedModel = {
   keywords: string[];
 };
 
+const OPENAI_CODEX_CHATGPT_SUPPORTED_MODEL_IDS = new Set([
+  "gpt-5.2",
+  "gpt-5.3-codex",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+]);
+
 async function loadPiSdkRuntimeModule(): Promise<
   typeof import("./PiSdkRuntime")
 > {
@@ -78,6 +85,17 @@ function stripPinnedDateSuffix(modelId: string): string {
 
 function normalizePiProviderId(value: unknown): string {
   return normalizeStudioPiProviderId(value);
+}
+
+export function isSupportedOpenAiCodexChatModel(providerId: string, modelId: string): boolean {
+  const normalizedProviderId = normalizePiProviderId(providerId);
+  if (normalizedProviderId !== "openai-codex") {
+    return true;
+  }
+
+  return OPENAI_CODEX_CHATGPT_SUPPORTED_MODEL_IDS.has(
+    String(modelId || "").trim().toLowerCase()
+  );
 }
 
 function toNumber(value: unknown): number {
@@ -251,7 +269,12 @@ export async function listLocalPiTextModels(
   const models: LocalPiListedModel[] = modelRegistry
     .getAvailable()
     .map((model) => toLocalPiListEntry(model))
-    .filter((model): model is LocalPiListedModel => !!model);
+    .filter((model): model is LocalPiListedModel => {
+      if (!model) {
+        return false;
+      }
+      return isSupportedOpenAiCodexChatModel(model.providerId, model.modelId);
+    });
 
   const byCanonicalId = new Map<string, LocalPiListedModel>();
   for (const model of models) {

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -27,6 +27,7 @@ import { classifyQuotaExceededError } from "./utils/quotaError";
 import { classifyStreamError, type StreamErrorKind } from "./utils/streamError";
 import { ChatErrorModal } from "./modals/ChatErrorModal";
 import type { ToolCall } from "../../types/toolCalls";
+import { TOOL_LOOP_ERROR_CODE } from "../../utils/tooling";
 import { tryCopyToClipboard } from "../../utils/clipboard";
 import { resolveAbsoluteVaultPath } from "../../utils/vaultPathUtils";
 import type { DocumentProcessingProgressEvent } from "../../types/documentProcessing";
@@ -65,6 +66,28 @@ import {
 } from "./modelSelection";
 
 export { CHAT_VIEW_TYPE };
+
+const OPENAI_CODEX_CHATGPT_SUPPORTED_MODEL_IDS = new Set([
+  "gpt-5.2",
+  "gpt-5.3-codex",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+]);
+
+function escapeMessageIdForSelector(messageId: string): string {
+  const cssEscape = (globalThis as any)?.CSS?.escape;
+  if (typeof cssEscape === "function") {
+    return cssEscape(messageId);
+  }
+
+  return String(messageId).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function isSupportedPersistedOpenAiCodexChatModel(modelId: string): boolean {
+  return OPENAI_CODEX_CHATGPT_SUPPORTED_MODEL_IDS.has(
+    String(modelId || "").trim().toLowerCase()
+  );
+}
 
 export class ChatView extends ItemView {
   public messages: ChatMessage[] = [];
@@ -415,6 +438,151 @@ export class ChatView extends ItemView {
     return mergedMessage;
   }
 
+  private shouldRecoverCommittedChatTurn(error: string | SystemSculptError): error is SystemSculptError {
+    if (!(error instanceof SystemSculptError)) {
+      return false;
+    }
+
+    return (
+      error.metadata?.recoverCommittedTurn === true ||
+      error.metadata?.errorCode === TOOL_LOOP_ERROR_CODE
+    );
+  }
+
+  private removeUnpersistedAssistantDraft(messageId: string | undefined): void {
+    const normalizedMessageId = String(messageId || "").trim();
+    if (!normalizedMessageId || !this.chatContainer) {
+      return;
+    }
+
+    const persisted = this.messages.some((message) => message.message_id === normalizedMessageId);
+    if (persisted) {
+      return;
+    }
+
+    const node = this.chatContainer.querySelector(
+      `.systemsculpt-message[data-message-id="${escapeMessageIdForSelector(normalizedMessageId)}"]`,
+    ) as HTMLElement | null;
+    removeMessageElement(node);
+  }
+
+  private findCommittedAssistantMessage(messageId: string | undefined): ChatMessage | null {
+    const normalizedMessageId = String(messageId || "").trim();
+    if (normalizedMessageId) {
+      const directMatch = this.messages.find(
+        (message) => message.role === "assistant" && message.message_id === normalizedMessageId
+      );
+      if (directMatch) {
+        return directMatch;
+      }
+    }
+
+    return [...this.messages].reverse().find((message) => message.role === "assistant") || null;
+  }
+
+  private formatCommittedTurnFailureText(errorMessage: string, error: SystemSculptError): string {
+    const completedToolCount = Number(error.metadata?.completedToolCount || 0);
+    const keptTools =
+      Number.isFinite(completedToolCount) && completedToolCount > 0
+        ? ` The ${completedToolCount === 1 ? "completed tool result was" : `${completedToolCount} completed tool results were`} kept in the transcript.`
+        : "";
+    const cleanMessage = String(errorMessage || "The hosted agent did not return a usable continuation.")
+      .trim()
+      .replace(/[.!?]+$/g, "");
+
+    return `SystemSculpt stopped after the turn was already in progress: ${cleanMessage}.${keptTools}`;
+  }
+
+  private appendFailurePart(message: ChatMessage, failureText: string): ChatMessage {
+    const normalizedParts = this.messageRenderer.normalizeMessageToParts(message);
+    const existingParts = Array.isArray(normalizedParts?.parts) ? [...normalizedParts.parts] : [];
+    const alreadyMarked = existingParts.some(
+      (part) =>
+        part.type === "content" &&
+        typeof part.data === "string" &&
+        part.data.includes("SystemSculpt stopped after the turn was already in progress")
+    );
+
+    if (alreadyMarked) {
+      return message;
+    }
+
+    const maxTimestamp = existingParts.reduce(
+      (max, part) => Math.max(max, Number(part.timestamp || 0)),
+      0
+    );
+    const timestamp = Math.max(Date.now(), maxTimestamp + 1);
+    const separator = existingParts.length > 0 ? "\n\n" : "";
+    const partText = `${separator}${failureText}`;
+    const currentContent = typeof message.content === "string" ? message.content.trim() : "";
+
+    return {
+      ...message,
+      content: currentContent ? `${currentContent}\n\n${failureText}` : failureText,
+      messageParts: [
+        ...existingParts,
+        {
+          id: `turn_failure-${timestamp}`,
+          type: "content",
+          timestamp,
+          data: partText,
+        },
+      ],
+    };
+  }
+
+  private async renderAssistantMessageUpdate(message: ChatMessage): Promise<void> {
+    const messageId = String(message.message_id || "").trim();
+    const messageEl = messageId && this.chatContainer
+      ? this.chatContainer.querySelector(
+          `.systemsculpt-message[data-message-id="${escapeMessageIdForSelector(messageId)}"]`
+        ) as HTMLElement | null
+      : null;
+
+    if (!messageEl) {
+      await this.addMessage(message.role, message.content, message.message_id, message);
+      return;
+    }
+
+    try {
+      this.messageRenderer.renderUnifiedMessageParts(
+        messageEl,
+        this.messageRenderer.normalizeMessageToParts(message).parts,
+        false
+      );
+      this.messageRenderer.finalizeInlineBlocks(messageEl);
+    } catch {
+      await messageHandling.reloadAllMessages(this);
+    }
+  }
+
+  private async recoverCommittedChatTurn(error: SystemSculptError, errorMessage: string): Promise<void> {
+    const assistantMessageId =
+      typeof error.metadata?.assistantMessageId === "string"
+        ? error.metadata.assistantMessageId
+        : undefined;
+    const committedAssistantMessageId =
+      typeof error.metadata?.committedAssistantMessageId === "string"
+        ? error.metadata.committedAssistantMessageId
+        : undefined;
+
+    this.removeUnpersistedAssistantDraft(assistantMessageId);
+
+    const committedAssistant = this.findCommittedAssistantMessage(committedAssistantMessageId || assistantMessageId);
+    const failureText = this.formatCommittedTurnFailureText(errorMessage, error);
+    const message =
+      committedAssistant ||
+      ({
+        role: "assistant",
+        content: "",
+        message_id: this.generateMessageId(),
+      } as ChatMessage);
+
+    const updatedMessage = this.appendFailurePart(message, failureText);
+    await this.persistAssistantMessage(updatedMessage, { syncPiTranscript: false });
+    await this.renderAssistantMessageUpdate(updatedMessage);
+  }
+
   public async handleError(error: string | SystemSculptError): Promise<void> {
     let errorMessage = typeof error === "string" ? error : error.message;
     const automationRequestActive = this.inputHandler?.isAutomationRequestActive?.() === true;
@@ -441,6 +609,17 @@ export class ChatView extends ItemView {
       error instanceof SystemSculptError && typeof error.metadata?.upstreamMessage === "string"
         ? String(error.metadata.upstreamMessage)
         : "";
+
+    const shouldRecoverCommittedTurn =
+      typeof (this as any).shouldRecoverCommittedChatTurn === "function" &&
+      (this as any).shouldRecoverCommittedChatTurn(error);
+    if (shouldRecoverCommittedTurn) {
+      await this.recoverCommittedChatTurn(error as SystemSculptError, errorMessage);
+      if (!automationRequestActive) {
+        new Notice("The turn stopped, but the submitted message and completed tool results were kept.", 8000);
+      }
+      return;
+    }
 
     if (isContextOverflowErrorMessage(errorMessage) || isContextOverflowErrorMessage(upstreamMessage)) {
       await this.resetFailedAssistantTurn();
@@ -774,6 +953,14 @@ export class ChatView extends ItemView {
       resolveLegacyPiTextSelectionId,
     } = await loadPiTextMigrationModule();
     const normalizedRawModelId = normalizeLegacyPiTextSelectionId(rawModelId);
+    const parsedLocalPiMatch = normalizedRawModelId.match(/^local-pi-openai-codex@@(.+)$/i);
+    if (
+      parsedLocalPiMatch &&
+      !isSupportedPersistedOpenAiCodexChatModel(parsedLocalPiMatch[1])
+    ) {
+      return getManagedSystemSculptModelId();
+    }
+
     const tryResolve = (models: any[]): string => {
       const directMatch = findModelById(models, rawModelId);
       if (directMatch?.id) {
@@ -866,7 +1053,7 @@ export class ChatView extends ItemView {
   private removeUserMessageDomById(messageId: string): void {
     if (!this.chatContainer) return;
     const node = this.chatContainer.querySelector(
-      `.systemsculpt-message[data-message-id="${CSS.escape(messageId)}"]`,
+      `.systemsculpt-message[data-message-id="${escapeMessageIdForSelector(messageId)}"]`,
     ) as HTMLElement | null;
     removeMessageElement(node);
   }

--- a/src/views/chatview/InputHandler.ts
+++ b/src/views/chatview/InputHandler.ts
@@ -15,7 +15,8 @@ import type SystemSculptPlugin from "../../main";
 import { validateBrowserFileSize } from "../../utils/FileValidator";
 import { MessagePart } from "../../types";
 import { SlashCommandMenu, SlashCommand } from "./SlashCommandMenu";
-import { StreamingController, type StreamTurnResult } from "./controllers/StreamingController";
+import { StreamingController, type StreamCompletionState, type StreamTurnResult } from "./controllers/StreamingController";
+import { ChatTurnProgressController } from "./controllers/ChatTurnProgressController";
 import { messageHandling } from "./messageHandling";
 import { AtMentionMenu } from "../../components/AtMentionMenu";
 import { LARGE_TEXT_THRESHOLDS, LARGE_TEXT_MESSAGES, LargeTextHelpers } from "../../constants/largeText";
@@ -68,6 +69,17 @@ export interface InputHandlerOptions {
 }
 
 export type AutomationApprovalMode = "interactive" | "auto-approve" | "deny";
+
+type HostedTurnTransaction = {
+  turnId: string;
+  submittedUserMessageId?: string;
+  submittedUserText?: string;
+  assistantMessageId?: string;
+  committedAssistantMessageId?: string;
+  committedPhase: "submitted_user" | "assistant_committed" | "tool_execution_committed";
+  completedToolCount: number;
+  latestStreamCompletionState?: StreamCompletionState;
+};
 
 export class InputHandler extends Component {
   private app: App;
@@ -281,7 +293,9 @@ export class InputHandler extends Component {
 
   private async streamAssistantTurn(
     signal: AbortSignal,
-    includeContextFiles: boolean
+    includeContextFiles: boolean,
+    turnProgress?: ChatTurnProgressController,
+    options?: { transientSystemPromptSuffix?: string }
   ): Promise<StreamTurnResult> {
     const continuationTarget = this.getHostedContinuationTarget();
     const { messageEl } = continuationTarget ?? this.createAssistantMessageContainer();
@@ -295,6 +309,7 @@ export class InputHandler extends Component {
 
     const contextFiles = includeContextFiles ? this.chatView.contextManager.getContextFiles() : new Set<string>();
     const selectedModelId = this.getSelectedModelIdForChat();
+    turnProgress?.attach(messageEl);
 
     // Read the selected prompt content if one is active
     let systemPromptOverride: string | undefined;
@@ -318,6 +333,9 @@ export class InputHandler extends Component {
         webSearchEnabled: this.webSearchEnabled,
         ...(this.agentModeEnabled ? {} : { allowTools: false }),
         ...(systemPromptOverride ? { systemPromptOverride } : {}),
+        ...(options?.transientSystemPromptSuffix
+          ? { transientSystemPromptSuffix: options.transientSystemPromptSuffix }
+          : {}),
       debug: this.chatView.getDebugLogService?.()?.createStreamLogger({
         chatId: this.getChatId(),
         assistantMessageId: messageId,
@@ -330,7 +348,9 @@ export class InputHandler extends Component {
       messageEl,
       messageId,
       signal,
-      continuationTarget?.seedParts
+      continuationTarget?.seedParts,
+      turnProgress?.getTracker(),
+      !!turnProgress
     );
   }
 
@@ -528,12 +548,16 @@ export class InputHandler extends Component {
   }
 
   private failHostedToolTurn(message: string, statusCode: number, metadata?: Record<string, unknown>): never {
+    const submitted = this.submittedInputSnapshot;
     const error = new SystemSculptError(
       message,
       ERROR_CODES.STREAM_ERROR,
       statusCode,
       {
         errorCode: TOOL_LOOP_ERROR_CODE,
+        recoverCommittedTurn: true,
+        submittedUserMessageId: submitted?.messageId,
+        submittedUserText: submitted?.rawText,
         ...metadata,
       }
     );
@@ -545,67 +569,172 @@ export class InputHandler extends Component {
     throw error;
   }
 
+  private isEmptyStreamCompletion(completionState: StreamCompletionState): boolean {
+    return (
+      completionState === "empty" ||
+      completionState === "no_events" ||
+      completionState === "reasoning_only" ||
+      completionState === "empty_after_seed"
+    );
+  }
+
+  private buildEmptyContinuationRetryHint(completionState: StreamCompletionState, retryAttempt: number): string {
+    const classification =
+      completionState === "reasoning_only"
+        ? "reasoning but no visible assistant content or tool call"
+        : completionState === "empty_after_seed"
+          ? "no new assistant output after the existing tool results"
+          : "no assistant output";
+
+    return [
+      `The previous continuation attempt returned ${classification}.`,
+      `This is retry ${retryAttempt}. Continue from the completed tool results already in the transcript.`,
+      "Either call the next needed tool or provide the final answer. Do not return an empty response.",
+    ].join(" ");
+  }
+
   private async runHostedAgentTurnLoop(signal: AbortSignal, includeContextFiles: boolean): Promise<void> {
     const maxToolContinuationRounds = 8;
+    const maxEmptyInitialRetries = 2;
     const maxEmptyContinuationRetries = 3;
     let completedToolContinuationRounds = 0;
+    let emptyInitialRetries = 0;
     let emptyContinuationRetries = 0;
     let hasExecutedHostedToolRound = false;
+    let transientSystemPromptSuffix: string | undefined;
+    const turnTransaction: HostedTurnTransaction = {
+      turnId: this.generateMessageId(),
+      submittedUserMessageId: this.submittedInputSnapshot?.messageId,
+      submittedUserText: this.submittedInputSnapshot?.rawText,
+      committedPhase: "submitted_user",
+      completedToolCount: 0,
+    };
+    const turnProgress = new ChatTurnProgressController({
+      showStreamingStatus: this.showStreamingStatus.bind(this),
+      hideStreamingStatus: this.hideStreamingStatus.bind(this),
+      updateStreamingStatus: this.updateStreamingStatus.bind(this),
+    });
 
-    while (completedToolContinuationRounds < maxToolContinuationRounds) {
-      const streamedTurn = await this.streamAssistantTurn(signal, includeContextFiles);
-      if (streamedTurn.completionState === "aborted") {
-        return;
-      }
+    turnProgress.begin();
 
-      if (streamedTurn.completionState === "empty") {
-        if (hasExecutedHostedToolRound && emptyContinuationRetries < maxEmptyContinuationRetries) {
-          emptyContinuationRetries += 1;
-          try {
-            errorLogger.debug("Retrying empty hosted continuation round", {
-              source: "InputHandler",
-              method: "runHostedAgentTurnLoop",
-              metadata: {
-                retryAttempt: emptyContinuationRetries,
-                maxEmptyContinuationRetries,
-                chatId: this.getChatId(),
-              },
-            });
-          } catch {}
-          continue;
+    try {
+      while (completedToolContinuationRounds < maxToolContinuationRounds) {
+        turnProgress.setStatus("preparing");
+        const streamedTurn = await this.streamAssistantTurn(
+          signal,
+          includeContextFiles,
+          turnProgress,
+          { transientSystemPromptSuffix }
+        );
+        turnTransaction.assistantMessageId = streamedTurn.messageId;
+        turnTransaction.latestStreamCompletionState = streamedTurn.completionState;
+        if (streamedTurn.completionState === "aborted") {
+          return;
         }
 
-        this.failHostedToolTurn(
-          hasExecutedHostedToolRound
-            ? "The hosted agent returned an empty continuation after tool execution."
-            : "The hosted agent returned an empty response.",
-          502,
-          {
-            reason: hasExecutedHostedToolRound ? "empty-continuation" : "empty-response",
-            emptyContinuationRetries,
+        if (this.isEmptyStreamCompletion(streamedTurn.completionState)) {
+          if (!hasExecutedHostedToolRound && emptyInitialRetries < maxEmptyInitialRetries) {
+            emptyInitialRetries += 1;
+            transientSystemPromptSuffix = undefined;
+            turnProgress.setStatus("retrying");
+            try {
+              errorLogger.debug("Retrying empty hosted initial turn", {
+                source: "InputHandler",
+                method: "runHostedAgentTurnLoop",
+                metadata: {
+                  retryAttempt: emptyInitialRetries,
+                  maxEmptyInitialRetries,
+                  chatId: this.getChatId(),
+                },
+              });
+            } catch {}
+            continue;
           }
-        );
+
+          if (hasExecutedHostedToolRound && emptyContinuationRetries < maxEmptyContinuationRetries) {
+            emptyContinuationRetries += 1;
+            transientSystemPromptSuffix = this.buildEmptyContinuationRetryHint(
+              streamedTurn.completionState,
+              emptyContinuationRetries
+            );
+            turnProgress.setStatus("retrying");
+            try {
+              errorLogger.debug("Retrying empty hosted continuation round", {
+                source: "InputHandler",
+                method: "runHostedAgentTurnLoop",
+                metadata: {
+                  retryAttempt: emptyContinuationRetries,
+                  maxEmptyContinuationRetries,
+                  chatId: this.getChatId(),
+                  completionState: streamedTurn.completionState,
+                },
+              });
+            } catch {}
+            continue;
+          }
+
+          this.failHostedToolTurn(
+            hasExecutedHostedToolRound
+              ? "The hosted agent returned an empty continuation after tool execution."
+              : "The hosted agent returned an empty response.",
+            502,
+            {
+              reason: hasExecutedHostedToolRound ? "empty-continuation" : "empty-response",
+              emptyInitialRetries,
+              emptyContinuationRetries,
+              latestStreamCompletionState: streamedTurn.completionState,
+              hasExecutedHostedToolRound,
+              assistantMessageId: turnTransaction.assistantMessageId,
+              committedAssistantMessageId: turnTransaction.committedAssistantMessageId,
+              submittedUserMessageId: turnTransaction.submittedUserMessageId,
+              submittedUserText: turnTransaction.submittedUserText,
+              committedPhase: turnTransaction.committedPhase,
+              completedToolCount: turnTransaction.completedToolCount,
+            }
+          );
+        }
+
+        emptyInitialRetries = 0;
+        emptyContinuationRetries = 0;
+        transientSystemPromptSuffix = undefined;
+        turnTransaction.committedPhase = "assistant_committed";
+        turnTransaction.committedAssistantMessageId = streamedTurn.messageId;
+        if (!this.shouldContinueHostedToolLoop(streamedTurn.message, streamedTurn.stopReason)) {
+          return;
+        }
+
+        turnProgress.attach(streamedTurn.messageEl);
+        turnProgress.setStatus("executing_tools");
+        const executedMessage = await this.executeHostedToolCalls(streamedTurn.message, signal);
+        await this.persistAssistantToolLoopUpdate(executedMessage);
+        turnProgress.attach(streamedTurn.messageEl);
+        hasExecutedHostedToolRound = true;
+        turnTransaction.committedPhase = "tool_execution_committed";
+        turnTransaction.completedToolCount += (executedMessage.tool_calls || []).filter(
+          (toolCall) => toolCall.state === "completed" || toolCall.state === "failed"
+        ).length;
+        completedToolContinuationRounds += 1;
       }
 
-      emptyContinuationRetries = 0;
-      if (!this.shouldContinueHostedToolLoop(streamedTurn.message, streamedTurn.stopReason)) {
-        return;
-      }
-
-      const executedMessage = await this.executeHostedToolCalls(streamedTurn.message, signal);
-      await this.persistAssistantToolLoopUpdate(executedMessage);
-      hasExecutedHostedToolRound = true;
-      completedToolContinuationRounds += 1;
+      this.failHostedToolTurn(
+        "The hosted agent exceeded the maximum tool continuation depth.",
+        500,
+        {
+          reason: "max-tool-continuation-depth",
+          maxToolContinuationRounds,
+          latestStreamCompletionState: turnTransaction.latestStreamCompletionState,
+          hasExecutedHostedToolRound,
+          assistantMessageId: turnTransaction.assistantMessageId,
+          committedAssistantMessageId: turnTransaction.committedAssistantMessageId,
+          submittedUserMessageId: turnTransaction.submittedUserMessageId,
+          submittedUserText: turnTransaction.submittedUserText,
+          committedPhase: turnTransaction.committedPhase,
+          completedToolCount: turnTransaction.completedToolCount,
+        }
+      );
+    } finally {
+      turnProgress.end();
     }
-
-    this.failHostedToolTurn(
-      "The hosted agent exceeded the maximum tool continuation depth.",
-      500,
-      {
-        reason: "max-tool-continuation-depth",
-        maxToolContinuationRounds,
-      }
-    );
   }
 
   private setupInput(): void {
@@ -1555,7 +1684,7 @@ export class InputHandler extends Component {
    */
   private cleanupAllStatusIndicators(): void {
     // Clean up any status indicators that might still be in the chat container
-    this.chatContainer?.querySelectorAll('.systemsculpt-streaming-status').forEach(el => {
+    this.chatContainer?.querySelectorAll('.systemsculpt-streaming-status, .ss-streaming-indicator').forEach(el => {
       el.remove();
     });
   }

--- a/src/views/chatview/StreamingMetricsTracker.ts
+++ b/src/views/chatview/StreamingMetricsTracker.ts
@@ -1,4 +1,10 @@
-export type StreamingStatus = "preparing" | "reasoning" | "content" | "tool_calls" | "executing_tools";
+export type StreamingStatus =
+  | "preparing"
+  | "reasoning"
+  | "content"
+  | "tool_calls"
+  | "executing_tools"
+  | "retrying";
 
 export interface StreamingMetrics {
   elapsedMs: number;
@@ -17,6 +23,7 @@ const STATUS_LABELS: Record<StreamingStatus, string> = {
   content: "Writing\u2026",
   tool_calls: "Using tools\u2026",
   executing_tools: "Running tools\u2026",
+  retrying: "Retrying response\u2026",
 };
 
 export class StreamingMetricsTracker {

--- a/src/views/chatview/__tests__/chatview-model-migration.test.ts
+++ b/src/views/chatview/__tests__/chatview-model-migration.test.ts
@@ -64,6 +64,24 @@ describe("ChatView loaded model migration", () => {
     ).resolves.toBe("systemsculpt@@systemsculpt/ai-agent");
   });
 
+  it("falls back from persisted OpenAI Codex models rejected by ChatGPT account auth", async () => {
+    const chatView = createChatView({
+      getCachedModels: jest.fn(() => [
+        {
+          id: "local-pi-openai-codex@@gpt-5.1",
+          provider: "openai-codex",
+          piExecutionModelId: "openai-codex/gpt-5.1",
+          piLocalAvailable: true,
+        },
+      ]),
+      getModels: jest.fn(async () => []),
+    });
+
+    await expect(
+      (chatView as any).resolveLoadedSelectedModelId("local-pi-openai-codex@@gpt-5.1")
+    ).resolves.toBe("systemsculpt@@systemsculpt/ai-agent");
+  });
+
   it("migrates stale local Pi chat selections using cached models", async () => {
     const getModels = jest.fn(async () => []);
     const chatView = createChatView({

--- a/src/views/chatview/__tests__/chatview-turn-recovery.test.ts
+++ b/src/views/chatview/__tests__/chatview-turn-recovery.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { ChatView } from "../ChatView";
+import { ERROR_CODES, SystemSculptError } from "../../../utils/errors";
+import { TOOL_LOOP_ERROR_CODE } from "../../../utils/tooling";
+import type { ChatMessage, MessagePart } from "../../../types";
+
+const contentPart = (id: string, text: string, timestamp = 1): MessagePart => ({
+  id,
+  type: "content",
+  timestamp,
+  data: text,
+});
+
+const createRecoverableView = (messages: ChatMessage[]) => {
+  const chatContainer = document.createElement("div");
+  const messageRenderer = {
+    normalizeMessageToParts: jest.fn((message: ChatMessage) => ({
+      parts:
+        message.messageParts ||
+        (typeof message.content === "string" && message.content.length > 0
+          ? [contentPart(`content-${message.message_id}`, message.content)]
+          : []),
+    })),
+    renderUnifiedMessageParts: jest.fn(),
+    finalizeInlineBlocks: jest.fn(),
+  };
+
+  const view = Object.create(ChatView.prototype) as ChatView & Record<string, any>;
+  view.messages = messages;
+  view.chatContainer = chatContainer;
+  view.messageRenderer = messageRenderer;
+  view.inputHandler = {
+    isAutomationRequestActive: jest.fn(() => true),
+    consumeSubmittedInputSnapshot: jest.fn(),
+    setInputText: jest.fn(),
+  };
+  view.getEffectiveSelectedModelId = jest.fn(() => "systemsculpt@@systemsculpt/ai-agent");
+  view.saveChat = jest.fn().mockResolvedValue(undefined);
+  view.isPiBackedChat = jest.fn(() => false);
+  view.getPiSessionFile = jest.fn(() => undefined);
+  view.generateMessageId = jest.fn(() => "assistant-failure");
+  view.addMessage = jest.fn().mockResolvedValue(undefined);
+  view.chatId = "chat-recovery";
+  view.isGenerating = false;
+  view.app = {} as any;
+
+  return { view, chatContainer, messageRenderer };
+};
+
+describe("ChatView committed turn recovery", () => {
+  it("keeps submitted user and completed tool rows when post-tool continuation fails", async () => {
+    const completedToolCall = {
+      id: "call_1",
+      messageId: "assistant-1",
+      request: {
+        id: "call_1",
+        type: "function",
+        function: {
+          name: "mcp-filesystem_read",
+          arguments: "{\"paths\":[\"alpha.md\"]}",
+        },
+      },
+      state: "completed",
+      timestamp: 2,
+      executionStartedAt: 2,
+      executionCompletedAt: 3,
+      result: {
+        success: true,
+        data: { contents: ["alpha"] },
+      },
+    } as any;
+
+    const messages: ChatMessage[] = [
+      {
+        role: "user",
+        content: "Read alpha.md and explain it.",
+        message_id: "user-1",
+      } as any,
+      {
+        role: "assistant",
+        content: "",
+        message_id: "assistant-1",
+        tool_calls: [completedToolCall],
+        messageParts: [
+          {
+            id: "tool-call-1",
+            type: "tool_call",
+            timestamp: 2,
+            data: completedToolCall,
+          },
+        ],
+      } as any,
+    ];
+
+    const { view, chatContainer, messageRenderer } = createRecoverableView(messages);
+    const assistantEl = document.createElement("div");
+    assistantEl.classList.add("systemsculpt-message");
+    assistantEl.dataset.messageId = "assistant-1";
+    assistantEl.appendChild(document.createElement("div")).classList.add("systemsculpt-message-content");
+    chatContainer.appendChild(assistantEl);
+
+    await ChatView.prototype.handleError.call(
+      view,
+      new SystemSculptError(
+        "The hosted agent returned an empty continuation after tool execution.",
+        ERROR_CODES.STREAM_ERROR,
+        502,
+        {
+          errorCode: TOOL_LOOP_ERROR_CODE,
+          recoverCommittedTurn: true,
+          reason: "empty-continuation",
+          assistantMessageId: "assistant-empty",
+          committedAssistantMessageId: "assistant-1",
+          committedPhase: "tool_execution_committed",
+          completedToolCount: 1,
+        }
+      )
+    );
+
+    expect(view.inputHandler.consumeSubmittedInputSnapshot).not.toHaveBeenCalled();
+    expect(view.messages).toHaveLength(2);
+    expect(view.messages[0]).toEqual(
+      expect.objectContaining({
+        role: "user",
+        content: "Read alpha.md and explain it.",
+      })
+    );
+    expect(view.messages[1].tool_calls?.[0]).toEqual(
+      expect.objectContaining({
+        id: "call_1",
+        state: "completed",
+        result: expect.objectContaining({ success: true }),
+      })
+    );
+    expect(view.messages[1].content).toContain("SystemSculpt stopped after the turn was already in progress");
+    expect(view.messages[1].messageParts?.some((part) =>
+      part.type === "content" &&
+      typeof part.data === "string" &&
+      part.data.includes("completed tool result was kept")
+    )).toBe(true);
+    expect(view.saveChat).toHaveBeenCalledTimes(1);
+    expect(messageRenderer.renderUnifiedMessageParts).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the user turn and replaces an unpersisted empty assistant draft with a visible failure marker", async () => {
+    const messages: ChatMessage[] = [
+      {
+        role: "user",
+        content: "Find the document and write the handoff.",
+        message_id: "user-1",
+      } as any,
+    ];
+
+    const { view, chatContainer } = createRecoverableView(messages);
+    const emptyAssistantEl = document.createElement("div");
+    emptyAssistantEl.classList.add("systemsculpt-message");
+    emptyAssistantEl.dataset.messageId = "assistant-empty";
+    chatContainer.appendChild(emptyAssistantEl);
+
+    await ChatView.prototype.handleError.call(
+      view,
+      new SystemSculptError(
+        "The hosted agent returned an empty response.",
+        ERROR_CODES.STREAM_ERROR,
+        502,
+        {
+          errorCode: TOOL_LOOP_ERROR_CODE,
+          recoverCommittedTurn: true,
+          reason: "empty-response",
+          assistantMessageId: "assistant-empty",
+          committedPhase: "submitted_user",
+          completedToolCount: 0,
+        }
+      )
+    );
+
+    expect(emptyAssistantEl.isConnected).toBe(false);
+    expect(view.inputHandler.consumeSubmittedInputSnapshot).not.toHaveBeenCalled();
+    expect(view.messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: "Find the document and write the handoff.",
+      }),
+      expect.objectContaining({
+        role: "assistant",
+        message_id: "assistant-failure",
+        content: expect.stringContaining("SystemSculpt stopped after the turn was already in progress"),
+      }),
+    ]);
+    expect(view.addMessage).toHaveBeenCalledWith(
+      "assistant",
+      expect.stringContaining("SystemSculpt stopped after the turn was already in progress"),
+      "assistant-failure",
+      expect.objectContaining({ message_id: "assistant-failure" })
+    );
+    expect(view.saveChat).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/views/chatview/__tests__/input-handler-tool-loop.test.ts
+++ b/src/views/chatview/__tests__/input-handler-tool-loop.test.ts
@@ -481,7 +481,7 @@ describe("InputHandler hosted tool loop", () => {
         } as any,
         messageEl: document.createElement("div"),
         completed: false,
-        completionState: "empty",
+        completionState: "reasoning_only",
       })
       .mockImplementationOnce(async () => {
         await (handler as any).onAssistantResponse(finalAssistantMessage);
@@ -498,6 +498,12 @@ describe("InputHandler hosted tool loop", () => {
     await handler.submitWithOverrides({ includeContextFiles: false });
 
     expect(streamAssistantTurn).toHaveBeenCalledTimes(3);
+    expect(streamAssistantTurn.mock.calls[2]?.[3]?.transientSystemPromptSuffix).toContain(
+      "previous continuation attempt"
+    );
+    expect(streamAssistantTurn.mock.calls[2]?.[3]?.transientSystemPromptSuffix).toContain(
+      "Do not return an empty response"
+    );
     expect(aiService.executeHostedToolCall).toHaveBeenCalledTimes(1);
     expect(onError).not.toHaveBeenCalled();
     expect(messages).toEqual(
@@ -519,10 +525,66 @@ describe("InputHandler hosted tool loop", () => {
     );
   });
 
+  it("retries an initial empty hosted turn before failing the user task", async () => {
+    const { handler, messages, onError } = createHostedToolLoopHarness();
+
+    const finalAssistantMessage: ChatMessage = {
+      role: "assistant",
+      content: "Found the note, wrote the handoff, and verified the output.",
+      message_id: "assistant-final",
+    } as any;
+
+    const streamAssistantTurn = jest.spyOn(handler as any, "streamAssistantTurn");
+    streamAssistantTurn
+      .mockResolvedValueOnce({
+        messageId: "assistant-empty",
+        message: {
+          role: "assistant",
+          content: "",
+          message_id: "assistant-empty",
+        } as any,
+        messageEl: document.createElement("div"),
+        completed: false,
+        completionState: "no_events",
+      })
+      .mockImplementationOnce(async () => {
+        await (handler as any).onAssistantResponse(finalAssistantMessage);
+        return {
+          messageId: "assistant-final",
+          message: finalAssistantMessage,
+          messageEl: document.createElement("div"),
+          completed: true,
+          completionState: "completed",
+        };
+      });
+
+    handler.setValue("Find a vault note, write a handoff file, then read it back.");
+    await handler.submitForAutomation({
+      includeContextFiles: false,
+      approvalMode: "auto-approve",
+      focusAfterSend: false,
+    });
+
+    expect(streamAssistantTurn).toHaveBeenCalledTimes(2);
+    expect(onError).not.toHaveBeenCalled();
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: "Find a vault note, write a handoff file, then read it back.",
+        }),
+        expect.objectContaining({
+          message_id: "assistant-final",
+          content: "Found the note, wrote the handoff, and verified the output.",
+        }),
+      ])
+    );
+  });
+
   it("surfaces an unrecoverable empty hosted turn instead of silently succeeding", async () => {
     const { handler, onError } = createHostedToolLoopHarness();
 
-    jest.spyOn(handler as any, "streamAssistantTurn").mockResolvedValue({
+    const streamAssistantTurn = jest.spyOn(handler as any, "streamAssistantTurn").mockResolvedValue({
       messageId: "assistant-empty",
       message: {
         role: "assistant",
@@ -531,7 +593,7 @@ describe("InputHandler hosted tool loop", () => {
       } as any,
       messageEl: document.createElement("div"),
       completed: false,
-      completionState: "empty",
+      completionState: "no_events",
     });
 
     handler.setValue("Tell me something.");
@@ -546,6 +608,107 @@ describe("InputHandler hosted tool loop", () => {
 
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError.mock.calls[0]?.[0]?.message || "").toContain("empty response");
+    expect(onError.mock.calls[0]?.[0]?.metadata).toEqual(
+      expect.objectContaining({
+        recoverCommittedTurn: true,
+        reason: "empty-response",
+        latestStreamCompletionState: "no_events",
+        committedPhase: "submitted_user",
+      })
+    );
+    expect(streamAssistantTurn).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps the submitted user message and completed tool result when continuation retries are exhausted", async () => {
+    const { aiService, handler, messages, onError } = createHostedToolLoopHarness();
+
+    const firstAssistantMessage: ChatMessage = {
+      role: "assistant",
+      content: "",
+      message_id: "assistant-1",
+      tool_calls: [
+        {
+          id: "call_1",
+          messageId: "assistant-1",
+          request: {
+            id: "call_1",
+            type: "function",
+            function: {
+              name: "mcp-filesystem_read",
+              arguments: "{\"paths\":[\"alpha.md\"]}",
+            },
+          },
+          state: "executing",
+          timestamp: 1,
+          executionStartedAt: 1,
+        },
+      ],
+      messageParts: [],
+    } as any;
+
+    const streamAssistantTurn = jest.spyOn(handler as any, "streamAssistantTurn");
+    streamAssistantTurn
+      .mockResolvedValueOnce({
+        messageId: "assistant-1",
+        message: firstAssistantMessage,
+        messageEl: document.createElement("div"),
+        completed: true,
+        completionState: "completed",
+        stopReason: "toolUse",
+      })
+      .mockResolvedValue({
+        messageId: "assistant-empty-continuation",
+        message: {
+          role: "assistant",
+          content: "",
+          message_id: "assistant-empty-continuation",
+        } as any,
+        messageEl: document.createElement("div"),
+        completed: false,
+        completionState: "empty_after_seed",
+      });
+
+    handler.setValue("Read the note and summarize it.");
+
+    await expect(
+      handler.submitForAutomation({
+        includeContextFiles: false,
+        approvalMode: "auto-approve",
+        focusAfterSend: false,
+      })
+    ).rejects.toThrow("empty continuation");
+
+    expect(streamAssistantTurn).toHaveBeenCalledTimes(5);
+    expect(aiService.executeHostedToolCall).toHaveBeenCalledTimes(1);
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: "Read the note and summarize it.",
+        }),
+        expect.objectContaining({
+          message_id: "assistant-1",
+          tool_calls: [
+            expect.objectContaining({
+              id: "call_1",
+              state: "completed",
+              result: expect.objectContaining({ success: true }),
+            }),
+          ],
+        }),
+      ])
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]?.metadata).toEqual(
+      expect.objectContaining({
+        recoverCommittedTurn: true,
+        reason: "empty-continuation",
+        latestStreamCompletionState: "empty_after_seed",
+        committedPhase: "tool_execution_committed",
+        completedToolCount: 1,
+        committedAssistantMessageId: "assistant-1",
+      })
+    );
   });
 
   it("streams using the chat's selected model instead of forcing managed SystemSculpt", async () => {

--- a/src/views/chatview/__tests__/streaming-controller.test.ts
+++ b/src/views/chatview/__tests__/streaming-controller.test.ts
@@ -64,7 +64,7 @@ describe("StreamingController stream behavior", () => {
     expect(onAssistantResponse).toHaveBeenCalledTimes(1);
   });
 
-  test("treats seeded continuations with no new renderable output as empty", async () => {
+  test("classifies seeded continuations with no new renderable output as empty_after_seed", async () => {
     const { controller, saveChat, onAssistantResponse } = createController();
 
     const stream = (async function* () {
@@ -94,7 +94,7 @@ describe("StreamingController stream behavior", () => {
     );
 
     expect(result.completed).toBe(false);
-    expect(result.completionState).toBe("empty");
+    expect(result.completionState).toBe("empty_after_seed");
     expect(saveChat).not.toHaveBeenCalled();
     expect(onAssistantResponse).not.toHaveBeenCalled();
     expect(messageEl.isConnected).toBe(true);
@@ -349,7 +349,7 @@ describe("StreamingController stream behavior", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
-  test("returns an empty completion state when stream has no renderable output", async () => {
+  test("returns no_events when stream has no output events", async () => {
     const { controller, saveChat, onAssistantResponse, onError } = createController();
 
     const stream = (async function* () {})();
@@ -362,14 +362,14 @@ describe("StreamingController stream behavior", () => {
     const result = await controller.stream(stream, messageEl, "assistant-empty", abortController.signal);
 
     expect(result.completed).toBe(false);
-    expect(result.completionState).toBe("empty");
+    expect(result.completionState).toBe("no_events");
     expect(saveChat).not.toHaveBeenCalled();
     expect(onAssistantResponse).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
     expect(messageEl.isConnected).toBe(false);
   });
 
-  test("treats reasoning-only terminal output as empty so blank assistant replies are not persisted", async () => {
+  test("classifies reasoning-only terminal output so blank assistant replies are not persisted", async () => {
     const { controller, saveChat, onAssistantResponse, onError } = createController();
 
     const stream = (async function* () {
@@ -389,7 +389,7 @@ describe("StreamingController stream behavior", () => {
     );
 
     expect(result.completed).toBe(false);
-    expect(result.completionState).toBe("empty");
+    expect(result.completionState).toBe("reasoning_only");
     expect(result.message.content).toBe("");
     expect(result.message.reasoning).toContain("Need to inspect the fixture carefully.");
     expect(saveChat).not.toHaveBeenCalled();

--- a/src/views/chatview/controllers/ChatTurnProgressController.ts
+++ b/src/views/chatview/controllers/ChatTurnProgressController.ts
@@ -1,0 +1,103 @@
+import {
+  StreamingMetricsTracker,
+  type StreamingMetrics,
+  type StreamingStatus,
+} from "../StreamingMetricsTracker";
+
+export interface ChatTurnProgressControllerOptions {
+  showStreamingStatus: (messageEl: HTMLElement) => void;
+  hideStreamingStatus: (messageEl: HTMLElement) => void;
+  updateStreamingStatus: (
+    messageEl: HTMLElement,
+    status: string,
+    text: string,
+    metrics?: StreamingMetrics
+  ) => void;
+}
+
+export class ChatTurnProgressController {
+  private readonly tracker: StreamingMetricsTracker;
+  private readonly showStreamingStatus: (messageEl: HTMLElement) => void;
+  private readonly hideStreamingStatus: (messageEl: HTMLElement) => void;
+  private readonly updateStreamingStatus: (
+    messageEl: HTMLElement,
+    status: string,
+    text: string,
+    metrics?: StreamingMetrics
+  ) => void;
+
+  private active = false;
+  private targetMessageEl: HTMLElement | null = null;
+
+  constructor(options: ChatTurnProgressControllerOptions) {
+    this.showStreamingStatus = options.showStreamingStatus;
+    this.hideStreamingStatus = options.hideStreamingStatus;
+    this.updateStreamingStatus = options.updateStreamingStatus;
+    this.tracker = new StreamingMetricsTracker({
+      onUpdate: (metrics) => this.render(metrics),
+    });
+  }
+
+  public begin(messageEl?: HTMLElement): void {
+    if (this.active) {
+      if (messageEl) {
+        this.attach(messageEl);
+      }
+      return;
+    }
+
+    this.active = true;
+    if (messageEl) {
+      this.attach(messageEl);
+    }
+    this.tracker.start();
+    this.renderNow();
+  }
+
+  public attach(messageEl: HTMLElement): void {
+    if (!this.active) {
+      return;
+    }
+
+    this.targetMessageEl = messageEl;
+    this.showStreamingStatus(messageEl);
+    this.renderNow();
+  }
+
+  public setStatus(status: StreamingStatus): void {
+    if (!this.active) {
+      return;
+    }
+
+    this.tracker.setStatus(status);
+    this.renderNow();
+  }
+
+  public getTracker(): StreamingMetricsTracker {
+    return this.tracker;
+  }
+
+  public end(): void {
+    const target = this.targetMessageEl;
+    this.active = false;
+    this.tracker.stop();
+    this.targetMessageEl = null;
+
+    if (target) {
+      this.hideStreamingStatus(target);
+    }
+  }
+
+  private renderNow(): void {
+    this.render(this.tracker.getMetrics());
+  }
+
+  private render(metrics: StreamingMetrics): void {
+    const target = this.targetMessageEl;
+    if (!this.active || !target) {
+      return;
+    }
+
+    this.updateStreamingStatus(target, metrics.status, metrics.statusLabel, metrics);
+  }
+}

--- a/src/views/chatview/controllers/StreamingController.ts
+++ b/src/views/chatview/controllers/StreamingController.ts
@@ -28,7 +28,13 @@ export interface StreamingControllerOptions {
   autosaveDebounceMs?: number;
 }
 
-export type StreamCompletionState = "completed" | "aborted" | "empty";
+export type StreamCompletionState =
+  | "completed"
+  | "aborted"
+  | "empty"
+  | "no_events"
+  | "reasoning_only"
+  | "empty_after_seed";
 
 export interface StreamTurnResult {
   messageId: string;
@@ -100,6 +106,7 @@ export class StreamingController extends Component {
     let collectedAnnotations: Annotation[] = [];
     const collectedReasoningDetails: unknown[] = [];
     let emittedRenderableOutput = false;
+    let emittedReasoningOutput = false;
     let restoredSeedRendering = false;
 
     const streamStartTime = performance.now();
@@ -142,6 +149,9 @@ export class StreamingController extends Component {
           case "reasoning": {
             assembler.apply(event);
             this.updateMessageRendering(assembler, messageEl, assistantMessage, true);
+            if (String(event.text || "").length > 0) {
+              emittedReasoningOutput = true;
+            }
             metricsTracker.setStatus("reasoning");
             break;
           }
@@ -335,7 +345,13 @@ export class StreamingController extends Component {
       ? "aborted"
       : completedNaturally
         ? "completed"
-        : "empty";
+        : emittedReasoningOutput
+          ? "reasoning_only"
+          : Array.isArray(seedParts) && seedParts.length > 0
+            ? "empty_after_seed"
+            : eventCount === 0
+              ? "no_events"
+              : "no_events";
     const completed = completionState === "completed";
     return {
       messageId: assistantMessage.message_id ?? messageId,

--- a/src/views/chatview/controllers/__tests__/ChatTurnProgressController.test.ts
+++ b/src/views/chatview/controllers/__tests__/ChatTurnProgressController.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { ChatTurnProgressController } from "../ChatTurnProgressController";
+
+describe("ChatTurnProgressController", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("keeps one elapsed turn status across stream, tool execution, and retry phases", () => {
+    const showStreamingStatus = jest.fn();
+    const hideStreamingStatus = jest.fn();
+    const updateStreamingStatus = jest.fn();
+    const firstMessageEl = document.createElement("div");
+    const secondMessageEl = document.createElement("div");
+
+    const progress = new ChatTurnProgressController({
+      showStreamingStatus,
+      hideStreamingStatus,
+      updateStreamingStatus,
+    });
+
+    progress.begin(firstMessageEl);
+    progress.setStatus("reasoning");
+    progress.setStatus("executing_tools");
+    progress.attach(secondMessageEl);
+    progress.setStatus("retrying");
+    progress.end();
+
+    expect(showStreamingStatus).toHaveBeenCalledWith(firstMessageEl);
+    expect(showStreamingStatus).toHaveBeenCalledWith(secondMessageEl);
+    expect(updateStreamingStatus).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      "reasoning",
+      "Thinking\u2026",
+      expect.objectContaining({ status: "reasoning" })
+    );
+    expect(updateStreamingStatus).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      "executing_tools",
+      "Running tools\u2026",
+      expect.objectContaining({ status: "executing_tools" })
+    );
+    expect(updateStreamingStatus).toHaveBeenCalledWith(
+      secondMessageEl,
+      "retrying",
+      "Retrying response\u2026",
+      expect.objectContaining({ status: "retrying" })
+    );
+    expect(hideStreamingStatus).toHaveBeenCalledWith(secondMessageEl);
+  });
+});

--- a/src/views/chatview/handlers/MessageElements.ts
+++ b/src/views/chatview/handlers/MessageElements.ts
@@ -50,7 +50,10 @@ export function updateStreamingStatus(
 ): void {
   const indicator = indicatorInstances.get(messageEl);
   if (indicator) {
-    const label = text || (status === "reasoning" ? "Thinking\u2026" : status === "tool_calls" ? "Using tools\u2026" : "Writing\u2026");
+    if (indicator.element.parentElement !== messageEl) {
+      messageEl.appendChild(indicator.element);
+    }
+    const label = text || (status === "reasoning" ? "Thinking\u2026" : status === "tool_calls" ? "Using tools\u2026" : status === "executing_tools" ? "Running tools\u2026" : status === "retrying" ? "Retrying response\u2026" : "Writing\u2026");
     indicator.update(status, label, metrics);
     if (liveRegionEl) {
       liveRegionEl.textContent = label;
@@ -76,6 +79,8 @@ export function showStreamingStatus(messageEl: HTMLElement, liveRegionEl: HTMLEl
   if (!indicator) {
     indicator = new StreamingIndicator();
     indicatorInstances.set(messageEl, indicator);
+  }
+  if (indicator.element.parentElement !== messageEl) {
     messageEl.appendChild(indicator.element);
   }
   indicator.show();

--- a/src/views/chatview/handlers/__tests__/MessageElements.test.ts
+++ b/src/views/chatview/handlers/__tests__/MessageElements.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  getStatusIndicator,
+  showStreamingStatus,
+  updateStreamingStatus,
+} from "../MessageElements";
+
+describe("MessageElements streaming status", () => {
+  it("reattaches the existing status indicator after message content is re-rendered", () => {
+    const messageEl = document.createElement("div");
+    const liveRegionEl = document.createElement("div");
+
+    showStreamingStatus(messageEl, liveRegionEl);
+    const indicator = getStatusIndicator(messageEl);
+    expect(indicator).toBeTruthy();
+    expect(indicator?.parentElement).toBe(messageEl);
+
+    messageEl.innerHTML = "";
+    expect(indicator?.parentElement).toBeNull();
+
+    showStreamingStatus(messageEl, liveRegionEl);
+    expect(getStatusIndicator(messageEl)).toBe(indicator);
+    expect(indicator?.parentElement).toBe(messageEl);
+
+    updateStreamingStatus(messageEl, liveRegionEl, "retrying", "Retrying response\u2026", {
+      elapsedMs: 1250,
+      elapsedFormatted: "0:01",
+      status: "retrying",
+      statusLabel: "Retrying response\u2026",
+    });
+
+    expect(indicator?.getAttribute("data-status")).toBe("retrying");
+    expect(indicator?.textContent).toContain("Retrying response\u2026");
+    expect(indicator?.textContent).toContain("0:01");
+    expect(liveRegionEl.textContent).toBe("Retrying response\u2026");
+  });
+});

--- a/src/views/chatview/ui/StreamingIndicator.ts
+++ b/src/views/chatview/ui/StreamingIndicator.ts
@@ -6,6 +6,7 @@ const VALID_STATUSES: Set<StreamingStatus> = new Set([
   "content",
   "tool_calls",
   "executing_tools",
+  "retrying",
 ]);
 
 export class StreamingIndicator {


### PR DESCRIPTION
## Summary
- Preserve submitted user turns and completed tool rows when a hosted continuation fails after partial work.
- Split empty stream handling into `no_events`, `reasoning_only`, and `empty_after_seed` so retry/recovery policy can make precise decisions.
- Keep one turn-level progress indicator alive across thinking, tool execution, continuation retries, and failure cleanup.
- Add transport-only continuation retry hints and tests for the retry path.
- Restrict persisted OpenAI Codex ChatGPT model selections to the currently supported set and migrate unsupported selections back to SystemSculpt.

## Verification
- `npm test -- --runInBand src/views/chatview`
- `npm test -- --runInBand src/services/__tests__/pi-text-models.test.ts src/services/pi-native/__tests__/PiTextCatalog.test.ts src/views/chatview/__tests__/chatview-model-migration.test.ts src/views/chatview/__tests__/modelSelection.test.ts src/services/__tests__/SystemSculptService.test.ts src/services/__tests__/ContextFileService.test.ts`
- `npm run build`
- `npm run check:plugin`
- Native desktop ChatView stress: 5/5 passes
- Live local Codex tool-turn smoke: read/write/readback completed with exact-token reply
- Live managed SystemSculpt tool-turn smoke: read/write/readback completed with exact-token reply
