### PR TITLE
Wait for Android shared storage before sync

### DIFF
--- a/testing/native/device/android/sync-plugin.mjs
+++ b/testing/native/device/android/sync-plugin.mjs
@@ -15,6 +15,7 @@ import {
   runAdbShell,
   selectAndroidDevice,
   shellQuote,
+  waitForAndroidSharedStorage,
 } from "./utils.mjs";
 import {
   REQUIRED_PLUGIN_ARTIFACTS,
@@ -141,6 +142,9 @@ console.log(`[android-sync] Target device: ${device.serial}`);
 console.log(`[android-sync] Vault path: ${vaultPath}`);
 console.log(`[android-sync] Plugin path: ${pluginPath}`);
 console.log(`[android-sync] main.js size: ${artifactInspection.mainBundle.formattedSize}`);
+
+console.log("[android-sync] Waiting for Android shared storage");
+await waitForAndroidSharedStorage({ adbPath, serial: device.serial });
 
 if (options.resetVault) {
   console.log("[android-sync] Resetting Android QA vault");

--- a/testing/native/device/android/utils.mjs
+++ b/testing/native/device/android/utils.mjs
@@ -230,6 +230,36 @@ export async function waitForDeviceBoot({ adbPath = resolveAdbPath(), serial, ti
   fail(`Timed out waiting for Android device ${serial || "(auto)"} to finish booting.`);
 }
 
+export function buildAndroidSharedStorageReadyScript() {
+  return "[ -d /sdcard/Android ] || [ -d /storage/self/primary/Android ]";
+}
+
+export async function waitForAndroidSharedStorage({
+  adbPath = resolveAdbPath(),
+  serial,
+  timeoutMs = 60000,
+  pollMs = 1000,
+  runAdbShellImpl = runAdbShell,
+  sleepImpl = sleep,
+} = {}) {
+  const attempts = Math.max(1, Math.ceil(Number(timeoutMs) / Math.max(1, Number(pollMs))));
+  let lastError = null;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      runAdbShellImpl(adbPath, serial, buildAndroidSharedStorageReadyScript());
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < attempts - 1) {
+      await sleepImpl(pollMs);
+    }
+  }
+
+  const details = lastError instanceof Error ? ` Last error: ${lastError.message}` : "";
+  fail(`Timed out waiting for Android shared storage on ${serial || "(auto)"}.${details}`);
+}
+
 export async function waitForAndroidDeviceSelection({
   adbPath = resolveAdbPath(),
   serial = null,

--- a/testing/native/device/android/utils.test.mjs
+++ b/testing/native/device/android/utils.test.mjs
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { inferAvdNameFromConfig, resolveAndroidDeviceSelection } from "./utils.mjs";
+import {
+  buildAndroidSharedStorageReadyScript,
+  inferAvdNameFromConfig,
+  resolveAndroidDeviceSelection,
+  waitForAndroidSharedStorage,
+} from "./utils.mjs";
 
 test("resolveAndroidDeviceSelection returns null for a missing configured serial when allowMissing is enabled", () => {
   const selected = resolveAndroidDeviceSelection(
@@ -49,4 +54,38 @@ test("inferAvdNameFromConfig returns a trimmed configured AVD name", () => {
     "SystemSculpt_Pixel_9_API_36_1"
   );
   assert.equal(inferAvdNameFromConfig({}), null);
+});
+
+test("buildAndroidSharedStorageReadyScript checks both sdcard aliases", () => {
+  const script = buildAndroidSharedStorageReadyScript();
+
+  assert.match(script, /\/sdcard\/Android/);
+  assert.match(script, /\/storage\/self\/primary\/Android/);
+});
+
+test("waitForAndroidSharedStorage retries until shared storage is ready", async () => {
+  let attempts = 0;
+  const sleepDurations = [];
+
+  await waitForAndroidSharedStorage({
+    adbPath: "/mock/adb",
+    serial: "emulator-5554",
+    timeoutMs: 3000,
+    pollMs: 1000,
+    runAdbShellImpl(adbPath, serial, script) {
+      attempts += 1;
+      assert.equal(adbPath, "/mock/adb");
+      assert.equal(serial, "emulator-5554");
+      assert.equal(script, buildAndroidSharedStorageReadyScript());
+      if (attempts < 3) {
+        throw new Error("shared storage not mounted yet");
+      }
+    },
+    sleepImpl: async (duration) => {
+      sleepDurations.push(duration);
+    },
+  });
+
+  assert.equal(attempts, 3);
+  assert.deepEqual(sleepDurations, [1000, 1000]);
 });


### PR DESCRIPTION
Update: Android release sync now waits for shared storage before recreating the QA vault, avoiding emulator boot races.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android device sync now waits for shared storage to be ready before continuing, helping avoid vault reset/sync failures during startup.
  * Improved reliability when running sync operations on Android by retrying until the storage check passes or a timeout is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->