### PR TITLE
ci: run embeddings tests and production build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,9 @@ jobs:
 
       - name: Unit Tests
         run: npm test
+
+      - name: Embeddings Tests
+        run: npm run test:embeddings
+
+      - name: Build (production)
+        run: npm run build


### PR DESCRIPTION
- CI's unit job now also runs the embeddings jest suite and a production build, so embeddings breakage and bundling failures fail the PR instead of shipping.
- Groundwork for #215: with this in place, `unit` and `desktop-baselines` become required checks on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline with additional test coverage and build verification steps to ensure code quality and production readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->