### PR TITLE
Built-bundle integration suite + deterministic provider fixtures (#215)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Build (production)
         run: npm run build
+
+      - name: Integration Tests (built bundle + provider fixtures)
+        run: npm run test:integration:ci

--- a/jest.integration.config.cjs
+++ b/jest.integration.config.cjs
@@ -1,0 +1,46 @@
+/**
+ * Jest configuration for the built-bundle integration suite (issue #215).
+ *
+ * Unlike jest.config.cjs (source-level unit tests), this suite loads the
+ * compiled `main.js` artifact and exercises it against the enriched host mock
+ * in testing/integration/mocks/ plus the deterministic provider fixtures in
+ * testing/fixtures/providers/. Run via `npm run test:integration` (builds
+ * first) or `npm run test:integration:ci` (assumes a fresh build).
+ */
+
+module.exports = {
+	testEnvironment: 'node',
+	roots: ['<rootDir>/testing/integration'],
+	testMatch: ['**/*.test.ts'],
+	testTimeout: 30000,
+	moduleNameMapper: {
+		'^obsidian$': '<rootDir>/testing/integration/mocks/obsidian-host.js',
+		'^@mariozechner/pi-coding-agent$': '<rootDir>/src/tests/mocks/pi-coding-agent.js',
+		'^@mariozechner/pi-ai$': '<rootDir>/node_modules/@mariozechner/pi-ai/dist/index.js',
+		'^@mariozechner/pi-ai/oauth$': '<rootDir>/node_modules/@mariozechner/pi-ai/dist/oauth.js',
+		'^@/(.*)$': '<rootDir>/src/$1',
+		'^src/(.*)$': '<rootDir>/src/$1'
+	},
+	setupFilesAfterEnv: ['<rootDir>/src/tests/setup.ts'],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'cjs', 'json', 'node'],
+	// The compiled bundle is already CommonJS — loading it through the
+	// transformer would re-parse ~14MB for nothing. Everything else matches
+	// the root config.
+	transformIgnorePatterns: [
+		'node_modules/(?!@mariozechner/pi-coding-agent|@mariozechner/pi-ai)',
+		'<rootDir>/main\\.js$'
+	],
+	transform: {
+		'^.+\\.(t|j)sx?$': [
+			'@swc/jest',
+			{
+				jsc: {
+					parser: { syntax: 'typescript', tsx: true, decorators: true },
+					target: 'es2018'
+				},
+				module: { type: 'commonjs' },
+				sourceMaps: 'inline'
+			}
+		]
+	}
+};

--- a/package.json
+++ b/package.json
@@ -131,6 +131,8 @@
     "test:related": "node scripts/jest.mjs --config jest.config.cjs --findRelatedTests --passWithNoTests",
     "test:leaks": "node scripts/jest.mjs --config jest.config.cjs --maxWorkers=1 --openHandlesTimeout=200 --passWithNoTests",
     "test:embeddings": "node scripts/jest.mjs --config jest.embeddings.config.cjs --passWithNoTests",
+    "test:integration": "npm run build && npm run test:integration:ci",
+    "test:integration:ci": "node scripts/jest.mjs --config jest.integration.config.cjs --runInBand --forceExit",
     "test:embeddings:serial": "node scripts/jest.mjs --config jest.embeddings.config.cjs --runInBand --passWithNoTests",
     "test:release-script": "node --test scripts/release-plugin.test.mjs scripts/check-release-surfaces.test.mjs",
     "check:release-surfaces": "node scripts/check-release-surfaces.mjs",

