### PR TITLE
Hermetic release smoke in macos-e2e via provider fixtures (#215)

### DIFF
--- a/.github/workflows/macos-e2e.yml
+++ b/.github/workflows/macos-e2e.yml
@@ -146,22 +146,8 @@ jobs:
               settings.transcriptionProvider = 'systemsculpt';
               settings.embeddingsProvider = 'systemsculpt';
             }
-            // Point a BYOK custom provider at the local fixture server so the
-            // release-smoke cases run hermetically (no real provider keys).
-            const fixtureState = JSON.parse(
-              fs.readFileSync(process.env.HOME + '/.systemsculpt-fixtures.json', 'utf8')
-            );
-            settings.customProviders = [
-              {
-                id: 'openrouter',
-                name: 'OpenRouter (fixture)',
-                endpoint: fixtureState.openrouter + '/api/v1',
-                apiKey: 'fixture-key',
-                isEnabled: true,
-              },
-            ];
             fs.writeFileSync('${plugin_dir}/data.json', JSON.stringify(settings, null, 2));
-            console.log('Plugin settings seeded (bridge enabled, fixture provider connected)');
+            console.log('Plugin settings seeded (bridge enabled)');
           "
 
           echo "Vault prepared at ${vault_path}"
@@ -250,11 +236,36 @@ jobs:
             --case managed-baseline \
             --no-reload
 
-      - name: Run release smoke (provider fixtures)
+      - name: Connect fixture provider and run release smoke
         run: |
+          # Seed the BYOK custom provider AFTER managed-baseline: with it in
+          # settings from first launch, the local-Pi openrouter model reads
+          # the fixture key as real auth and managed-baseline's local-Pi leg
+          # would send to the real OpenRouter API. The release-smoke run
+          # below omits --no-reload so the plugin reloads and picks up the
+          # new settings before the fixture cases execute.
+          plugin_dir="${HOME}/Documents/SystemSculptMacQA/.obsidian/plugins/systemsculpt-ai"
+          node --input-type=module -e "
+            import fs from 'node:fs';
+            const dataPath = '${plugin_dir}/data.json';
+            const settings = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+            const fixtureState = JSON.parse(
+              fs.readFileSync(process.env.HOME + '/.systemsculpt-fixtures.json', 'utf8')
+            );
+            settings.customProviders = [
+              {
+                id: 'openrouter',
+                name: 'OpenRouter (fixture)',
+                endpoint: fixtureState.openrouter + '/api/v1',
+                apiKey: 'fixture-key',
+                isEnabled: true,
+              },
+            ];
+            fs.writeFileSync(dataPath, JSON.stringify(settings, null, 2));
+            console.log('Fixture provider connected in plugin settings');
+          "
           node testing/native/desktop-automation/run.mjs \
-            --case release-smoke \
-            --no-reload
+            --case release-smoke
 
       # ---- Failure diagnostics ----
 

--- a/.github/workflows/macos-e2e.yml
+++ b/.github/workflows/macos-e2e.yml
@@ -96,6 +96,20 @@ jobs:
 
       # ---- Bootstrap vault and launch ----
 
+      - name: Start provider fixtures
+        run: |
+          state_file="${HOME}/.systemsculpt-fixtures.json"
+          node testing/fixtures/providers/serve.mjs --state-file "${state_file}" &
+          for i in $(seq 1 20); do
+            [ -f "${state_file}" ] && break
+            sleep 1
+          done
+          if [ ! -f "${state_file}" ]; then
+            echo "ERROR: provider fixtures did not start"
+            exit 1
+          fi
+          cat "${state_file}"
+
       - name: Prepare vault and launch Obsidian
         run: |
           vault_path="${HOME}/Documents/SystemSculptMacQA"
@@ -132,8 +146,22 @@ jobs:
               settings.transcriptionProvider = 'systemsculpt';
               settings.embeddingsProvider = 'systemsculpt';
             }
