### PR TITLE
Recorder + embeddings release smoke, CONTRIBUTING (#215)

### DIFF
--- a/.github/workflows/macos-e2e.yml
+++ b/.github/workflows/macos-e2e.yml
@@ -179,8 +179,13 @@ jobs:
                 OPENROUTER_API_KEY PERPLEXITY_API_KEY DEEPSEEK_API_KEY \
                 XAI_API_KEY CEREBRAS_API_KEY SAMBANOVA_API_KEY TOGETHER_API_KEY 2>/dev/null || true
 
-          # Launch Obsidian with remote debugging so we can interact via CDP
-          /Applications/Obsidian.app/Contents/MacOS/Obsidian --remote-debugging-port=9222 &
+          # Launch Obsidian with remote debugging so we can interact via CDP.
+          # The fake media-stream flags give getUserMedia a synthetic
+          # microphone without a permission prompt (recorder smoke).
+          /Applications/Obsidian.app/Contents/MacOS/Obsidian \
+            --remote-debugging-port=9222 \
+            --use-fake-device-for-media-stream \
+            --use-fake-ui-for-media-stream &
           echo "Obsidian launched with remote debugging on port 9222"
 
       - name: Dismiss trust prompt and enable plugin via CDP
@@ -261,6 +266,18 @@ jobs:
                 isEnabled: true,
               },
             ];
+            // Recorder smoke: transcribe captured fake-device audio through
+            // the local Whisper-shaped fixture.
+            settings.autoTranscribeRecordings = true;
+            settings.transcriptionProvider = 'custom';
+            settings.customTranscriptionEndpoint = fixtureState.whisper + '/v1/audio/transcriptions';
+            settings.customTranscriptionApiKey = 'fixture-key';
+            settings.customTranscriptionModel = 'whisper-1';
+            // Embeddings smoke: round-trip through the OpenAI-shaped fixture.
+            settings.embeddingsProvider = 'custom';
+            settings.embeddingsCustomEndpoint = fixtureState.lmstudio + '/v1/embeddings';
+            settings.embeddingsCustomApiKey = 'fixture-key';
+            settings.embeddingsCustomModel = 'fixture-embeddings';
             fs.writeFileSync(dataPath, JSON.stringify(settings, null, 2));
             console.log('Fixture provider connected in plugin settings');
           "

--- a/.github/workflows/macos-e2e.yml
+++ b/.github/workflows/macos-e2e.yml
@@ -241,48 +241,17 @@ jobs:
             --case managed-baseline \
             --no-reload
 
-      - name: Connect fixture provider and run release smoke
+      - name: Run release smoke (provider fixtures)
         run: |
-          # Seed the BYOK custom provider AFTER managed-baseline: with it in
-          # settings from first launch, the local-Pi openrouter model reads
-          # the fixture key as real auth and managed-baseline's local-Pi leg
-          # would send to the real OpenRouter API. The release-smoke run
-          # below omits --no-reload so the plugin reloads and picks up the
-          # new settings before the fixture cases execute.
-          plugin_dir="${HOME}/Documents/SystemSculptMacQA/.obsidian/plugins/systemsculpt-ai"
-          node --input-type=module -e "
-            import fs from 'node:fs';
-            const dataPath = '${plugin_dir}/data.json';
-            const settings = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-            const fixtureState = JSON.parse(
-              fs.readFileSync(process.env.HOME + '/.systemsculpt-fixtures.json', 'utf8')
-            );
-            settings.customProviders = [
-              {
-                id: 'openrouter',
-                name: 'OpenRouter (fixture)',
-                endpoint: fixtureState.openrouter + '/api/v1',
-                apiKey: 'fixture-key',
-                isEnabled: true,
-              },
-            ];
-            // Recorder smoke: transcribe captured fake-device audio through
-            // the local Whisper-shaped fixture.
-            settings.autoTranscribeRecordings = true;
-            settings.transcriptionProvider = 'custom';
-            settings.customTranscriptionEndpoint = fixtureState.whisper + '/v1/audio/transcriptions';
-            settings.customTranscriptionApiKey = 'fixture-key';
-            settings.customTranscriptionModel = 'whisper-1';
-            // Embeddings smoke: round-trip through the OpenAI-shaped fixture.
-            settings.embeddingsProvider = 'custom';
-            settings.embeddingsCustomEndpoint = fixtureState.lmstudio + '/v1/embeddings';
-            settings.embeddingsCustomApiKey = 'fixture-key';
-            settings.embeddingsCustomModel = 'fixture-embeddings';
-            fs.writeFileSync(dataPath, JSON.stringify(settings, null, 2));
-            console.log('Fixture provider connected in plugin settings');
-          "
+          # Fixture settings apply AFTER managed-baseline (a fixture-keyed
+          # openrouter entry present during the baseline would make its
+          # local-Pi leg call the real OpenRouter API). The runner patches
+          # settings through the live bridge, which persists them itself —
+          # editing data.json externally races the plugin's settings flush.
           node testing/native/desktop-automation/run.mjs \
