### PR TITLE
feat(studio): model + lever controls for the image generation node

### DIFF
--- a/src/services/canvasflow/ImageGenerationModelCatalog.ts
+++ b/src/services/canvasflow/ImageGenerationModelCatalog.ts
@@ -63,16 +63,30 @@ type CuratedImageGenerationModelSeed = {
 
 const EXCLUDED_MODEL_IDS = new Set(["openrouter/auto"]);
 
+// Mirrors the server's curated image-model allow-list (see the website repo's
+// image-generation catalog). The managed default is offered separately as the
+// "SystemSculpt Default" option, so it is intentionally absent here. Server
+// catalog metadata (pricing, limits) overrides these fallbacks once synced.
 const CURATED_IMAGE_GENERATION_MODELS_SEED: readonly CuratedImageGenerationModelSeed[] = [
   {
-    id: "openai/gpt-5-image-mini",
-    label: "OpenAI GPT-5 Image Mini",
-    provider: "OpenAI",
+    id: "google/gemini-3-pro-image-preview",
+    label: "Google Nano Banana Pro (Gemini 3 Pro Image)",
+    provider: "Google",
     supportsImageInput: true,
     maxImagesPerJob: 4,
     defaultAspectRatio: "1:1",
     allowedAspectRatios: ["1:1", "4:3", "3:4", "16:9", "9:16", "3:2", "2:3"],
-    fallbackUsdPerImage: 0.02,
+    fallbackUsdPerImage: 0.12,
+  },
+  {
+    id: "google/gemini-2.5-flash-image",
+    label: "Google Nano Banana (Gemini 2.5 Flash Image)",
+    provider: "Google",
+    supportsImageInput: true,
+    maxImagesPerJob: 4,
+    defaultAspectRatio: "1:1",
+    allowedAspectRatios: ["1:1", "4:3", "3:4", "16:9", "9:16", "3:2", "2:3"],
+    fallbackUsdPerImage: 0.04,
   },
   {
     id: "openai/gpt-5-image",
@@ -82,17 +96,27 @@ const CURATED_IMAGE_GENERATION_MODELS_SEED: readonly CuratedImageGenerationModel
     maxImagesPerJob: 4,
     defaultAspectRatio: "1:1",
     allowedAspectRatios: ["1:1", "4:3", "3:4", "16:9", "9:16", "3:2", "2:3"],
-    fallbackUsdPerImage: 0.04,
+    fallbackUsdPerImage: 0.08,
   },
   {
-    id: "google/gemini-2.5-flash-image",
-    label: "Google Gemini 2.5 Flash Image",
-    provider: "Google",
+    id: "openai/gpt-5-image-mini",
+    label: "OpenAI GPT-5 Image Mini",
+    provider: "OpenAI",
     supportsImageInput: true,
     maxImagesPerJob: 4,
     defaultAspectRatio: "1:1",
     allowedAspectRatios: ["1:1", "4:3", "3:4", "16:9", "9:16", "3:2", "2:3"],
-    fallbackUsdPerImage: 0.015,
+    fallbackUsdPerImage: 0.03,
+  },
+  {
+    id: "black-forest-labs/flux.2-pro",
+    label: "Black Forest Labs FLUX.2 Pro",
+    provider: "Black Forest Labs",
+    supportsImageInput: true,
+    maxImagesPerJob: 4,
+    defaultAspectRatio: "1:1",
+    allowedAspectRatios: ["1:1", "4:3", "3:4", "16:9", "9:16", "3:2", "2:3"],
+    fallbackUsdPerImage: 0.06,
   },
 ] as const;
 

--- a/src/services/canvasflow/SystemSculptImageGenerationService.ts
+++ b/src/services/canvasflow/SystemSculptImageGenerationService.ts
@@ -87,10 +87,12 @@ export type SystemSculptPrepareInputImageUploadsResponse = {
 
 export type SystemSculptCreateGenerationJobRequest = {
   prompt: string;
+  model?: string;
   input_images?: SystemSculptImageInput[];
   options?: {
     count?: number;
     aspect_ratio?: string;
+    image_size?: string;
     seed?: number;
   };
 };
@@ -946,6 +948,11 @@ export class SystemSculptImageGenerationService {
       input_images: request.input_images || [],
     };
 
+    const modelId = typeof request.model === "string" ? request.model.trim() : "";
+    if (modelId) {
+      payload.model = modelId;
+    }
+
     if (request.options) {
       const optionsPayload: Record<string, unknown> = {};
       if (typeof request.options.count === "number" && Number.isFinite(request.options.count)) {
@@ -953,6 +960,9 @@ export class SystemSculptImageGenerationService {
       }
       if (typeof request.options.aspect_ratio === "string" && request.options.aspect_ratio.trim()) {
         optionsPayload.aspect_ratio = request.options.aspect_ratio.trim();
+      }
+      if (typeof request.options.image_size === "string" && request.options.image_size.trim()) {
+        optionsPayload.image_size = request.options.image_size.trim();
       }
       if (typeof request.options.seed === "number" && Number.isFinite(request.options.seed)) {
         optionsPayload.seed = Math.max(0, Math.floor(request.options.seed));

--- a/src/services/canvasflow/__tests__/ImageGenerationModelCatalog.test.ts
+++ b/src/services/canvasflow/__tests__/ImageGenerationModelCatalog.test.ts
@@ -39,7 +39,7 @@ describe("ImageGenerationModelCatalog", () => {
     const text = formatCuratedImageModelOptionText(model!);
     expect(text).toContain("OpenAI GPT-5 Image Mini");
     expect(text).not.toContain("openai/gpt-5-image-mini");
-    expect(text).toContain("$0.02");
+    expect(text).toContain("$0.03");
     expect(text).toContain("cr/img");
   });
 

--- a/src/studio/StudioApiExecutionAdapter.ts
+++ b/src/studio/StudioApiExecutionAdapter.ts
@@ -70,7 +70,7 @@ function buildStudioImageIdempotencyKey(
     .map((asset) => `${String(asset.hash || "").toLowerCase()}:${Math.max(0, Number(asset.sizeBytes) || 0)}`)
     .join("|");
   const payloadSignature = hashFnv1aHex(
-    `${String(request.prompt || "")}|${String(request.aspectRatio || "")}|${String(request.count || "")}|${imageSignature}`
+    `${String(request.prompt || "")}|${String(request.aspectRatio || "")}|${String(request.count || "")}|${String(request.imageSize || "")}|${request.seed ?? ""}|${imageSignature}`
   );
   return `studio-image-${runToken}-${modelToken}-r${attemptToken}-${payloadSignature}`;
 }
@@ -411,7 +411,14 @@ export class StudioApiExecutionAdapter implements StudioApiAdapter {
   }
 
   async generateImage(request: StudioImageGenerationRequest): Promise<StudioImageGenerationResult> {
-    const modelId = String(request.modelId || STUDIO_MANAGED_IMAGE_MODEL_ID).trim() || STUDIO_MANAGED_IMAGE_MODEL_ID;
+    // An empty selection means "let the server pick the managed default"; we must
+    // not send the synthetic local sentinel as a model id (the server rejects it).
+    const selectedModelId = String(request.modelId || "").trim();
+    const requestModelId = selectedModelId || undefined;
+    const resultModelId = selectedModelId || STUDIO_MANAGED_IMAGE_MODEL_ID;
+    const imageSize = String(request.imageSize || "").trim();
+    const seedRaw = Number(request.seed);
+    const seed = Number.isFinite(seedRaw) && seedRaw >= 0 ? Math.floor(seedRaw) : undefined;
     const imageClient = this.ensureImageClient();
     const { uploadedInputImages, inputImageBytes } = await this.uploadInputImagesForStudioGeneration(
       imageClient,
@@ -429,14 +436,17 @@ export class StudioApiExecutionAdapter implements StudioApiAdapter {
         create = await imageClient.createGenerationJob(
           {
             prompt: request.prompt,
+            model: requestModelId,
             input_images: uploadedInputImages,
             options: {
               count: request.count,
               aspect_ratio: resolvedAspectRatio || undefined,
+              image_size: imageSize || undefined,
+              seed,
             },
           },
           {
-            idempotencyKey: buildStudioImageIdempotencyKey(request, modelId, attempt),
+            idempotencyKey: buildStudioImageIdempotencyKey(request, resultModelId, attempt),
           }
         );
       } catch (error) {
@@ -492,7 +502,7 @@ export class StudioApiExecutionAdapter implements StudioApiAdapter {
 
       return {
         images,
-        modelId,
+        modelId: resultModelId,
       };
     }
 

--- a/src/studio/StudioDynamicSelectOptions.ts
+++ b/src/studio/StudioDynamicSelectOptions.ts
@@ -5,6 +5,10 @@ import type {
   StudioNodeConfigSelectOption,
 } from "./types";
 import type { SystemSculptModel } from "../types/llm";
+import {
+  getCuratedImageGenerationModelGroups,
+  type ImageGenerationServerCatalogModel,
+} from "../services/canvasflow/ImageGenerationModelCatalog";
 
 function normalizeText(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -56,11 +60,64 @@ function toPiTextOption(
   };
 }
 
+function readCachedServerImageModels(
+  plugin: SystemSculptPlugin
+): ImageGenerationServerCatalogModel[] {
+  const raw = plugin.settings.imageGenerationModelCatalogCache?.models;
+  // The cached catalog is normalized again downstream, so a loose pass-through is safe.
+  return Array.isArray(raw) ? (raw as ImageGenerationServerCatalogModel[]) : [];
+}
+
+function resolveStudioImageModelOptions(
+  plugin: SystemSculptPlugin
+): StudioNodeConfigSelectOption[] {
+  const authenticated = normalizeText(plugin.settings.licenseKey).length > 0;
+  const options: StudioNodeConfigSelectOption[] = [
+    {
+      value: "",
+      label: "SystemSculpt Default",
+      description: "Managed image model chosen by SystemSculpt (recommended).",
+      badge: "Default",
+      keywords: ["default", "managed", "systemsculpt", "auto", "nano banana"],
+      providerAuthenticated: authenticated,
+    },
+  ];
+
+  const groups = getCuratedImageGenerationModelGroups(readCachedServerImageModels(plugin));
+  for (const group of groups) {
+    for (const model of group.models) {
+      const id = normalizeText(model.id);
+      // The managed engine is already represented by the "SystemSculpt Default" entry.
+      if (!id || id.toLowerCase().startsWith("systemsculpt/managed")) {
+        continue;
+      }
+      const summary = normalizeText(model.pricing?.summary);
+      options.push({
+        value: id,
+        label: normalizeText(model.label) || id,
+        description: summary || undefined,
+        badge: normalizeText(model.provider) || undefined,
+        keywords: [id, normalizeText(model.label), normalizeText(model.provider)].filter(
+          (entry) => entry.length > 0
+        ),
+        providerAuthenticated: authenticated,
+      });
+    }
+  }
+
+  return options;
+}
+
 export async function resolveStudioDynamicSelectOptions(options: {
   plugin: SystemSculptPlugin;
   source: StudioNodeConfigDynamicOptionsSource;
 }): Promise<StudioNodeConfigSelectOption[]> {
   const { plugin, source } = options;
+
+  if (source === "studio.systemsculpt_image_models") {
+    return resolveStudioImageModelOptions(plugin);
+  }
+
   if (
     source !== "studio.pi_text_models" &&
     source !== "studio.systemsculpt_text_models" &&

--- a/src/studio/StudioDynamicSelectOptions.ts
+++ b/src/studio/StudioDynamicSelectOptions.ts
@@ -86,6 +86,11 @@ function resolveStudioImageModelOptions(
   const groups = getCuratedImageGenerationModelGroups(readCachedServerImageModels(plugin));
   for (const group of groups) {
     for (const model of group.models) {
+      // Skip models the synced catalog explicitly marks as non-generating, so the
+      // picker never offers a model the backend would reject at generation time.
+      if (model.supportsGeneration === false) {
+        continue;
+      }
       const id = normalizeText(model.id);
       // The managed engine is already represented by the "SystemSculpt Default" entry.
       if (!id || id.toLowerCase().startsWith("systemsculpt/managed")) {

--- a/src/studio/StudioGraphMigrations.ts
+++ b/src/studio/StudioGraphMigrations.ts
@@ -191,8 +191,13 @@ function migrateImageGenerationNodes(
         : typeof countValue === "string"
           ? Number(countValue.trim())
           : Number.NaN;
-    if (Number.isFinite(countNumeric) && countNumeric > 4) {
-      nextConfig.count = 4;
+    if (Number.isFinite(countNumeric)) {
+      // Floor as well as clamp: the schema is integer-constrained, so a stray
+      // decimal would also fail validation, not just an out-of-range integer.
+      const normalizedCount = Math.min(4, Math.floor(countNumeric));
+      if (normalizedCount !== countValue) {
+        nextConfig.count = normalizedCount;
+      }
     }
 
     if (JSON.stringify(nextConfig) !== JSON.stringify(currentConfig)) {

--- a/src/studio/StudioGraphMigrations.ts
+++ b/src/studio/StudioGraphMigrations.ts
@@ -7,6 +7,7 @@ const PROMPT_TEMPLATE_INLINE_MIGRATION_ID = "studio.inline-prompt-template.v1";
 const RESEND_TO_HTTP_REQUEST_MIGRATION_ID = "studio.resend-http-request.v1";
 const NOTE_NODE_CANONICAL_MIGRATION_ID = "studio.note-canonical-config.v1";
 const PI_TEXT_NODE_MODEL_MIGRATION_ID = "studio.pi-text-model-selector.v1";
+const IMAGE_NODE_LEVERS_MIGRATION_ID = "studio.image-node-levers.v1";
 const RESEND_DEFAULT_BASE_URL = "https://api.resend.com";
 const RESEND_DEFAULT_MAX_RETRIES = 3;
 
@@ -138,6 +139,47 @@ function migrateTextGenerationNodes(
     };
     delete nextConfig.sourceMode;
     delete nextConfig.localModelId;
+
+    if (JSON.stringify(nextConfig) !== JSON.stringify(currentConfig)) {
+      changed = true;
+      return {
+        ...node,
+        config: nextConfig,
+      };
+    }
+
+    return node;
+  });
+
+  return {
+    nodes: nextNodes,
+    changed,
+  };
+}
+
+function migrateImageGenerationNodes(
+  nodes: StudioProjectV1["graph"]["nodes"]
+): {
+  nodes: StudioProjectV1["graph"]["nodes"];
+  changed: boolean;
+} {
+  let changed = false;
+  const nextNodes = nodes.map((node) => {
+    if (node.kind !== "studio.image_generation") {
+      return node;
+    }
+
+    const currentConfig = (node.config || {}) as Record<string, StudioJsonValue>;
+    const nextConfig: Record<string, StudioJsonValue> = { ...currentConfig };
+    // Backfill the model + resolution levers as explicit defaults so the new
+    // controls render with a known selection ("" => SystemSculpt managed default).
+    // Seed is intentionally left absent, which the node treats as "random".
+    if (typeof nextConfig.modelId !== "string") {
+      nextConfig.modelId = "";
+    }
+    if (typeof nextConfig.imageSize !== "string") {
+      nextConfig.imageSize = "";
+    }
 
     if (JSON.stringify(nextConfig) !== JSON.stringify(currentConfig)) {
       changed = true;
@@ -505,6 +547,12 @@ export function migrateStudioProjectToPathOnlyPorts(project: StudioProjectV1): {
     nodes = textGenerationMigration.nodes;
   }
 
+  const imageGenerationMigration = migrateImageGenerationNodes(nodes);
+  if (imageGenerationMigration.changed) {
+    changed = true;
+    nodes = imageGenerationMigration.nodes;
+  }
+
   let entryNodeIds = project.graph.entryNodeIds;
   let groups = project.graph.groups;
   const promptTemplateMigration = migratePromptTemplateNodes(nodes, edges, entryNodeIds, groups);
@@ -549,6 +597,12 @@ export function migrateStudioProjectToPathOnlyPorts(project: StudioProjectV1): {
   if (textGenerationMigration.changed && !appliedMigrationIds.has(PI_TEXT_NODE_MODEL_MIGRATION_ID)) {
     nextApplied.push({
       id: PI_TEXT_NODE_MODEL_MIGRATION_ID,
+      at: nowIso(),
+    });
+  }
+  if (imageGenerationMigration.changed && !appliedMigrationIds.has(IMAGE_NODE_LEVERS_MIGRATION_ID)) {
+    nextApplied.push({
+      id: IMAGE_NODE_LEVERS_MIGRATION_ID,
       at: nowIso(),
     });
   }

--- a/src/studio/StudioGraphMigrations.ts
+++ b/src/studio/StudioGraphMigrations.ts
@@ -180,6 +180,20 @@ function migrateImageGenerationNodes(
     if (typeof nextConfig.imageSize !== "string") {
       nextConfig.imageSize = "";
     }
+    // Older projects could save count 5-8 under the previous schema (max 8). The
+    // new max is 4, and config validation rejects out-of-range values before the
+    // node's runtime clamp runs, so normalize legacy counts here or the flow
+    // would fail to compile instead of being capped.
+    const countValue = nextConfig.count;
+    const countNumeric =
+      typeof countValue === "number"
+        ? countValue
+        : typeof countValue === "string"
+          ? Number(countValue.trim())
+          : Number.NaN;
+    if (Number.isFinite(countNumeric) && countNumeric > 4) {
+      nextConfig.count = 4;
+    }
 
     if (JSON.stringify(nextConfig) !== JSON.stringify(currentConfig)) {
       changed = true;

--- a/src/studio/__tests__/studio-built-in-node-execution.test.ts
+++ b/src/studio/__tests__/studio-built-in-node-execution.test.ts
@@ -668,7 +668,73 @@ describe("Studio built-in text/image node execution", () => {
     const imageRequest = generateImageMock.mock.calls[0]?.[0];
     expect(typeof imageRequest.prompt).toBe("string");
     expect(String(imageRequest.prompt).length).toBeLessThanOrEqual(7_900);
-    expect(imageRequest).not.toHaveProperty("modelId");
+    // No model configured => no override; the server applies its managed default.
+    expect(imageRequest.modelId).toBeUndefined();
+  });
+
+  it("forwards configured model, resolution, and seed levers to image generation", async () => {
+    const definition = registry.get("studio.image_generation", "1.0.0");
+    expect(definition).toBeDefined();
+    const generateImageMock = jest.fn(async () => ({
+      images: [],
+      modelId: "google/gemini-3-pro-image-preview",
+    }));
+
+    await definition!.execute(
+      createContext({
+        nodeId: "image-node",
+        kind: "studio.image_generation",
+        config: {
+          modelId: "google/gemini-3-pro-image-preview",
+          count: 3,
+          aspectRatio: "9:16",
+          imageSize: "4K",
+          seed: 42,
+        },
+        inputs: {
+          prompt: "A cinematic skyline at dusk",
+        },
+        generateImageMock,
+      })
+    );
+
+    const imageRequest = generateImageMock.mock.calls[0]?.[0];
+    expect(imageRequest.modelId).toBe("google/gemini-3-pro-image-preview");
+    expect(imageRequest.aspectRatio).toBe("9:16");
+    expect(imageRequest.imageSize).toBe("4K");
+    expect(imageRequest.seed).toBe(42);
+    expect(imageRequest.count).toBe(3);
+  });
+
+  it("treats a blank seed as random and clamps count to the model maximum", async () => {
+    const definition = registry.get("studio.image_generation", "1.0.0");
+    expect(definition).toBeDefined();
+    const generateImageMock = jest.fn(async () => ({
+      images: [],
+      modelId: "openai/gpt-5-image-mini",
+    }));
+
+    await definition!.execute(
+      createContext({
+        nodeId: "image-node",
+        kind: "studio.image_generation",
+        config: {
+          count: 12,
+          seed: "",
+          imageSize: "",
+        },
+        inputs: {
+          prompt: "A watercolor fox",
+        },
+        generateImageMock,
+      })
+    );
+
+    const imageRequest = generateImageMock.mock.calls[0]?.[0];
+    expect(imageRequest.seed).toBeUndefined();
+    expect(imageRequest.imageSize).toBeUndefined();
+    expect(imageRequest.modelId).toBeUndefined();
+    expect(imageRequest.count).toBe(4);
   });
 
   it("truncates oversized plain image prompts before API submission", async () => {

--- a/src/studio/__tests__/studio-dynamic-select-options.test.ts
+++ b/src/studio/__tests__/studio-dynamic-select-options.test.ts
@@ -1,0 +1,55 @@
+import { resolveStudioDynamicSelectOptions } from "../StudioDynamicSelectOptions";
+
+function fakePlugin(cacheModels?: unknown[]): any {
+  return {
+    settings: {
+      licenseKey: "license_abc",
+      imageGenerationModelCatalogCache: cacheModels ? { models: cacheModels } : undefined,
+    },
+  };
+}
+
+describe("resolveStudioDynamicSelectOptions (image models)", () => {
+  it("offers the managed default first, then curated models", async () => {
+    const options = await resolveStudioDynamicSelectOptions({
+      plugin: fakePlugin(),
+      source: "studio.systemsculpt_image_models",
+    });
+
+    expect(options[0]).toMatchObject({ value: "", label: "SystemSculpt Default" });
+
+    const values = options.map((option) => option.value);
+    expect(values).toContain("google/gemini-3-pro-image-preview");
+    expect(values).toContain("openai/gpt-5-image-mini");
+    expect(values).toContain("black-forest-labs/flux.2-pro");
+    // The managed engine is represented by the "" Default entry, never a model row.
+    expect(values).not.toContain("systemsculpt/managed-image-engine");
+  });
+
+  it("merges server catalog models and filters the managed engine", async () => {
+    const options = await resolveStudioDynamicSelectOptions({
+      plugin: fakePlugin([
+        { id: "systemsculpt/managed-image-engine", name: "Managed", provider: "SystemSculpt" },
+        {
+          id: "stability/sdxl",
+          name: "Stability SDXL",
+          provider: "Stability",
+          supports_generation: true,
+        },
+      ]),
+      source: "studio.systemsculpt_image_models",
+    });
+
+    const values = options.map((option) => option.value);
+    expect(values).not.toContain("systemsculpt/managed-image-engine");
+    expect(values).toContain("stability/sdxl");
+  });
+
+  it("returns an empty list for unrecognized sources", async () => {
+    const options = await resolveStudioDynamicSelectOptions({
+      plugin: fakePlugin(),
+      source: "studio.unknown_source" as any,
+    });
+    expect(options).toEqual([]);
+  });
+});

--- a/src/studio/__tests__/studio-dynamic-select-options.test.ts
+++ b/src/studio/__tests__/studio-dynamic-select-options.test.ts
@@ -45,6 +45,20 @@ describe("resolveStudioDynamicSelectOptions (image models)", () => {
     expect(values).toContain("stability/sdxl");
   });
 
+  it("omits models the synced catalog marks as non-generating", async () => {
+    const options = await resolveStudioDynamicSelectOptions({
+      plugin: fakePlugin([
+        { id: "dead/model", name: "Dead Model", provider: "X", supports_generation: false },
+        { id: "live/model", name: "Live Model", provider: "X", supports_generation: true },
+      ]),
+      source: "studio.systemsculpt_image_models",
+    });
+
+    const values = options.map((option) => option.value);
+    expect(values).toContain("live/model");
+    expect(values).not.toContain("dead/model");
+  });
+
   it("returns an empty list for unrecognized sources", async () => {
     const options = await resolveStudioDynamicSelectOptions({
       plugin: fakePlugin(),

--- a/src/studio/__tests__/studio-graph-migrations.test.ts
+++ b/src/studio/__tests__/studio-graph-migrations.test.ts
@@ -547,6 +547,32 @@ describe("migrateStudioProjectToPathOnlyPorts", () => {
     ).toBe(true);
   });
 
+  it("clamps legacy image counts above the new maximum to 4", () => {
+    const project = baseProject();
+    project.graph.nodes.push({
+      id: "image",
+      kind: "studio.image_generation",
+      version: "1.0.0",
+      title: "Image",
+      position: { x: 0, y: 0 },
+      config: {
+        count: 8,
+        aspectRatio: "16:9",
+      },
+    });
+
+    const migrated = migrateStudioProjectToPathOnlyPorts(project);
+    expect(migrated.changed).toBe(true);
+
+    const imageNode = migrated.project.graph.nodes.find((node) => node.id === "image");
+    expect(imageNode?.config).toMatchObject({
+      count: 4,
+      aspectRatio: "16:9",
+      modelId: "",
+      imageSize: "",
+    });
+  });
+
   it("leaves image nodes that already declare model levers unchanged", () => {
     const project = baseProject();
     project.graph.nodes.push({

--- a/src/studio/__tests__/studio-graph-migrations.test.ts
+++ b/src/studio/__tests__/studio-graph-migrations.test.ts
@@ -515,4 +515,55 @@ describe("migrateStudioProjectToPathOnlyPorts", () => {
       )
     ).toBe(true);
   });
+
+  it("backfills model and resolution levers on legacy image generation nodes", () => {
+    const project = baseProject();
+    project.graph.nodes.push({
+      id: "image",
+      kind: "studio.image_generation",
+      version: "1.0.0",
+      title: "Image",
+      position: { x: 0, y: 0 },
+      config: {
+        count: 2,
+        aspectRatio: "16:9",
+      },
+    });
+
+    const migrated = migrateStudioProjectToPathOnlyPorts(project);
+    expect(migrated.changed).toBe(true);
+
+    const imageNode = migrated.project.graph.nodes.find((node) => node.id === "image");
+    expect(imageNode?.config).toMatchObject({
+      count: 2,
+      aspectRatio: "16:9",
+      modelId: "",
+      imageSize: "",
+    });
+    expect(
+      migrated.project.migrations.applied.some(
+        (entry) => entry.id === "studio.image-node-levers.v1"
+      )
+    ).toBe(true);
+  });
+
+  it("leaves image nodes that already declare model levers unchanged", () => {
+    const project = baseProject();
+    project.graph.nodes.push({
+      id: "image",
+      kind: "studio.image_generation",
+      version: "1.0.0",
+      title: "Image",
+      position: { x: 0, y: 0 },
+      config: {
+        modelId: "openai/gpt-5-image",
+        count: 1,
+        aspectRatio: "1:1",
+        imageSize: "2K",
+      },
+    });
+
+    const migrated = migrateStudioProjectToPathOnlyPorts(project);
+    expect(migrated.changed).toBe(false);
+  });
 });

--- a/src/studio/__tests__/studio-graph-migrations.test.ts
+++ b/src/studio/__tests__/studio-graph-migrations.test.ts
@@ -573,6 +573,26 @@ describe("migrateStudioProjectToPathOnlyPorts", () => {
     });
   });
 
+  it("floors decimal legacy image counts to a valid integer", () => {
+    const project = baseProject();
+    project.graph.nodes.push({
+      id: "image",
+      kind: "studio.image_generation",
+      version: "1.0.0",
+      title: "Image",
+      position: { x: 0, y: 0 },
+      config: {
+        count: 3.7,
+      },
+    });
+
+    const migrated = migrateStudioProjectToPathOnlyPorts(project);
+    expect(migrated.changed).toBe(true);
+
+    const imageNode = migrated.project.graph.nodes.find((node) => node.id === "image");
+    expect(imageNode?.config).toMatchObject({ count: 3 });
+  });
+
   it("leaves image nodes that already declare model levers unchanged", () => {
     const project = baseProject();
     project.graph.nodes.push({

--- a/src/studio/__tests__/studio-systemsculpt-api-adapter.test.ts
+++ b/src/studio/__tests__/studio-systemsculpt-api-adapter.test.ts
@@ -314,8 +314,8 @@ describe("StudioApiExecutionAdapter", () => {
       expect.any(Object)
     );
     expect(imageClient.createGenerationJob).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        model: expect.anything(),
+      expect.objectContaining({
+        model: "openai/gpt-5-image-mini",
       }),
       expect.any(Object)
     );

--- a/src/studio/nodes/imageGenerationNode.ts
+++ b/src/studio/nodes/imageGenerationNode.ts
@@ -15,7 +15,15 @@ import {
 
 const IMAGE_PROMPT_MAX_CHARS = 7_900;
 const IMAGE_INPUT_MAX_COUNT = 8;
+const IMAGE_OUTPUT_MAX_COUNT = 4;
 const DEFAULT_IMAGE_ASPECT_RATIO = "16:9";
+const IMAGE_SIZE_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "Auto (model default)" },
+  { value: "0.5K", label: "0.5K" },
+  { value: "1K", label: "1K" },
+  { value: "2K", label: "2K" },
+  { value: "4K", label: "4K" },
+];
 const LEGACY_LOCAL_PROVIDER_IDS = new Set([
   "local_macos_image_generation",
   "local_macos",
@@ -156,18 +164,29 @@ export const imageGenerationNode: StudioNodeDefinition = {
   ],
   outputPorts: [{ id: "images", type: "json" }],
   configDefaults: {
+    modelId: "",
     count: 1,
     aspectRatio: DEFAULT_IMAGE_ASPECT_RATIO,
+    imageSize: "",
   },
   configSchema: {
     fields: [
+      {
+        key: "modelId",
+        label: "Model",
+        type: "select",
+        required: false,
+        description: "Image model routed through SystemSculpt (OpenRouter). Leave on Default to let SystemSculpt choose.",
+        selectPresentation: "searchable_dropdown",
+        optionsSource: "studio.systemsculpt_image_models",
+      },
       {
         key: "count",
         label: "Image Count",
         type: "number",
         required: true,
         min: 1,
-        max: 8,
+        max: IMAGE_OUTPUT_MAX_COUNT,
         integer: true,
       },
       {
@@ -186,6 +205,24 @@ export const imageGenerationNode: StudioNodeDefinition = {
           { value: "2:3", label: "2:3" },
         ],
       },
+      {
+        key: "imageSize",
+        label: "Resolution",
+        type: "select",
+        required: false,
+        description: "Output resolution hint. Applied only by models that support it; ignored otherwise.",
+        options: IMAGE_SIZE_OPTIONS,
+      },
+      {
+        key: "seed",
+        label: "Seed",
+        type: "number",
+        required: false,
+        min: 0,
+        integer: true,
+        placeholder: "Random",
+        description: "Fix a seed for reproducible results. Leave blank for random.",
+      },
     ],
     allowUnknownKeys: true,
   },
@@ -202,13 +239,26 @@ export const imageGenerationNode: StudioNodeDefinition = {
       );
     }
     const countRaw = Number(context.node.config.count as StudioJsonValue);
-    const count = Number.isFinite(countRaw) && countRaw > 0 ? Math.min(8, Math.floor(countRaw)) : 1;
+    const count =
+      Number.isFinite(countRaw) && countRaw > 0
+        ? Math.min(IMAGE_OUTPUT_MAX_COUNT, Math.floor(countRaw))
+        : 1;
     const configuredAspectRatio = getText(context.node.config.aspectRatio as StudioJsonValue).trim();
     const aspectRatio = configuredAspectRatio || DEFAULT_IMAGE_ASPECT_RATIO;
+    const modelId = getText(context.node.config.modelId as StudioJsonValue).trim();
+    const imageSize = getText(context.node.config.imageSize as StudioJsonValue).trim();
+    const seedConfig = context.node.config.seed;
+    const seedText =
+      typeof seedConfig === "number" ? String(seedConfig) : getText(seedConfig as StudioJsonValue).trim();
+    const seedNum = seedText.length > 0 ? Number(seedText) : Number.NaN;
+    const seed = Number.isFinite(seedNum) && seedNum >= 0 ? Math.floor(seedNum) : undefined;
     const result = await context.services.api.generateImage({
       prompt,
+      modelId: modelId || undefined,
       count,
       aspectRatio,
+      imageSize: imageSize || undefined,
+      seed,
       inputImages,
       runId: context.runId,
       projectPath: context.projectPath,

--- a/src/studio/nodes/imageGenerationNode.ts
+++ b/src/studio/nodes/imageGenerationNode.ts
@@ -214,14 +214,16 @@ export const imageGenerationNode: StudioNodeDefinition = {
         options: IMAGE_SIZE_OPTIONS,
       },
       {
+        // Text (not number) so an empty value stays empty: the inline number
+        // editor coerces blanks to its min (0), which would silently pin a fixed
+        // seed of 0. execute() parses this string and treats blank/non-numeric as
+        // "random".
         key: "seed",
         label: "Seed",
-        type: "number",
+        type: "text",
         required: false,
-        min: 0,
-        integer: true,
         placeholder: "Random",
-        description: "Fix a seed for reproducible results. Leave blank for random.",
+        description: "Whole number for reproducible results. Leave blank for random.",
       },
     ],
     allowUnknownKeys: true,

--- a/src/studio/types.ts
+++ b/src/studio/types.ts
@@ -69,7 +69,8 @@ export type StudioNodeConfigSelectPresentation =
 export type StudioNodeConfigDynamicOptionsSource =
   | "studio.local_text_models"
   | "studio.systemsculpt_text_models"
-  | "studio.pi_text_models";
+  | "studio.pi_text_models"
+  | "studio.systemsculpt_image_models";
 export type StudioNodeConfigFieldVisibilityRule = {
   key: string;
   equals: StudioPrimitiveValue | StudioPrimitiveValue[];
@@ -285,6 +286,8 @@ export type StudioImageGenerationRequest = {
   modelId?: string;
   count?: number;
   aspectRatio?: string;
+  imageSize?: string;
+  seed?: number;
   inputImages?: StudioAssetRef[];
   runId: string;
   projectPath: string;

--- a/src/views/studio/graph-v3/StudioGraphNodeInlineEditors.ts
+++ b/src/views/studio/graph-v3/StudioGraphNodeInlineEditors.ts
@@ -231,7 +231,7 @@ function renderNodeSpecificInlineConfig(options: RenderStudioNodeInlineEditorOpt
       nodeEl,
       node,
       definition,
-      orderedFieldKeys: ["modelId", "count", "aspectRatio"],
+      orderedFieldKeys: ["modelId", "count", "aspectRatio", "imageSize", "seed"],
       interactionLocked,
       onNodeConfigMutated,
       onNodeConfigValueChange,


### PR DESCRIPTION
- Adds Model (OpenRouter, searchable), Resolution, and Seed controls to the Studio image generation node; image count capped at 4.
- Forwards the chosen model + image_size + seed through the SystemSculpt proxy; an empty model selection uses the server-managed default.
- Backfills existing image nodes via a graph migration; model list is sourced from the synced catalog.

Blocked: requires the backend image-model PR (systemsculpt-website#45) deployed before this is released to users.

https://claude.ai/code/session_016WqJg11hcBhnmLfHEDovap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added routed image-model selection with a “SystemSculpt Default” option plus curated catalog-backed choices.
  * Added image size (resolution hint) and seed controls to the image generation node.
* **Bug Fixes**
  * Improved behavior when no model is explicitly selected to correctly use the managed default.
* **Changes**
  * Updated image-generation deduplication to account for image size and seed.
  * Added migration/backfill for legacy image-generation nodes and standardized count limits (max 4).
* **Documentation/Tests**
  * Updated inline editor ordering and refreshed related tests, including curated model pricing display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->