+            // Point a BYOK custom provider at the local fixture server so the
+            // release-smoke cases run hermetically (no real provider keys).
+            const fixtureState = JSON.parse(
+              fs.readFileSync(process.env.HOME + '/.systemsculpt-fixtures.json', 'utf8')
+            );
+            settings.customProviders = [
+              {
+                id: 'openrouter',
+                name: 'OpenRouter (fixture)',
+                endpoint: fixtureState.openrouter + '/api/v1',
+                apiKey: 'fixture-key',
+                isEnabled: true,
+              },
+            ];
             fs.writeFileSync('${plugin_dir}/data.json', JSON.stringify(settings, null, 2));
-            console.log('Plugin settings seeded (bridge enabled)');
+            console.log('Plugin settings seeded (bridge enabled, fixture provider connected)');
           "
 
           echo "Vault prepared at ${vault_path}"
@@ -220,6 +248,12 @@ jobs:
             > systemsculpt-sync.config.json
           node testing/native/desktop-automation/run.mjs \
             --case managed-baseline \
+            --no-reload
+
+      - name: Run release smoke (provider fixtures)
+        run: |
+          node testing/native/desktop-automation/run.mjs \
+            --case release-smoke \
             --no-reload
 
       # ---- Failure diagnostics ----

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "test:native:desktop:extended": "node testing/native/desktop-automation/run.mjs --case extended",
     "test:native:desktop:baselines": "node testing/native/desktop-automation/run.mjs --case baselines --no-reload",
     "test:native:desktop:provider-connected": "node testing/native/desktop-automation/run.mjs --case provider-connected-baseline --no-reload",
+    "test:native:desktop:release-smoke": "node testing/native/desktop-automation/run.mjs --case release-smoke --no-reload",
     "test:native:desktop:chatview-stress": "node testing/native/desktop-automation/run.mjs --case chatview-stress --repeat 5 --pause-ms 750 --no-reload",
     "test:native:desktop:stress": "node testing/native/desktop-automation/run.mjs --case stress --repeat 5 --pause-ms 1500 --no-reload",
     "test:native:desktop:soak": "node testing/native/desktop-automation/run.mjs --case soak --repeat 25 --pause-ms 1500 --no-reload",

--- a/src/services/providerRuntime/OpenRouterRemoteStreamExecutor.ts
+++ b/src/services/providerRuntime/OpenRouterRemoteStreamExecutor.ts
@@ -7,7 +7,7 @@ import { StreamingService } from "../StreamingService";
 import { resolveStudioPiProviderApiKey } from "../../studio/piAuth/StudioPiAuthStorage";
 import { transformToolsForModel } from "../../utils/tooling";
 import { toChatCompletionsMessages } from "../../utils/messages/toChatCompletionsMessages";
-import { resolveRemoteProviderEndpoint } from "./RemoteProviderCatalog";
+import { resolveConfiguredRemoteProviderEndpoint } from "./RemoteProviderCatalog";
 
 type RemoteOpenRouterStreamInput = {
   plugin: SystemSculptPlugin;
@@ -46,7 +46,7 @@ function buildRemoteRequestBody(input: RemoteOpenRouterStreamInput): Record<stri
       input.prepared.resolvedModel.provider ||
       "openrouter",
   ).trim();
