### PR TITLE
chore: remove Discord from support links

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ These files define the user-facing surfaces and are the source of truth:
 
 - Website: `https://systemsculpt.com`
 - Repo: `https://github.com/SystemSculpt/obsidian-systemsculpt-ai`
-- Discord: `https://discord.gg/3gNUZJWxnJ`
+- Issues: `https://github.com/SystemSculpt/obsidian-systemsculpt-ai/issues`
 - Email: `support@systemsculpt.com`
 
 ## License

--- a/docs/archive/release-5.0.0-audit-todo.md
+++ b/docs/archive/release-5.0.0-audit-todo.md
@@ -198,7 +198,7 @@ What to do:
 
 1. Turn the high-level release notes into a fuller changelog grouped by user-facing areas.
 2. Write a short migration note explaining the SystemSculpt Pi-provider cutover in plain English.
-3. Prepare the matching website/Discord/email announcement copy if this release is being actively promoted.
+3. Prepare the matching website/email announcement copy if this release is being actively promoted.
 
 Exit criteria:
 


### PR DESCRIPTION
Retire Discord as a contact channel.

- README and archived release note now point to GitHub Issues + email.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated community support information: The Discord support link in the README has been replaced with a GitHub Issues link for bug reporting and feature requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->