-            --case release-smoke
+            --case release-smoke \
+            --no-reload \
+            --apply-fixture-settings "${HOME}/.systemsculpt-fixtures.json"
 
       # ---- Failure diagnostics ----
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,8 @@ review when all of them are green locally.
 
 - Match the surrounding file's style exactly (indentation, naming, idiom).
   No drive-by reformatting.
-- The compiled `main.js`/`styles.css` at the repo root are build artifacts;
-  never edit them by hand and only commit them when a release flow asks for it.
+- The compiled `main.js`/`styles.css` at the repo root are gitignored build
+  artifacts (`npm run build` regenerates them; releases attach them); never
+  edit them by hand.
 - New emails, providers, or commands follow registry patterns; grep for an
   existing exemplar before inventing a new shape.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+## Failing test first
+
+Every bug fix and rework PR starts with a test that fails on `main` and
+passes with the change. Pick the cheapest layer that can actually catch the
+regression:
+
+| Layer | When it is the right home | Run with |
+|-------|---------------------------|----------|
+| Unit (`src/**/__tests__/`) | Pure logic, services with mockable edges | `npm test` |
+| Built-bundle integration (`testing/integration/`) | Anything that can break in the compiled artifact: externals, plugin load, settings defaults, provider listing | `npm run test:integration` |
+| Release smoke (`testing/native/desktop-automation/`, runs in `macos-e2e.yml`) | Behavior that needs real Obsidian: provider dropdown, chat round-trips, recorder, embeddings | `npm run test:native:desktop:release-smoke` |
+| Device lanes (`test:native:windows:*`, `test:native:android*`) | Platform-specific runtime behavior | local only |
+
+If a regression recurs (see #201), its guard belongs in CI permanently, not
+in a one-off manual check.
+
+## Provider fixtures, not real keys
+
+Tests never depend on real provider credentials. `testing/fixtures/providers/`
+serves deterministic OpenRouter-compatible, Ollama, LM Studio, Whisper, and
+embeddings endpoints on ephemeral ports; point settings at those. If a test
+needs a response shape the fixtures lack, extend the fixture and lock the new
+shape into `testing/integration/provider-fixtures.test.ts`.
+
+## Gates before any PR
+
+```
+npm run check:plugin:fast   # tsc + bundle + script tests + unit tests
+npm test                    # full unit suite
+npm run test:integration    # production build + built-bundle suite
+```
+
+CI runs the same gates plus the macOS E2E lane on every PR. A PR is ready for
+review when all of them are green locally.
+
+## Conventions
+
+- Match the surrounding file's style exactly (indentation, naming, idiom).
+  No drive-by reformatting.
+- The compiled `main.js`/`styles.css` at the repo root are build artifacts;
+  never edit them by hand and only commit them when a release flow asks for it.
+- New emails, providers, or commands follow registry patterns; grep for an
+  existing exemplar before inventing a new shape.

--- a/src/services/RecorderService.ts
+++ b/src/services/RecorderService.ts
@@ -33,6 +33,7 @@ export class RecorderService {
   private lastRecordingPath: string | null = null;
   private offlineRecordings: Map<string, Blob> = new Map();
   private listeners: Set<(recording: boolean) => void> = new Set();
+  private transcriptionListeners: Set<(text: string) => void> = new Set();
   private sessionCompletionPromise: Promise<void> | null = null;
   private sessionCompletionResolver: (() => void) | null = null;
   private toggleQueue: Promise<void> = Promise.resolve();
@@ -72,12 +73,26 @@ export class RecorderService {
     return () => this.listeners.delete(callback);
   }
 
+  /**
+   * Observe completed transcriptions without replacing the service-level
+   * onTranscriptionComplete callback (used by the desktop automation bridge).
+   */
+  public onTranscription(callback: (text: string) => void): () => void {
+    this.transcriptionListeners.add(callback);
+    return () => this.transcriptionListeners.delete(callback);
+  }
+
+  public isCurrentlyRecording(): boolean {
+    return this.isRecording;
+  }
+
   public unload(): void {
     if (this.isRecording) {
       void this.stopRecording();
     }
     this.cleanup(true);
     this.listeners.clear();
+    this.transcriptionListeners.clear();
   }
 
   public toggleRecording(): Promise<void> {
@@ -286,6 +301,13 @@ export class RecorderService {
   }
 
   private handleTranscriptionComplete(text: string): void {
+    for (const listener of this.transcriptionListeners) {
+      try {
+        listener(text);
+      } catch {
+        // Observers must never break the recorder flow.
+      }
+    }
     try {
       this.info("transcription complete callback received", { receivedChars: text.length });
       if (this.onTranscriptionDone) {

--- a/src/services/embeddings/EmbeddingsManager.ts
+++ b/src/services/embeddings/EmbeddingsManager.ts
@@ -1169,6 +1169,26 @@ export class EmbeddingsManager {
     return { provider: this.provider.id, model, schema: EMBEDDING_SCHEMA_VERSION };
   }
 
+  /**
+   * Public: single-text embedding round-trip for diagnostics/automation.
+   * Returns shape metadata only, never the vector itself.
+   */
+  public async embedTextForDiagnostics(
+    text: string,
+  ): Promise<{ provider: string; model: string; dimensions: number }> {
+    await this.awaitReady();
+    const vectors = await this.provider.generateEmbeddings(
+      [String(text || '').trim() || 'diagnostics'],
+      { inputType: 'query' },
+    );
+    const descriptor = this.getCurrentNamespaceDescriptor();
+    return {
+      provider: descriptor.provider,
+      model: descriptor.model,
+      dimensions: Array.isArray(vectors?.[0]) ? vectors[0].length : 0,
+    };
+  }
+
   /** Public: List available namespaces with counts */
   public async getNamespaceStats(): Promise<Array<{ namespace: string; provider: string; model: string; schema: number; dimension: number; vectors: number; files: number }>> {
     await this.awaitReady();

--- a/src/testing/automation/DesktopAutomationBridge.ts
+++ b/src/testing/automation/DesktopAutomationBridge.ts
@@ -761,6 +761,27 @@ export class DesktopAutomationBridge {
         return;
       }
 
+      if (method === "POST" && url.pathname === "/v1/settings/update") {
+        const body = await this.readJsonBody(request);
+        const patch = body.settings;
+        if (!patch || typeof patch !== "object" || Array.isArray(patch)) {
+          throw new BridgeHttpError(400, "settings must be an object of keys to merge.");
+        }
+        // In-memory merge + persist: applying settings through the live
+        // plugin avoids the data.json write race a reload-based flow has
+        // (the plugin can flush its own settings over an external edit).
+        Object.assign(this.plugin.settings as unknown as Record<string, unknown>, patch);
+        await this.plugin.saveSettings();
+        await this.refreshModelCatalog();
+        this.sendJson(response, 200, {
+          ok: true,
+          data: {
+            updatedKeys: Object.keys(patch as Record<string, unknown>),
+          },
+        });
+        return;
+      }
+
       if (method === "POST" && url.pathname === "/v1/recorder/toggle") {
         const recorder = this.plugin.getRecorderService();
         this.ensureRecorderTranscriptionObserver(recorder);

--- a/src/testing/automation/DesktopAutomationBridge.ts
+++ b/src/testing/automation/DesktopAutomationBridge.ts
@@ -148,6 +148,8 @@ export class DesktopAutomationBridge {
   private selfReloadScheduled = false;
   private selfReloadPromise: Promise<void> | null = null;
   private selfReloadRequestedAt: string | null = null;
+  private lastRecorderTranscript: string | null = null;
+  private unsubscribeRecorderTranscription: (() => void) | null = null;
   private readonly singletonToken = Symbol("DesktopAutomationBridge");
 
   constructor(private readonly plugin: SystemSculptPlugin) {}
@@ -208,6 +210,10 @@ export class DesktopAutomationBridge {
   }
 
   private async stopNow(): Promise<void> {
+    if (this.unsubscribeRecorderTranscription) {
+      this.unsubscribeRecorderTranscription();
+      this.unsubscribeRecorderTranscription = null;
+    }
     const runtime = loadBridgeRuntime();
     const server = this.server;
     const sockets = Array.from(this.serverSockets);
@@ -755,6 +761,46 @@ export class DesktopAutomationBridge {
         return;
       }
 
+      if (method === "POST" && url.pathname === "/v1/recorder/toggle") {
+        const recorder = this.plugin.getRecorderService();
+        this.ensureRecorderTranscriptionObserver(recorder);
+        await recorder.toggleRecording();
+        this.sendJson(response, 200, {
+          ok: true,
+          data: {
+            recording: recorder.isCurrentlyRecording(),
+          },
+        });
+        return;
+      }
+
+      if (method === "GET" && url.pathname === "/v1/recorder/status") {
+        const recorder = this.plugin.getRecorderService();
+        this.ensureRecorderTranscriptionObserver(recorder);
+        this.sendJson(response, 200, {
+          ok: true,
+          data: {
+            recording: recorder.isCurrentlyRecording(),
+            lastTranscript: this.lastRecorderTranscript,
+          },
+        });
+        return;
+      }
+
+      if (method === "POST" && url.pathname === "/v1/embeddings/embed") {
+        const body = await this.readJsonBody(request);
+        const text = String(body.text || "").trim();
+        if (!text) {
+          throw new BridgeHttpError(400, "text is required.");
+        }
+        const manager = this.plugin.getOrCreateEmbeddingsManager();
+        this.sendJson(response, 200, {
+          ok: true,
+          data: await manager.embedTextForDiagnostics(text),
+        });
+        return;
+      }
+
       if (method === "POST" && url.pathname === "/v1/plugin/reload") {
         const reload = this.requestSelfReload();
         response.once("finish", () => {
@@ -792,6 +838,22 @@ export class DesktopAutomationBridge {
       }
       this.sendJson(response, statusCode, payload);
     }
+  }
+
+  /**
+   * Lazily observe recorder transcriptions so /v1/recorder/status can report
+   * the last transcript. Subscribing on first recorder route keeps the bridge
+   * from initializing the recorder for vaults that never touch it.
+   */
+  private ensureRecorderTranscriptionObserver(recorder: {
+    onTranscription: (callback: (text: string) => void) => () => void;
+  }): void {
+    if (this.unsubscribeRecorderTranscription) {
+      return;
+    }
+    this.unsubscribeRecorderTranscription = recorder.onTranscription((text) => {
+      this.lastRecorderTranscript = text;
+    });
   }
 
   private assertAuthorized(request: IncomingMessage): void {

--- a/testing/README.md
+++ b/testing/README.md
@@ -95,10 +95,12 @@ Automated E2E testing runs in GitHub Actions on every PR and push to main:
 
 | Workflow | Runner | What it proves |
 |----------|--------|----------------|
-| `ci.yml` | ubuntu-latest | Unit tests + fast plugin checks |
-| `windows-e2e.yml` | windows-latest | Fresh Obsidian install, plugin loads, bridge comes up, clean-install parity |
-| `macos-e2e.yml` | macos-latest | Obsidian .dmg install, vault bootstrap, bridge, managed baseline |
-| `android-e2e.yml` | ubuntu-latest + emulator | APK install on Android emulator, vault prep, WebView bridge, chat smoke |
+| `ci.yml` | ubuntu-latest | Unit tests, embeddings tests, production build, built-bundle integration suite |
+| `macos-e2e.yml` | macos-latest | Obsidian .dmg install, vault bootstrap, bridge, managed baseline, release smoke against local provider fixtures (provider listing, chat round-trip, recorder, embeddings) |
+
+Windows and Android E2E run locally via the `test:native:windows:*` and
+`test:native:android*` scripts (Windows over SSH to the paired machine,
+Android against a connected device/emulator); they have no CI workflow yet.
 
 iOS is local-only: it requires a cable-connected physical iPad with Developer Mode. There is no simulator path for real Obsidian plugin QA. See `testing/native/device/ios/README.md`.
 

--- a/testing/fixtures/providers/index.cjs
+++ b/testing/fixtures/providers/index.cjs
@@ -34,6 +34,8 @@ const LMSTUDIO_FIXTURE_MODELS = [
 	{ id: "qwen/qwen3-8b", object: "model", owned_by: "organization_owner" },
 ];
 
+const FIXTURE_EMBEDDING_VECTOR = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
+
 function readBody(req) {
 	return new Promise((resolve) => {
 		let data = "";
@@ -151,6 +153,26 @@ function createLmStudioServer() {
 		if (req.method === "POST" && url.pathname === "/v1/chat/completions") {
 			return handleOpenAiChat(req, res);
 		}
+		if (req.method === "POST" && url.pathname === "/v1/embeddings") {
+			const raw = await readBody(req);
+			let parsed = {};
+			try {
+				parsed = JSON.parse(raw || "{}");
+			} catch {
+				return sendJson(res, 400, { error: { message: "invalid JSON body" } });
+			}
+			const inputs = Array.isArray(parsed.input) ? parsed.input : [parsed.input];
+			return sendJson(res, 200, {
+				object: "list",
+				model: String(parsed.model || "fixture-embeddings"),
+				data: inputs.map((_, index) => ({
+					object: "embedding",
+					index,
+					embedding: FIXTURE_EMBEDDING_VECTOR,
+				})),
+				usage: { prompt_tokens: 4, total_tokens: 4 },
+			});
+		}
 		return sendJson(res, 404, { error: { message: `no fixture route for ${req.method} ${url.pathname}` } });
 	});
 }
@@ -218,6 +240,7 @@ module.exports = {
 	OPENROUTER_FIXTURE_MODELS,
 	OLLAMA_FIXTURE_MODELS,
 	LMSTUDIO_FIXTURE_MODELS,
+	FIXTURE_EMBEDDING_VECTOR,
 	FIXTURE_TEXTS,
 	startProviderFixtures,
 };

--- a/testing/integration/provider-fixtures.test.ts
+++ b/testing/integration/provider-fixtures.test.ts
@@ -8,6 +8,7 @@
 const {
   startProviderFixtures,
   FIXTURE_TEXTS,
+  FIXTURE_EMBEDDING_VECTOR,
   OPENROUTER_FIXTURE_MODELS,
   OLLAMA_FIXTURE_MODELS,
   LMSTUDIO_FIXTURE_MODELS,
@@ -104,6 +105,20 @@ describe("provider fixture servers", () => {
     });
     const completion = await completionResponse.json();
     expect(completion.choices[0].message.content).toBe(FIXTURE_TEXTS.completion);
+  });
+
+  it("lmstudio fixture answers OpenAI-shape embeddings", async () => {
+    const response = await fetch(`${fixtures.lmstudio.url}/v1/embeddings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "fixture-embeddings", input: ["hello", "world"] }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.object).toBe("list");
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0].embedding).toEqual(FIXTURE_EMBEDDING_VECTOR);
+    expect(body.data[1].index).toBe(1);
   });
 
   it("whisper fixture returns the deterministic transcript", async () => {

--- a/testing/native/desktop-automation/client.mjs
+++ b/testing/native/desktop-automation/client.mjs
@@ -320,6 +320,15 @@ export class DesktopAutomationClient {
     });
   }
 
+  async updateSettings(settings) {
+    return await this.request("/v1/settings/update", {
+      method: "POST",
+      body: { settings },
+      timeoutMs: 30000,
+      allowRecovery: true,
+    });
+  }
+
   async toggleRecorder() {
     return await this.request("/v1/recorder/toggle", {
       method: "POST",

--- a/testing/native/desktop-automation/client.mjs
+++ b/testing/native/desktop-automation/client.mjs
@@ -320,6 +320,31 @@ export class DesktopAutomationClient {
     });
   }
 
+  async toggleRecorder() {
+    return await this.request("/v1/recorder/toggle", {
+      method: "POST",
+      body: {},
+      timeoutMs: 30000,
+      allowRecovery: true,
+    });
+  }
+
+  async getRecorderStatus() {
+    return await this.request("/v1/recorder/status", {
+      timeoutMs: 15000,
+      allowRecovery: true,
+    });
+  }
+
+  async embedText(text) {
+    return await this.request("/v1/embeddings/embed", {
+      method: "POST",
+      body: { text },
+      timeoutMs: 120000,
+      allowRecovery: true,
+    });
+  }
+
   async reloadPlugin() {
     return await this.request("/v1/plugin/reload", {
       method: "POST",

--- a/testing/native/desktop-automation/run.mjs
+++ b/testing/native/desktop-automation/run.mjs
@@ -18,7 +18,7 @@ Run no-focus desktop automation against the already-running Obsidian vault by
 talking to the plugin's localhost bridge instead of driving the renderer.
 
 Options:
-  --case <name|all|extended|stress|soak>   Case list: setup-baseline, managed-baseline, provider-connected-baseline, release-smoke, fixture-provider-listing, fixture-chat-roundtrip, model-switch, chat-exact, file-read, file-write, web-fetch, youtube-transcript, reload-stress, chatview-stress, all, extended, stress, or soak. Default: all
+  --case <name|all|extended|stress|soak>   Case list: setup-baseline, managed-baseline, provider-connected-baseline, release-smoke, fixture-provider-listing, fixture-chat-roundtrip, recorder-smoke, embeddings-smoke, model-switch, chat-exact, file-read, file-write, web-fetch, youtube-transcript, reload-stress, chatview-stress, all, extended, stress, or soak. Default: all
   --sync-config <path>         Sync config used to resolve the desktop plugin target. Default: ./systemsculpt-sync.config.json
   --target-index <n>           Pin a pluginTargets entry from the sync config
   --vault-name <name>          Pin a specific sync target by vault name

--- a/testing/native/desktop-automation/run.mjs
+++ b/testing/native/desktop-automation/run.mjs
@@ -29,6 +29,10 @@ Options:
   --repeat <n>                 Repeat the selected cases. Default: ${DEFAULT_REPEAT}
   --pause-ms <n>               Delay between iterations. Default: ${DEFAULT_PAUSE_MS}
   --json-output <path>         Write the final JSON report to this path as well as stdout
+  --apply-fixture-settings <path>
+                               Read a provider-fixture state file (see testing/fixtures/providers/serve.mjs)
+                               and apply the fixture-backed provider/transcription/embeddings settings
+                               through the live bridge before running cases
   --no-reload                  Reuse a live bridge if one already exists instead of forcing a plugin reload
   --allow-single-model-fallback
                                Allow fresh-install fallback coverage when only one authenticated model exists
@@ -122,6 +126,11 @@ function parseArgs(argv) {
     }
     if (arg === "--json-output") {
       options.jsonOutput = path.resolve(String(argv[index + 1] || "").trim());
+      index += 1;
+      continue;
+    }
+    if (arg === "--apply-fixture-settings") {
+      options.applyFixtureSettings = path.resolve(String(argv[index + 1] || "").trim());
       index += 1;
       continue;
     }

--- a/testing/native/desktop-automation/runner.mjs
+++ b/testing/native/desktop-automation/runner.mjs
@@ -2715,6 +2715,43 @@ export async function runChatViewStressCase(client, options = {}) {
   );
 }
 
+/**
+ * Settings patch that points the BYOK custom provider, transcription, and
+ * embeddings at the local fixture servers (issue #215 release smoke). Applied
+ * through the live bridge so the plugin persists it itself — editing
+ * data.json externally races the plugin's own settings flush.
+ */
+export function buildFixtureSettingsPatch(fixtureState) {
+  const openrouterUrl = String(fixtureState?.openrouter || "").trim();
+  const whisperUrl = String(fixtureState?.whisper || "").trim();
+  const lmstudioUrl = String(fixtureState?.lmstudio || "").trim();
+  if (!openrouterUrl || !whisperUrl || !lmstudioUrl) {
+    throw new Error(
+      `Fixture state file is missing server URLs. Got: ${JSON.stringify(fixtureState)}`
+    );
+  }
+  return {
+    customProviders: [
+      {
+        id: "openrouter",
+        name: "OpenRouter (fixture)",
+        endpoint: `${openrouterUrl}/api/v1`,
+        apiKey: "fixture-key",
+        isEnabled: true,
+      },
+    ],
+    autoTranscribeRecordings: true,
+    transcriptionProvider: "custom",
+    customTranscriptionEndpoint: `${whisperUrl}/v1/audio/transcriptions`,
+    customTranscriptionApiKey: "fixture-key",
+    customTranscriptionModel: "whisper-1",
+    embeddingsProvider: "custom",
+    embeddingsCustomEndpoint: `${lmstudioUrl}/v1/embeddings`,
+    embeddingsCustomApiKey: "fixture-key",
+    embeddingsCustomModel: "fixture-embeddings",
+  };
+}
+
 export async function runCase(client, options, caseName) {
   switch (caseName) {
     case SETUP_BASELINE_CASE:
@@ -2784,6 +2821,15 @@ export async function runDesktopAutomation(options, dependencies = {}) {
     `[desktop-automation] Connected to ${bootstrapResult.target.vaultName} via ${bootstrapResult.reload.method} ` +
       `(${bootstrapResult.client.baseUrl})`
   );
+
+  if (options.applyFixtureSettings) {
+    const fixtureState = JSON.parse(await fs.readFile(options.applyFixtureSettings, "utf8"));
+    const updated = await client.updateSettings(buildFixtureSettingsPatch(fixtureState));
+    log(
+      `[desktop-automation] Applied fixture settings (${(updated?.updatedKeys || []).length} keys) ` +
+        `from ${options.applyFixtureSettings}`
+    );
+  }
 
   const seededFixtures = await seedTextFixtures(client, fixtureDir, {
     loadFixtureBundle: dependencies.loadFixtureBundle,

--- a/testing/native/desktop-automation/runner.mjs
+++ b/testing/native/desktop-automation/runner.mjs
@@ -38,8 +38,15 @@ export const PROVIDER_CONNECTED_BASELINE_CASE = "provider-connected-baseline";
 export const SOAK_CASES = [DEFAULT_STRESS_CASE, CHATVIEW_STRESS_CASE];
 export const FIXTURE_PROVIDER_LISTING_CASE = "fixture-provider-listing";
 export const FIXTURE_CHAT_ROUNDTRIP_CASE = "fixture-chat-roundtrip";
+export const RECORDER_SMOKE_CASE = "recorder-smoke";
+export const EMBEDDINGS_SMOKE_CASE = "embeddings-smoke";
 export const RELEASE_SMOKE_CASE = "release-smoke";
-const RELEASE_SMOKE_CASES = [FIXTURE_PROVIDER_LISTING_CASE, FIXTURE_CHAT_ROUNDTRIP_CASE];
+const RELEASE_SMOKE_CASES = [
+  FIXTURE_PROVIDER_LISTING_CASE,
+  FIXTURE_CHAT_ROUNDTRIP_CASE,
+  RECORDER_SMOKE_CASE,
+  EMBEDDINGS_SMOKE_CASE,
+];
 const BASELINE_SUITE_CASES = [MANAGED_BASELINE_CASE, PROVIDER_CONNECTED_BASELINE_CASE];
 const MANAGED_SYSTEMSCULPT_MODEL_ID = "systemsculpt@@systemsculpt/ai-agent";
 const DESKTOP_BASELINE_PI_MODEL_ID = "local-pi-openrouter@@openai/gpt-5.4-mini";
@@ -1851,6 +1858,63 @@ export async function runFixtureChatRoundtripCase(client) {
   };
 }
 
+/**
+ * Release smoke (issue #215): recorder start/stop with the Chromium fake
+ * media device, transcribed through the local Whisper-shaped fixture. Proves
+ * the capture pipeline, the custom transcription path, and the deterministic
+ * transcript end to end without microphones or real credentials.
+ */
+export async function runRecorderSmokeCase(client, options = {}) {
+  const recordMs = Number.isFinite(options.recorderCaptureMs) ? Number(options.recorderCaptureMs) : 2000;
+  const started = await client.toggleRecorder();
+  if (started?.recording !== true) {
+    throw new Error(`Recorder smoke expected recording to start. Got: ${JSON.stringify(started)}`);
+  }
+
+  await sleep(recordMs);
+
+  const stopped = await client.toggleRecorder();
+  if (stopped?.recording !== false) {
+    throw new Error(`Recorder smoke expected recording to stop. Got: ${JSON.stringify(stopped)}`);
+  }
+
+  const deadline = Date.now() + 90000;
+  let status = null;
+  while (Date.now() < deadline) {
+    status = await client.getRecorderStatus();
+    if (typeof status?.lastTranscript === "string" && status.lastTranscript.trim()) {
+      break;
+    }
+    await sleep(1000);
+  }
+
+  const transcript = String(status?.lastTranscript || "").trim();
+  assertIncludes(transcript, FIXTURE_TEXTS.transcript, "Recorder smoke transcript");
+
+  return {
+    capturedMs: recordMs,
+    transcript,
+  };
+}
+
+/**
+ * Release smoke (issue #215): one embeddings round-trip through the active
+ * provider (the CI vault points the custom embeddings provider at the local
+ * OpenAI-shaped fixture). Asserts a non-empty vector came back.
+ */
+export async function runEmbeddingsSmokeCase(client) {
+  const result = await client.embedText("release smoke embeddings round-trip");
+  const dimensions = Number(result?.dimensions || 0);
+  if (!(dimensions > 0)) {
+    throw new Error(`Embeddings smoke expected a non-empty vector. Got: ${JSON.stringify(result)}`);
+  }
+  return {
+    provider: String(result?.provider || ""),
+    model: String(result?.model || ""),
+    dimensions,
+  };
+}
+
 export async function runProviderConnectedBaselineCase(client, options = {}) {
   const authConfig = resolveProviderConnectedAuthConfig(options.env || process.env);
   const inventory = await loadModelInventory(client);
@@ -2663,6 +2727,10 @@ export async function runCase(client, options, caseName) {
       return { client, result: await runFixtureProviderListingCase(client) };
     case FIXTURE_CHAT_ROUNDTRIP_CASE:
       return { client, result: await runFixtureChatRoundtripCase(client) };
+    case RECORDER_SMOKE_CASE:
+      return { client, result: await runRecorderSmokeCase(client, options) };
+    case EMBEDDINGS_SMOKE_CASE:
+      return { client, result: await runEmbeddingsSmokeCase(client) };
     case "model-switch":
       return { client, result: await runModelSwitchCase(client, options) };
     case "chat-exact":

--- a/testing/native/desktop-automation/runner.test.mjs
+++ b/testing/native/desktop-automation/runner.test.mjs
@@ -6,6 +6,7 @@ import {
   RECORDER_SMOKE_CASE,
   runEmbeddingsSmokeCase,
   runRecorderSmokeCase,
+  buildFixtureSettingsPatch,
   BASELINE_SUITE_CASE,
   CHATVIEW_STRESS_CASE,
   FIXTURE_CHAT_ROUNDTRIP_CASE,
@@ -2738,4 +2739,20 @@ test("runEmbeddingsSmokeCase asserts a non-empty vector", async () => {
     }),
     /non-empty vector/
   );
+});
+
+test("buildFixtureSettingsPatch maps fixture URLs onto provider/transcription/embeddings settings", () => {
+  const patch = buildFixtureSettingsPatch({
+    openrouter: "http://127.0.0.1:4310",
+    whisper: "http://127.0.0.1:4311",
+    lmstudio: "http://127.0.0.1:4312",
+  });
+  assert.equal(patch.customProviders[0].endpoint, "http://127.0.0.1:4310/api/v1");
+  assert.equal(patch.customTranscriptionEndpoint, "http://127.0.0.1:4311/v1/audio/transcriptions");
+  assert.equal(patch.embeddingsCustomEndpoint, "http://127.0.0.1:4312/v1/embeddings");
+  assert.equal(patch.transcriptionProvider, "custom");
+  assert.equal(patch.embeddingsProvider, "custom");
+  assert.equal(patch.autoTranscribeRecordings, true);
+
+  assert.throws(() => buildFixtureSettingsPatch({}), /missing server URLs/);
 });

--- a/testing/native/desktop-automation/runner.test.mjs
+++ b/testing/native/desktop-automation/runner.test.mjs
@@ -2,6 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   assertHealthyStatus,
+  EMBEDDINGS_SMOKE_CASE,
+  RECORDER_SMOKE_CASE,
+  runEmbeddingsSmokeCase,
+  runRecorderSmokeCase,
   BASELINE_SUITE_CASE,
   CHATVIEW_STRESS_CASE,
   FIXTURE_CHAT_ROUNDTRIP_CASE,
@@ -2623,6 +2627,8 @@ test("caseList resolves release-smoke to the fixture cases", () => {
   assert.deepEqual(caseList(RELEASE_SMOKE_CASE), [
     FIXTURE_PROVIDER_LISTING_CASE,
     FIXTURE_CHAT_ROUNDTRIP_CASE,
+    RECORDER_SMOKE_CASE,
+    EMBEDDINGS_SMOKE_CASE,
   ]);
 });
 
@@ -2691,4 +2697,45 @@ test("runFixtureChatRoundtripCase asserts the deterministic fixture completion",
   const outcome = await runFixtureChatRoundtripCase(buildFixtureSmokeClient());
   assert.equal(outcome.selectedModelId, "openrouter@@openai/gpt-5.4-mini");
   assert.match(outcome.response, /fixture-completion: hello from the mock provider/);
+});
+
+test("runRecorderSmokeCase drives toggle on/off and waits for the fixture transcript", async () => {
+  let recording = false;
+  let transcript = null;
+  const client = {
+    async toggleRecorder() {
+      recording = !recording;
+      if (!recording) {
+        setTimeout(() => {
+          transcript = "fixture-transcript: hello from the mock whisper";
+        }, 10);
+      }
+      return { recording };
+    },
+    async getRecorderStatus() {
+      return { recording, lastTranscript: transcript };
+    },
+  };
+
+  const outcome = await runRecorderSmokeCase(client, { recorderCaptureMs: 5 });
+  assert.match(outcome.transcript, /fixture-transcript/);
+});
+
+test("runEmbeddingsSmokeCase asserts a non-empty vector", async () => {
+  const outcome = await runEmbeddingsSmokeCase({
+    async embedText() {
+      return { provider: "custom", model: "fixture-embeddings", dimensions: 8 };
+    },
+  });
+  assert.equal(outcome.dimensions, 8);
+  assert.equal(outcome.provider, "custom");
+
+  await assert.rejects(
+    runEmbeddingsSmokeCase({
+      async embedText() {
+        return { provider: "custom", model: "fixture-embeddings", dimensions: 0 };
+      },
+    }),
+    /non-empty vector/
+  );
 });


### PR DESCRIPTION
- Completes the #215 smoke surface: recorder start/stop captures fake-device audio and must produce the fixture transcript; embeddings round-trip through the local fixture must return a real vector. Both run in macos-e2e on every PR alongside the provider listing and chat cases.
- New automation-bridge routes (recorder toggle/status, embeddings embed) so agents and CI drive these behaviors directly.
- Adds CONTRIBUTING.md (failing-test-first convention, gate list) and fixes the testing README's CI lane table.

Final slice of #215 after #217 and #218. The recorder case is the first run of Chromium's fake media device on the macOS runner; if it proves flaky there, the case can be split out of the PR gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transcription observer callback API for recording functionality
  * Added embeddings diagnostics helper for testing

* **Tests**
  * Added recorder and embeddings smoke test cases
  * Added deterministic embeddings fixtures with vector validation

* **Documentation**
  * Updated contribution guidelines with testing workflow strategy
  * Updated testing documentation for CI workflows

* **Chores**
  * Refactored macOS E2E workflow and release-smoke test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->