-  const endpoint = resolveRemoteProviderEndpoint(providerId);
+  const endpoint = resolveConfiguredRemoteProviderEndpoint(input.plugin, providerId);
   const body: Record<string, unknown> = {
     model: input.prepared.actualModelId,
     messages: toChatCompletionsMessages(input.prepared.preparedMessages, {
@@ -79,7 +79,7 @@ export async function* executeOpenRouterRemoteStream(
       input.prepared.resolvedModel.provider ||
       "openrouter",
   ).trim();
-  const endpoint = resolveRemoteProviderEndpoint(providerId);
+  const endpoint = resolveConfiguredRemoteProviderEndpoint(input.plugin, providerId);
   if (!endpoint) {
     throw new Error(`No remote endpoint configured for provider "${providerId}".`);
   }

--- a/src/services/providerRuntime/RemoteProviderCatalog.ts
+++ b/src/services/providerRuntime/RemoteProviderCatalog.ts
@@ -122,6 +122,36 @@ export function resolveRemoteProviderEndpoint(providerId: string): string {
   return "";
 }
 
+/**
+ * Endpoint resolution for executing against a remote provider. A user who
+ * configured the provider with an explicit endpoint (proxy, gateway, or a
+ * local fixture in tests) gets that endpoint; otherwise the canonical base
+ * URL applies. Matching mirrors resolveConfiguredProviderApiKey: the entry's
+ * id/name (or endpoint-derived provider) keys the lookup, and disabled
+ * entries never win.
+ */
+export function resolveConfiguredRemoteProviderEndpoint(
+  plugin: Pick<SystemSculptPlugin, "settings">,
+  providerId: string,
+): string {
+  const normalized = normalizeProviderId(providerId);
+  const customProviders = Array.isArray(plugin.settings?.customProviders)
+    ? (plugin.settings.customProviders as CustomProvider[])
+    : [];
+
+  for (const provider of customProviders) {
+    const endpointProvider = resolvePiProviderFromEndpoint(provider.endpoint || "");
+    const providerKey = normalizeProviderId(provider.id || provider.name || endpointProvider);
+    const enabled = provider.isEnabled !== false;
+    const endpoint = String(provider.endpoint || "").trim();
+    if (enabled && providerKey === normalized && /^https?:\/\//i.test(endpoint)) {
+      return endpoint.replace(/\/+$/, "");
+    }
+  }
+
+  return resolveRemoteProviderEndpoint(providerId);
+}
+
 export function getConfiguredRemoteProviderApiKey(
   plugin: SystemSculptPlugin,
   providerId: string,

--- a/src/services/providerRuntime/__tests__/OpenRouterRemoteStreamExecutor.test.ts
+++ b/src/services/providerRuntime/__tests__/OpenRouterRemoteStreamExecutor.test.ts
@@ -7,6 +7,8 @@ const mockStreamResponse = jest.fn();
 
 jest.mock("../RemoteProviderCatalog", () => ({
   resolveRemoteProviderEndpoint: (...args: any[]) => mockResolveEndpoint(...args),
+  resolveConfiguredRemoteProviderEndpoint: (_plugin: unknown, ...args: any[]) =>
+    mockResolveEndpoint(...args),
 }));
 
 jest.mock("../../../studio/piAuth/StudioPiAuthStorage", () => ({

--- a/src/services/providerRuntime/__tests__/RemoteProviderCatalog.test.ts
+++ b/src/services/providerRuntime/__tests__/RemoteProviderCatalog.test.ts
@@ -1,6 +1,7 @@
 import {
   listConfiguredRemoteProviderModels,
   resolveRemoteProviderEndpoint,
+  resolveConfiguredRemoteProviderEndpoint,
   getConfiguredRemoteProviderApiKey,
 } from "../RemoteProviderCatalog";
 import { AI_PROVIDERS } from "../../../constants/externalServices";
@@ -34,6 +35,39 @@ describe("RemoteProviderCatalog", () => {
     it("returns empty string for unknown providers", () => {
       expect(resolveRemoteProviderEndpoint("anthropic")).toBe("");
       expect(resolveRemoteProviderEndpoint("")).toBe("");
+    });
+  });
+
+  describe("resolveConfiguredRemoteProviderEndpoint", () => {
+    it("prefers the enabled custom provider's configured endpoint", () => {
+      const plugin = makePlugin([
+        { id: "openrouter", endpoint: "http://127.0.0.1:4310/api/v1/", apiKey: "k", isEnabled: true },
+      ]);
+      expect(resolveConfiguredRemoteProviderEndpoint(plugin, "openrouter")).toBe(
+        "http://127.0.0.1:4310/api/v1"
+      );
+    });
+
+    it("falls back to the canonical base URL when no entry matches", () => {
+      expect(resolveConfiguredRemoteProviderEndpoint(makePlugin(), "openrouter")).toBe(
+        AI_PROVIDERS.OPENROUTER.BASE_URL
+      );
+    });
+
+    it("ignores disabled entries and invalid endpoints", () => {
+      const disabled = makePlugin([
+        { id: "openrouter", endpoint: "http://127.0.0.1:4310", apiKey: "k", isEnabled: false },
+      ]);
+      expect(resolveConfiguredRemoteProviderEndpoint(disabled, "openrouter")).toBe(
+        AI_PROVIDERS.OPENROUTER.BASE_URL
+      );
+
+      const invalid = makePlugin([
+        { id: "openrouter", endpoint: "not-a-url", apiKey: "k", isEnabled: true },
+      ]);
+      expect(resolveConfiguredRemoteProviderEndpoint(invalid, "openrouter")).toBe(
+        AI_PROVIDERS.OPENROUTER.BASE_URL
+      );
     });
   });
 

--- a/testing/fixtures/providers/serve.mjs
+++ b/testing/fixtures/providers/serve.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Long-running host for the deterministic provider fixtures (issue #215).
+ *
+ * Starts every fixture server on an ephemeral port, writes their base URLs to
+ * a JSON state file, then stays alive until SIGINT/SIGTERM. CI launches this
+ * in the background before Obsidian starts so the vault's seeded
+ * customProviders entry can point at a live local endpoint.
+ *
+ * Usage:
+ *   node testing/fixtures/providers/serve.mjs --state-file ~/.systemsculpt-fixtures.json
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { startProviderFixtures } = require("./index.cjs");
+
+function parseStateFile(argv) {
+	const index = argv.indexOf("--state-file");
+	if (index === -1 || !argv[index + 1]) {
+		console.error("[provider-fixtures] --state-file <path> is required");
+		process.exit(1);
+	}
+	return path.resolve(String(argv[index + 1]));
+}
+
+async function main() {
+	const stateFile = parseStateFile(process.argv.slice(2));
+	const fixtures = await startProviderFixtures();
+
+	const state = {
+		openrouter: fixtures.openrouter.url,
+		ollama: fixtures.ollama.url,
+		lmstudio: fixtures.lmstudio.url,
+		whisper: fixtures.whisper.url,
+		pid: process.pid,
+		startedAt: new Date().toISOString(),
+	};
+	fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+	fs.writeFileSync(stateFile, `${JSON.stringify(state, null, 2)}\n`);
+	console.log(`[provider-fixtures] serving; state written to ${stateFile}`);
+	console.log(`[provider-fixtures] openrouter=${state.openrouter} ollama=${state.ollama} lmstudio=${state.lmstudio} whisper=${state.whisper}`);
+
+	const shutdown = async () => {
+		await fixtures.close();
+		process.exit(0);
+	};
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+}
+
+main().catch((error) => {
+	console.error(`[provider-fixtures] failed to start: ${error instanceof Error ? error.message : String(error)}`);
+	process.exit(1);
+});

--- a/testing/native/desktop-automation/run.mjs
+++ b/testing/native/desktop-automation/run.mjs
@@ -18,7 +18,7 @@ Run no-focus desktop automation against the already-running Obsidian vault by
 talking to the plugin's localhost bridge instead of driving the renderer.
 
 Options:
-  --case <name|all|extended|stress|soak>   Case list: setup-baseline, managed-baseline, provider-connected-baseline, model-switch, chat-exact, file-read, file-write, web-fetch, youtube-transcript, reload-stress, chatview-stress, all, extended, stress, or soak. Default: all
+  --case <name|all|extended|stress|soak>   Case list: setup-baseline, managed-baseline, provider-connected-baseline, release-smoke, fixture-provider-listing, fixture-chat-roundtrip, model-switch, chat-exact, file-read, file-write, web-fetch, youtube-transcript, reload-stress, chatview-stress, all, extended, stress, or soak. Default: all
   --sync-config <path>         Sync config used to resolve the desktop plugin target. Default: ./systemsculpt-sync.config.json
   --target-index <n>           Pin a pluginTargets entry from the sync config
   --vault-name <name>          Pin a specific sync target by vault name

--- a/testing/native/desktop-automation/runner.mjs
+++ b/testing/native/desktop-automation/runner.mjs
@@ -21,6 +21,10 @@ import {
   normalizeProviderId,
   resolveProviderModelPreferences,
 } from "../shared/model-inventory.mjs";
+import { createRequire } from "node:module";
+
+const requireCjs = createRequire(import.meta.url);
+const { OPENROUTER_FIXTURE_MODELS, FIXTURE_TEXTS } = requireCjs("../../fixtures/providers/index.cjs");
 
 export const CORE_CASES = ["model-switch", "chat-exact", "file-read", "file-write", "web-fetch"];
 export const EXTENDED_CASES = [...CORE_CASES, "youtube-transcript"];
@@ -32,6 +36,10 @@ export const BASELINE_SUITE_CASE = "baselines";
 export const MANAGED_BASELINE_CASE = "managed-baseline";
 export const PROVIDER_CONNECTED_BASELINE_CASE = "provider-connected-baseline";
 export const SOAK_CASES = [DEFAULT_STRESS_CASE, CHATVIEW_STRESS_CASE];
+export const FIXTURE_PROVIDER_LISTING_CASE = "fixture-provider-listing";
+export const FIXTURE_CHAT_ROUNDTRIP_CASE = "fixture-chat-roundtrip";
+export const RELEASE_SMOKE_CASE = "release-smoke";
+const RELEASE_SMOKE_CASES = [FIXTURE_PROVIDER_LISTING_CASE, FIXTURE_CHAT_ROUNDTRIP_CASE];
 const BASELINE_SUITE_CASES = [MANAGED_BASELINE_CASE, PROVIDER_CONNECTED_BASELINE_CASE];
 const MANAGED_SYSTEMSCULPT_MODEL_ID = "systemsculpt@@systemsculpt/ai-agent";
 const DESKTOP_BASELINE_PI_MODEL_ID = "local-pi-openrouter@@openai/gpt-5.4-mini";
@@ -705,6 +713,9 @@ export function caseList(caseName) {
   }
   if (caseName === PROVIDER_CONNECTED_BASELINE_CASE) {
     return [PROVIDER_CONNECTED_BASELINE_CASE];
+  }
+  if (caseName === RELEASE_SMOKE_CASE) {
+    return [...RELEASE_SMOKE_CASES];
   }
   return [caseName];
 }
@@ -1766,6 +1777,80 @@ export async function runManagedBaselineCase(client) {
   };
 }
 
+const FIXTURE_OPENROUTER_MODEL_ID = `openrouter@@${OPENROUTER_FIXTURE_MODELS[0].id}`;
+
+/**
+ * Release smoke (issue #215): the model catalog must list the managed model
+ * and the remote seed model surfaced by the customProviders entry the CI
+ * vault seeds against the local fixture server. Encodes #201 against the
+ * real app: providers disappearing from the dropdown fails this case.
+ */
+export async function runFixtureProviderListingCase(client) {
+  const inventory = await loadModelInventory(client);
+  if (!inventory.managedOption) {
+    throw new Error("Fixture provider listing expected the managed SystemSculpt model in the dropdown.");
+  }
+  const fixtureOption = inventory.options.find(
+    (option) => option && option.value === FIXTURE_OPENROUTER_MODEL_ID
+  );
+  if (!fixtureOption) {
+    throw new Error(
+      `Fixture provider listing expected "${FIXTURE_OPENROUTER_MODEL_ID}" from the seeded custom provider. ` +
+        `Available: ${describeModelOptions(inventory.options)}`
+    );
+  }
+
+  return {
+    availableModelCount: inventory.options.length,
+    readyModelCount: inventory.ready.length,
+    managedModel: buildModelSummary(inventory.managedOption),
+    fixtureModel: buildModelSummary(fixtureOption),
+  };
+}
+
+/**
+ * Release smoke (issue #215): a full chat round-trip through the remote
+ * provider execution path against the local OpenRouter-compatible fixture.
+ * No real provider credentials are involved; the fixture streams a
+ * deterministic completion, so any drift in endpoint resolution, auth
+ * plumbing, request shape, or SSE parsing fails the case.
+ */
+export async function runFixtureChatRoundtripCase(client) {
+  const inventory = await loadModelInventory(client);
+  const fixtureOption = inventory.options.find(
+    (option) => option && option.value === FIXTURE_OPENROUTER_MODEL_ID
+  );
+  if (!fixtureOption) {
+    throw new Error(
+      `Fixture chat round-trip expected "${FIXTURE_OPENROUTER_MODEL_ID}" from the seeded custom provider. ` +
+        `Available: ${describeModelOptions(inventory.options)}`
+    );
+  }
+
+  await ensureChatModelSelection(client, fixtureOption.value, {
+    reset: true,
+    label: "Fixture chat round-trip selection",
+  });
+  const snapshot = await client.sendChat({
+    text: "Reply with OK.",
+    includeContextFiles: false,
+    webSearchEnabled: false,
+    approvalMode: "interactive",
+  });
+  const assistant = getLastAssistantMessage(snapshot);
+  const assistantText = toMessageText(assistant?.content).trim();
+
+  assertEqual(snapshot.selectedModelId, fixtureOption.value, "Fixture model selected after send");
+  assertIncludes(assistantText, FIXTURE_TEXTS.completion, "Fixture chat reply");
+
+  return {
+    response: assistantText,
+    model: buildModelSummary(fixtureOption),
+    selectedModelId: snapshot.selectedModelId,
+    currentModelName: snapshot.currentModelName || null,
+  };
+}
+
 export async function runProviderConnectedBaselineCase(client, options = {}) {
   const authConfig = resolveProviderConnectedAuthConfig(options.env || process.env);
   const inventory = await loadModelInventory(client);
@@ -2574,6 +2659,10 @@ export async function runCase(client, options, caseName) {
       return { client, result: await runManagedBaselineCase(client) };
     case PROVIDER_CONNECTED_BASELINE_CASE:
       return { client, result: await runProviderConnectedBaselineCase(client, options) };
+    case FIXTURE_PROVIDER_LISTING_CASE:
+      return { client, result: await runFixtureProviderListingCase(client) };
+    case FIXTURE_CHAT_ROUNDTRIP_CASE:
+      return { client, result: await runFixtureChatRoundtripCase(client) };
     case "model-switch":
       return { client, result: await runModelSwitchCase(client, options) };
     case "chat-exact":

--- a/testing/native/desktop-automation/runner.test.mjs
+++ b/testing/native/desktop-automation/runner.test.mjs
@@ -4,14 +4,19 @@ import {
   assertHealthyStatus,
   BASELINE_SUITE_CASE,
   CHATVIEW_STRESS_CASE,
+  FIXTURE_CHAT_ROUNDTRIP_CASE,
+  FIXTURE_PROVIDER_LISTING_CASE,
   MANAGED_BASELINE_CASE,
   PROVIDER_CONNECTED_BASELINE_CASE,
+  RELEASE_SMOKE_CASE,
   SETUP_BASELINE_CASE,
   buildBaselineSummary,
   caseList,
   isTransientModelExecutionError,
   resolveBootstrapReload,
   runChatExactCase,
+  runFixtureChatRoundtripCase,
+  runFixtureProviderListingCase,
   runManagedBaselineCase,
   runProviderConnectedBaselineCase,
   runChatViewStressCase,
@@ -2612,4 +2617,78 @@ test("runProviderConnectedBaselineCase fails clearly when no provider API key is
     runProviderConnectedBaselineCase(client, { env: {} }),
     /No provider API key was available/
   );
+});
+
+test("caseList resolves release-smoke to the fixture cases", () => {
+  assert.deepEqual(caseList(RELEASE_SMOKE_CASE), [
+    FIXTURE_PROVIDER_LISTING_CASE,
+    FIXTURE_CHAT_ROUNDTRIP_CASE,
+  ]);
+});
+
+function buildFixtureSmokeClient({ includeFixtureModel = true } = {}) {
+  let currentModelId = "systemsculpt@@systemsculpt/ai-agent";
+  const options = [
+    {
+      value: "systemsculpt@@systemsculpt/ai-agent",
+      label: "SystemSculpt Agent",
+      providerAuthenticated: true,
+      providerLabel: "SystemSculpt",
+      section: "systemsculpt",
+    },
+  ];
+  if (includeFixtureModel) {
+    options.push({
+      value: "openrouter@@openai/gpt-5.4-mini",
+      label: "GPT-5.4 Mini",
+      providerAuthenticated: true,
+      providerId: "openrouter",
+      providerLabel: "OpenRouter",
+      section: "custom",
+    });
+  }
+  return {
+    async listModels() {
+      return { selectedModelId: currentModelId, options };
+    },
+    async ensureChatOpen(body = {}) {
+      if (body.selectedModelId) {
+        currentModelId = body.selectedModelId;
+      }
+      return { selectedModelId: currentModelId };
+    },
+    async setModel(modelId) {
+      currentModelId = modelId;
+      return { selectedModelId: currentModelId };
+    },
+    async sendChat() {
+      return {
+        selectedModelId: currentModelId,
+        currentModelName: "GPT-5.4 Mini",
+        messages: [
+          {
+            role: "assistant",
+            content: "fixture-completion: hello from the mock provider",
+          },
+        ],
+      };
+    },
+  };
+}
+
+test("runFixtureProviderListingCase requires both the managed and fixture models", async () => {
+  const outcome = await runFixtureProviderListingCase(buildFixtureSmokeClient());
+  assert.equal(outcome.managedModel.modelId, "systemsculpt@@systemsculpt/ai-agent");
+  assert.equal(outcome.fixtureModel.modelId, "openrouter@@openai/gpt-5.4-mini");
+
+  await assert.rejects(
+    runFixtureProviderListingCase(buildFixtureSmokeClient({ includeFixtureModel: false })),
+    /expected "openrouter@@openai\/gpt-5\.4-mini"/
+  );
+});
+
+test("runFixtureChatRoundtripCase asserts the deterministic fixture completion", async () => {
+  const outcome = await runFixtureChatRoundtripCase(buildFixtureSmokeClient());
+  assert.equal(outcome.selectedModelId, "openrouter@@openai/gpt-5.4-mini");
+  assert.match(outcome.response, /fixture-completion: hello from the mock provider/);
 });


### PR DESCRIPTION
- macos-e2e now runs release-smoke cases against local provider fixtures on every PR: the model dropdown must list the managed model plus the seeded custom provider model (#201 as a red-build check), and a full chat round-trip streams from the OpenRouter-compatible fixture with no real keys.
- Includes a fix: remote provider execution honors the configured custom provider endpoint (proxy/gateway/fixture) instead of always hitting the canonical OpenRouter URL.
- Recorder and embeddings smoke land next; they need new automation-bridge routes (separate review).

Builds on #217. Local: npm run test:native:desktop:release-smoke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom provider endpoint configuration to use alternative provider services.
  * Desktop automation script added for running a "release smoke" desktop test case.

* **Tests**
  * Enhanced end-to-end testing with local provider fixtures to validate release scenarios without external services.
  * Added new "release smoke" test cases covering provider discovery and deterministic chat roundtrips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->