--- a/testing/fixtures/providers/index.cjs
+++ b/testing/fixtures/providers/index.cjs
@@ -1,0 +1,223 @@
+/**
+ * Deterministic provider fixture servers for integration and smoke tests
+ * (issue #215). Plain node:http, no dependencies, ephemeral ports.
+ *
+ * Servers:
+ *  - OpenRouter-compatible: GET /api/v1/models, POST /api/v1/chat/completions
+ *    (JSON or SSE stream when `stream: true`)
+ *  - Ollama:                GET /api/tags, POST /api/chat
+ *  - LM Studio (OpenAI):    GET /v1/models, POST /v1/chat/completions
+ *  - Whisper reference:     POST /v1/audio/transcriptions
+ *
+ * Usage (CJS so both jest and plain-node consumers can load it):
+ *   const { startProviderFixtures } = require("./index.cjs")
+ *   const fixtures = await startProviderFixtures()
+ *   fixtures.openrouter.url // http://127.0.0.1:<port>
+ *   await fixtures.close()
+ */
+const http = require("node:http");
+
+const FIXTURE_COMPLETION_TEXT = "fixture-completion: hello from the mock provider";
+const FIXTURE_TRANSCRIPT_TEXT = "fixture-transcript: hello from the mock whisper";
+
+const OPENROUTER_FIXTURE_MODELS = [
+	{ id: "openai/gpt-5.4-mini", name: "GPT-5.4 Mini (fixture)", context_length: 400000 },
+	{ id: "anthropic/claude-fable-5", name: "Claude Fable 5 (fixture)", context_length: 1000000 },
+];
+
+const OLLAMA_FIXTURE_MODELS = [
+	{ name: "llama3.2:latest", model: "llama3.2:latest", size: 2019393189 },
+	{ name: "qwen2.5-coder:7b", model: "qwen2.5-coder:7b", size: 4683087332 },
+];
+
+const LMSTUDIO_FIXTURE_MODELS = [
+	{ id: "qwen/qwen3-8b", object: "model", owned_by: "organization_owner" },
+];
+
+function readBody(req) {
+	return new Promise((resolve) => {
+		let data = "";
+		req.on("data", (chunk) => {
+			data += chunk;
+		});
+		req.on("end", () => resolve(data));
+	});
+}
+
+function sendJson(res, status, body) {
+	res.writeHead(status, { "Content-Type": "application/json" });
+	res.end(JSON.stringify(body));
+}
+
+function openAiCompletion(model) {
+	return {
+		id: "chatcmpl-fixture-1",
+		object: "chat.completion",
+		created: 1750000000,
+		model,
+		choices: [
+			{
+				index: 0,
+				message: { role: "assistant", content: FIXTURE_COMPLETION_TEXT },
+				finish_reason: "stop",
+			},
+		],
+		usage: { prompt_tokens: 7, completion_tokens: 9, total_tokens: 16 },
+	};
+}
+
+function sendOpenAiStream(res, model) {
+	res.writeHead(200, {
+		"Content-Type": "text/event-stream",
+		"Cache-Control": "no-cache",
+		Connection: "keep-alive",
+	});
+	const chunk = {
+		id: "chatcmpl-fixture-1",
+		object: "chat.completion.chunk",
+		created: 1750000000,
+		model,
+		choices: [{ index: 0, delta: { role: "assistant", content: FIXTURE_COMPLETION_TEXT }, finish_reason: null }],
+	};
+	const done = {
+		...chunk,
+		choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+	};
+	res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+	res.write(`data: ${JSON.stringify(done)}\n\n`);
+	res.write("data: [DONE]\n\n");
+	res.end();
+}
+
+async function handleOpenAiChat(req, res) {
+	const raw = await readBody(req);
+	let parsed = {};
+	try {
+		parsed = JSON.parse(raw || "{}");
+	} catch {
+		return sendJson(res, 400, { error: { message: "invalid JSON body" } });
+	}
+	const model = String(parsed.model || "fixture-model");
+	if (parsed.stream === true) {
+		return sendOpenAiStream(res, model);
+	}
+	return sendJson(res, 200, openAiCompletion(model));
+}
+
+function createOpenRouterServer() {
+	return http.createServer(async (req, res) => {
+		const url = new URL(req.url, "http://fixture");
+		if (req.method === "GET" && (url.pathname === "/api/v1/models" || url.pathname === "/models")) {
+			return sendJson(res, 200, { data: OPENROUTER_FIXTURE_MODELS });
+		}
+		if (req.method === "POST" && (url.pathname === "/api/v1/chat/completions" || url.pathname === "/chat/completions")) {
+			return handleOpenAiChat(req, res);
+		}
+		return sendJson(res, 404, { error: { message: `no fixture route for ${req.method} ${url.pathname}` } });
+	});
+}
+
+function createOllamaServer() {
+	return http.createServer(async (req, res) => {
+		const url = new URL(req.url, "http://fixture");
+		if (req.method === "GET" && url.pathname === "/api/tags") {
+			return sendJson(res, 200, { models: OLLAMA_FIXTURE_MODELS });
+		}
+		if (req.method === "POST" && url.pathname === "/api/chat") {
+			const raw = await readBody(req);
+			let parsed = {};
+			try {
+				parsed = JSON.parse(raw || "{}");
+			} catch {
+				return sendJson(res, 400, { error: "invalid JSON body" });
+			}
+			return sendJson(res, 200, {
+				model: String(parsed.model || "llama3.2:latest"),
+				created_at: "2026-01-15T00:00:00Z",
+				message: { role: "assistant", content: FIXTURE_COMPLETION_TEXT },
+				done: true,
+			});
+		}
+		return sendJson(res, 404, { error: `no fixture route for ${req.method} ${url.pathname}` });
+	});
+}
+
+function createLmStudioServer() {
+	return http.createServer(async (req, res) => {
+		const url = new URL(req.url, "http://fixture");
+		if (req.method === "GET" && url.pathname === "/v1/models") {
+			return sendJson(res, 200, { object: "list", data: LMSTUDIO_FIXTURE_MODELS });
+		}
+		if (req.method === "POST" && url.pathname === "/v1/chat/completions") {
+			return handleOpenAiChat(req, res);
+		}
+		return sendJson(res, 404, { error: { message: `no fixture route for ${req.method} ${url.pathname}` } });
+	});
+}
+
+function createWhisperServer() {
+	return http.createServer(async (req, res) => {
+		const url = new URL(req.url, "http://fixture");
+		if (req.method === "POST" && url.pathname === "/v1/audio/transcriptions") {
+			// Accepts any multipart/form-data payload; deterministic transcript.
+			await readBody(req);
+			return sendJson(res, 200, { text: FIXTURE_TRANSCRIPT_TEXT });
+		}
+		return sendJson(res, 404, { error: { message: `no fixture route for ${req.method} ${url.pathname}` } });
+	});
+}
+
+function listen(server) {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const { port } = server.address();
+			resolve(`http://127.0.0.1:${port}`);
+		});
+	});
+}
+
+const FIXTURE_TEXTS = {
+	completion: FIXTURE_COMPLETION_TEXT,
+	transcript: FIXTURE_TRANSCRIPT_TEXT,
+};
+
+async function startProviderFixtures() {
+	const servers = {
+		openrouter: createOpenRouterServer(),
+		ollama: createOllamaServer(),
+		lmstudio: createLmStudioServer(),
+		whisper: createWhisperServer(),
+	};
+
+	const entries = await Promise.all(
+		Object.entries(servers).map(async ([name, server]) => [name, { url: await listen(server), server }]),
+	);
+
+	const byName = Object.fromEntries(entries);
+
+	return {
+		openrouter: { url: byName.openrouter.url },
+		ollama: { url: byName.ollama.url },
+		lmstudio: { url: byName.lmstudio.url },
+		whisper: { url: byName.whisper.url },
+		async close() {
+			await Promise.all(
+				Object.values(byName).map(
+					({ server }) =>
+						new Promise((resolve) => {
+							server.close(() => resolve());
+						}),
+				),
+			);
+		},
+	};
+}
+
+module.exports = {
+	OPENROUTER_FIXTURE_MODELS,
+	OLLAMA_FIXTURE_MODELS,
+	LMSTUDIO_FIXTURE_MODELS,
+	FIXTURE_TEXTS,
+	startProviderFixtures,
+};

