### PR TITLE
Update release CI action pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Use Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           cache: "npm"
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/macos-e2e.yml
+++ b/.github/workflows/macos-e2e.yml
@@ -25,12 +25,12 @@ jobs:
       SYSTEMSCULPT_RUNTIME_SMOKE_SERVER_URL: ${{ secrets.SYSTEMSCULPT_RUNTIME_SMOKE_SERVER_URL }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Use Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           cache: "npm"
           cache-dependency-path: package-lock.json
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Cache Obsidian installer
         id: obsidian-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/obsidian-installer
           key: obsidian-dmg-${{ env.OBSIDIAN_VERSION }}
@@ -272,7 +272,7 @@ jobs:
 
       - name: Upload failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-e2e-diagnostics
           path: |

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   windows-e2e:
     name: windows-e2e
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     timeout-minutes: 25
     env:
       OBSIDIAN_VERSION: ${{ inputs.obsidian_version || '1.8.9' }}
@@ -30,12 +30,12 @@ jobs:
       XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Use Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           cache: "npm"
           cache-dependency-path: package-lock.json
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Cache Obsidian installer
         id: obsidian-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~\obsidian-installer
           key: obsidian-exe-${{ env.OBSIDIAN_VERSION }}
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload Windows diagnostics
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-e2e-diagnostics
           path: ${{ runner.temp }}\systemsculpt-windows-diagnostics

--- a/scripts/github-workflows.test.mjs
+++ b/scripts/github-workflows.test.mjs
@@ -18,7 +18,7 @@ test("Windows E2E workflow keeps the canonical build, bootstrap, clean-install, 
 
   assert.match(text, /^\s*windows-e2e:/m);
   assert.match(text, /^\s*name: windows-e2e$/m);
-  assert.match(text, /runs-on: windows-latest/);
+  assert.match(text, /runs-on: windows-2025-vs2026/);
   assert.match(text, /XAI_API_KEY: \$\{\{ secrets\.XAI_API_KEY \}\}/);
   assert.match(text, /--skip-trust-prompt/);
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -80,7 +80,7 @@ Docs:
 Before ship, the required native matrix is:
 
 - macOS: `npm run test:native:desktop:baselines`
-- Windows: GitHub check `windows-e2e` on the exact release commit. The job installs Obsidian on `windows-latest`, launches the fresh Windows QA vault, then runs `npm run test:native:windows:clean-install` and `npm run test:native:windows:baselines`.
+- Windows: GitHub check `windows-e2e` on the exact release commit. The job installs Obsidian on `windows-2025-vs2026`, launches the fresh Windows QA vault, then runs `npm run test:native:windows:clean-install` and `npm run test:native:windows:baselines`.
 - Android: `npm run test:native:android:debug:open -- --config ./systemsculpt-sync.android.json --headless --sync --reset-vault` then `npm run test:native:android:extended`
 - iOS: `npm run test:native:ios` when a paired physical device is available
 
@@ -96,7 +96,7 @@ Automated E2E testing runs in GitHub Actions on every PR and push to main:
 |----------|--------|----------------|
 | `ci.yml` | ubuntu-latest | Unit tests, embeddings tests, production build, built-bundle integration suite |
 | `macos-e2e.yml` | macos-latest | Obsidian .dmg install, vault bootstrap, bridge, managed baseline, release smoke against local provider fixtures (provider listing, chat round-trip, recorder, embeddings) |
-| `windows-e2e.yml` | windows-latest | Obsidian `.exe` install, fresh Windows vault bootstrap, local bridge, clean-install parity, xAI/Grok provider pass, and Windows desktop baselines |
+| `windows-e2e.yml` | windows-2025-vs2026 | Obsidian `.exe` install, fresh Windows vault bootstrap, local bridge, clean-install parity, xAI/Grok provider pass, and Windows desktop baselines |
 
 Android E2E still runs locally via the `test:native:android*` scripts against a connected device/emulator.
 

--- a/testing/native/device/windows/README.md
+++ b/testing/native/device/windows/README.md
@@ -106,7 +106,7 @@ republish the bridge without foregrounding Obsidian.
 That split keeps Windows responsible for fresh-user truth while still reusing the same bridge
 automation layer as macOS once the runtime is open.
 
-`npm run check:release:windows` is the canonical Windows release gate: it requires the GitHub `windows-e2e` check to be green for the current commit. That hosted job installs Obsidian on `windows-latest`, runs the local Windows bootstrap with a fresh vault, then runs `test:native:windows:clean-install` and `test:native:windows:baselines` in that order.
+`npm run check:release:windows` is the canonical Windows release gate: it requires the GitHub `windows-e2e` check to be green for the current commit. That hosted job installs Obsidian on `windows-2025-vs2026`, runs the local Windows bootstrap with a fresh vault, then runs `test:native:windows:clean-install` and `test:native:windows:baselines` in that order.
 
 `npm run check:release:windows:local` is the optional development helper for a maintained Windows host. It still runs `build`, `test:native:windows:clean-install`, and `test:native:windows:baselines` locally or through the configured SSH transport, but release creation no longer depends on a Mac-side VM or throwaway Windows guest.
 


### PR DESCRIPTION
Update: move release CI to current pinned GitHub Actions and Node 24, and pin the Windows runner image used by the release gate.