--- a/testing/integration/bundle-load.test.ts
+++ b/testing/integration/bundle-load.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Built-bundle load smoke (issue #215). Loads the compiled `main.js` — the
+ * exact artifact Obsidian ships — against the enriched host mock and proves
+ * the plugin class loads, constructs, and survives onload with its core
+ * surface registered. This is the artifact-level guard the unit suite cannot
+ * provide: it catches broken externals, top-level require failures, and
+ * onload regressions in bundled dependency code.
+ *
+ * Run `npm run build` first (npm run test:integration does this for you).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const BUNDLE_PATH = path.resolve(__dirname, "..", "..", "main.js");
+const MANIFEST_PATH = path.resolve(__dirname, "..", "..", "manifest.json");
+
+describe("built bundle (main.js)", () => {
+  beforeAll(() => {
+    if (!existsSync(BUNDLE_PATH)) {
+      throw new Error(
+        `Built bundle not found at ${BUNDLE_PATH} — run \`npm run build\` first ` +
+          "(or use `npm run test:integration`, which builds before testing)."
+      );
+    }
+  });
+
+  it("loads, constructs, and onloads against the mock host", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const bundleModule = require(BUNDLE_PATH);
+    const PluginClass = bundleModule?.default ?? bundleModule;
+    expect(typeof PluginClass).toBe("function");
+
+    const { App, Plugin } = require("obsidian");
+    expect(Object.getPrototypeOf(PluginClass.prototype) instanceof Object).toBe(true);
+    expect(PluginClass.prototype instanceof Plugin).toBe(true);
+
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    const plugin = new PluginClass(new App(), manifest);
+
+    await plugin.onload();
+
+    // onload schedules command/service registration in the critical and
+    // deferred lifecycle phases without awaiting them — wait for both so the
+    // assertions below see the fully initialized surface.
+    await plugin.criticalInitializationPromise;
+    await plugin.deferredInitializationPromise;
+
+    // Settings migration ran: loadData returned null, so defaults applied.
+    expect(plugin.settings).toBeDefined();
+    expect(typeof plugin.settings).toBe("object");
+    expect(plugin.settings.settingsMode).toBe("standard");
+    expect(Array.isArray(plugin.settings.customProviders)).toBe(true);
+    expect(plugin.settings.selectedModelId).toBe("systemsculpt@@systemsculpt/ai-agent");
+
+    // Core surface registered through the mock host.
+    expect(plugin._commands.length).toBeGreaterThan(0);
+    expect(plugin._settingTabs.length).toBeGreaterThan(0);
+
+    const commandIds = plugin._commands.map((command: { id: string }) => command.id);
+    expect(new Set(commandIds).size).toBe(commandIds.length);
+
+    plugin.unload();
+  });
+});

--- a/testing/integration/mocks/obsidian-host.js
+++ b/testing/integration/mocks/obsidian-host.js
@@ -1,0 +1,32 @@
+/**
+ * Enriched Obsidian host mock for the built-bundle integration suite.
+ *
+ * Extends the unit-test mock (src/tests/mocks/obsidian.js) with the plugin
+ * persistence surface (`loadData`/`saveData`) and any host APIs the compiled
+ * bundle touches during onload that unit tests never exercise. Keep additions
+ * minimal and explicit — a missing export failing loudly here is the signal
+ * this suite exists to produce.
+ */
+const base = require("../../../src/tests/mocks/obsidian.js");
+
+class IntegrationPlugin extends base.Plugin {
+  constructor(app, manifest) {
+    super(app, manifest);
+    this._data = null;
+  }
+
+  async loadData() {
+    return this._data;
+  }
+
+  async saveData(data) {
+    this._data = data;
+  }
+
+  async onExternalSettingsChange() {}
+}
+
+module.exports = {
+  ...base,
+  Plugin: IntegrationPlugin,
+};

--- a/testing/integration/provider-fixtures.test.ts
+++ b/testing/integration/provider-fixtures.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Self-test for the deterministic provider fixture servers (issue #215).
+ *
+ * Every shape asserted here is a contract the release smoke suite (and any
+ * future provider regression test) builds on. If a provider integration needs
+ * a response field the fixtures lack, extend the fixture and lock it in here.
+ */
+const {
+  startProviderFixtures,
+  FIXTURE_TEXTS,
+  OPENROUTER_FIXTURE_MODELS,
+  OLLAMA_FIXTURE_MODELS,
+  LMSTUDIO_FIXTURE_MODELS,
+} = require("../fixtures/providers/index.cjs");
+
+type Fixtures = Awaited<ReturnType<typeof startProviderFixtures>>;
+
+describe("provider fixture servers", () => {
+  let fixtures: Fixtures;
+
+  beforeAll(async () => {
+    fixtures = await startProviderFixtures();
+  });
+
+  afterAll(async () => {
+    await fixtures.close();
+  });
+
+  it("openrouter fixture lists models", async () => {
+    const response = await fetch(`${fixtures.openrouter.url}/api/v1/models`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toEqual(OPENROUTER_FIXTURE_MODELS);
+  });
+
+  it("openrouter fixture answers a chat completion", async () => {
+    const response = await fetch(`${fixtures.openrouter.url}/api/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: OPENROUTER_FIXTURE_MODELS[0].id,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.model).toBe(OPENROUTER_FIXTURE_MODELS[0].id);
+    expect(body.choices[0].message.content).toBe(FIXTURE_TEXTS.completion);
+    expect(body.choices[0].finish_reason).toBe("stop");
+  });
+
+  it("openrouter fixture streams SSE chunks when stream:true", async () => {
+    const response = await fetch(`${fixtures.openrouter.url}/api/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: OPENROUTER_FIXTURE_MODELS[0].id,
+        messages: [{ role: "user", content: "hello" }],
+        stream: true,
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    const raw = await response.text();
+    const dataLines = raw
+      .split("\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => line.slice("data: ".length));
+    expect(dataLines[dataLines.length - 1]).toBe("[DONE]");
+    const firstChunk = JSON.parse(dataLines[0]);
+    expect(firstChunk.choices[0].delta.content).toBe(FIXTURE_TEXTS.completion);
+  });
+
+  it("ollama fixture lists tags and answers chat", async () => {
+    const tags = await (await fetch(`${fixtures.ollama.url}/api/tags`)).json();
+    expect(tags.models).toEqual(OLLAMA_FIXTURE_MODELS);
+
+    const chatResponse = await fetch(`${fixtures.ollama.url}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: OLLAMA_FIXTURE_MODELS[0].name,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    const chat = await chatResponse.json();
+    expect(chat.model).toBe(OLLAMA_FIXTURE_MODELS[0].name);
+    expect(chat.message.content).toBe(FIXTURE_TEXTS.completion);
+    expect(chat.done).toBe(true);
+  });
+
+  it("lmstudio fixture serves the OpenAI shape", async () => {
+    const models = await (await fetch(`${fixtures.lmstudio.url}/v1/models`)).json();
+    expect(models.object).toBe("list");
+    expect(models.data).toEqual(LMSTUDIO_FIXTURE_MODELS);
+
+    const completionResponse = await fetch(`${fixtures.lmstudio.url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: LMSTUDIO_FIXTURE_MODELS[0].id,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    const completion = await completionResponse.json();
+    expect(completion.choices[0].message.content).toBe(FIXTURE_TEXTS.completion);
+  });
+
+  it("whisper fixture returns the deterministic transcript", async () => {
+    const form = new FormData();
+    form.append("file", new Blob([new Uint8Array([1, 2, 3])]), "audio.wav");
+    form.append("model", "whisper-1");
+    const response = await fetch(`${fixtures.whisper.url}/v1/audio/transcriptions`, {
+      method: "POST",
+      body: form,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ text: FIXTURE_TEXTS.transcript });
+  });
+
+  it("unknown routes 404 with a route hint", async () => {
+    const response = await fetch(`${fixtures.openrouter.url}/api/v1/nope`);
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error.message).toContain("GET /api/v1/nope");
+  });
+});

--- a/testing/integration/provider-listing.test.ts
+++ b/testing/integration/provider-listing.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression guard for issue #201 — providers disappearing from the model
+ * dropdown. Locks the two invariants of the text model catalog:
+ *
+ *   1. The managed SystemSculpt model is ALWAYS present (first entry),
+ *      license or not, providers configured or not.
+ *   2. A BYOK custom provider with an API key (e.g. OpenRouter) makes its
+ *      remote seed model appear; removing the key or disabling the provider
+ *      makes it disappear without touching the managed model.
+ *
+ * Platform flags are forced to mobile for determinism: the desktop-only
+ * branch of the catalog scans local Pi provider auth state on the host
+ * machine, which is not reproducible in CI. The managed + remote-seed paths
+ * asserted here are platform-independent.
+ */
+import { Platform } from "obsidian";
+
+import { listPiTextCatalogModels } from "src/services/pi-native/PiTextCatalog";
+import { SYSTEMSCULPT_PI_CANONICAL_MODEL_ID } from "src/services/pi/PiCanonicalIds";
+import { createCanonicalId } from "src/utils/modelUtils";
+
+const { startProviderFixtures } = require("../fixtures/providers/index.cjs");
+
+type Fixtures = Awaited<ReturnType<typeof startProviderFixtures>>;
+
+const OPENROUTER_SEED_MODEL_ID = createCanonicalId("openrouter", "openai/gpt-5.4-mini");
+
+function buildPluginStub(customProviders: unknown[] = []) {
+  return {
+    settings: { customProviders },
+    manifest: { version: "0.0.0" },
+    getLogger: () => ({
+      warn: () => {},
+      info: () => {},
+      error: () => {},
+    }),
+  } as never;
+}
+
+describe("text model catalog (#201 guard)", () => {
+  let fixtures: Fixtures;
+  const platformAny = Platform as unknown as Record<string, boolean>;
+  let savedFlags: Record<string, boolean>;
+
+  beforeAll(async () => {
+    fixtures = await startProviderFixtures();
+    savedFlags = { ...platformAny };
+    platformAny.isDesktop = false;
+    platformAny.isDesktopApp = false;
+    platformAny.isMobile = true;
+    platformAny.isMobileApp = true;
+  });
+
+  afterAll(async () => {
+    Object.assign(platformAny, savedFlags);
+    await fixtures.close();
+  });
+
+  it("always lists the managed model first, even with no providers configured", async () => {
+    const models = await listPiTextCatalogModels(buildPluginStub());
+    expect(models.length).toBeGreaterThan(0);
+    expect(models[0].id).toBe(SYSTEMSCULPT_PI_CANONICAL_MODEL_ID);
+  });
+
+  it("lists the OpenRouter seed model when a keyed custom provider is configured", async () => {
+    const models = await listPiTextCatalogModels(
+      buildPluginStub([
+        {
+          id: "openrouter",
+          name: "OpenRouter",
+          endpoint: fixtures.openrouter.url,
+          apiKey: "fixture-key",
+          isEnabled: true,
+        },
+      ])
+    );
+
+    const ids = models.map((model) => model.id);
+    expect(ids[0]).toBe(SYSTEMSCULPT_PI_CANONICAL_MODEL_ID);
+    expect(ids).toContain(OPENROUTER_SEED_MODEL_ID);
+
+    const seed = models.find((model) => model.id === OPENROUTER_SEED_MODEL_ID);
+    expect(seed?.piAuthMode).toBe("byok");
+    expect(seed?.provider).toBe("openrouter");
+  });
+
+  it("drops the seed model when the provider has no API key", async () => {
+    const models = await listPiTextCatalogModels(
+      buildPluginStub([
+        {
+          id: "openrouter",
+          name: "OpenRouter",
+          endpoint: fixtures.openrouter.url,
+          apiKey: "",
+          isEnabled: true,
+        },
+      ])
+    );
+
+    const ids = models.map((model) => model.id);
+    expect(ids).not.toContain(OPENROUTER_SEED_MODEL_ID);
+    expect(ids[0]).toBe(SYSTEMSCULPT_PI_CANONICAL_MODEL_ID);
+  });
+
+  it("drops the seed model when the provider is disabled", async () => {
+    const models = await listPiTextCatalogModels(
+      buildPluginStub([
+        {
+          id: "openrouter",
+          name: "OpenRouter",
+          endpoint: fixtures.openrouter.url,
+          apiKey: "fixture-key",
+          isEnabled: false,
+        },
+      ])
+    );
+
+    expect(models.map((model) => model.id)).not.toContain(OPENROUTER_SEED_MODEL_ID);
+  });
+});


### PR DESCRIPTION
- Adds deterministic local fixture servers for OpenRouter-compatible, Ollama, LM Studio, and Whisper APIs, plus an integration suite that loads the compiled main.js and locks plugin onload, settings defaults, and command registration.
- Encodes #201 as a permanent guard: managed model always listed, keyed custom provider surfaces its seed model, keyless/disabled drops it.
- CI runs the suite right after the production build (~1s); locally: npm run test:integration.

Part of #215 (foundation layer); follow-ups will add the release smoke suite and mobile lane on top of these fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration testing to the CI pipeline
  * Tests now validate bundle compatibility with multiple AI provider platforms
  * Introduced regression tests for provider catalog functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->