### PR TITLE
fix(providers): surface OpenAI BYOK models in the Chat dropdown (#201)

### DIFF
--- a/src/services/providerRuntime/RemoteProviderCatalog.ts
+++ b/src/services/providerRuntime/RemoteProviderCatalog.ts
@@ -36,6 +36,16 @@ const REMOTE_PROVIDER_SEEDS: readonly RemoteProviderSeed[] = [
     supportedParameters: ["tools"],
     endpoint: AI_PROVIDERS.XAI.BASE_URL,
   },
+  {
+    providerId: "openai",
+    modelId: "gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    description: "OpenAI remote provider model for chat, tool use, reasoning, and image-capable turns.",
+    contextLength: 400_000,
+    modality: "text+image->text",
+    supportedParameters: ["tools"],
+    endpoint: AI_PROVIDERS.OPENAI.BASE_URL,
+  },
 ];
 
 function normalizeProviderId(value: unknown): string {
@@ -131,6 +141,9 @@ export function resolveRemoteProviderEndpoint(providerId: string): string {
   }
   if (normalized === "xai") {
     return AI_PROVIDERS.XAI.BASE_URL;
+  }
+  if (normalized === "openai") {
+    return AI_PROVIDERS.OPENAI.BASE_URL;
   }
   return "";
 }

--- a/src/services/providerRuntime/__tests__/RemoteProviderCatalog.test.ts
+++ b/src/services/providerRuntime/__tests__/RemoteProviderCatalog.test.ts
@@ -33,6 +33,12 @@ describe("RemoteProviderCatalog", () => {
       );
     });
 
+    it("returns the OpenAI base URL for the openai provider", () => {
+      expect(resolveRemoteProviderEndpoint("openai")).toBe(
+        AI_PROVIDERS.OPENAI.BASE_URL
+      );
+    });
+
     it("is case-insensitive", () => {
       expect(resolveRemoteProviderEndpoint("OpenRouter")).toBe(
         AI_PROVIDERS.OPENROUTER.BASE_URL
@@ -251,6 +257,52 @@ describe("RemoteProviderCatalog", () => {
       expect(grok?.capabilities).toEqual(
         expect.arrayContaining(["chat", "reasoning", "vision"])
       );
+    });
+
+    it("returns GPT-5.4 Mini when OpenAI is configured", () => {
+      const plugin = makePlugin([
+        {
+          id: "openai",
+          name: "OpenAI",
+          endpoint: "https://api.openai.com/v1",
+          apiKey: "sk-openai-key",
+          isEnabled: true,
+        },
+      ]);
+
+      const models = listConfiguredRemoteProviderModels(plugin);
+      const gpt = models.find((model) => model.id === "openai@@gpt-5.4-mini");
+
+      expect(gpt).toMatchObject({
+        id: "openai@@gpt-5.4-mini",
+        name: "GPT-5.4 Mini",
+        provider: "openai",
+        sourceMode: "custom_endpoint",
+        sourceProviderId: "openai",
+        piRemoteAvailable: true,
+        piLocalAvailable: false,
+        piAuthMode: "byok",
+        piExecutionModelId: "gpt-5.4-mini",
+      });
+      expect(gpt?.supported_parameters).toContain("tools");
+    });
+
+    it("gives every configured remote provider model a resolvable execution endpoint (#201 contract)", () => {
+      // The core #201 failure mode: a model appears in the Chat dropdown but
+      // has no execution endpoint, so selecting it throws "No remote endpoint
+      // configured". Lock catalog appearance to executability so a future seed
+      // can never ship that gap again.
+      const plugin = makePlugin([
+        { id: "openrouter", name: "OpenRouter", endpoint: "https://openrouter.ai/api/v1", apiKey: "k", isEnabled: true },
+        { id: "xai", name: "xAI", endpoint: "https://api.x.ai/v1", apiKey: "k", isEnabled: true },
+        { id: "openai", name: "OpenAI", endpoint: "https://api.openai.com/v1", apiKey: "k", isEnabled: true },
+      ]);
+
+      const models = listConfiguredRemoteProviderModels(plugin);
+      expect(models.length).toBeGreaterThanOrEqual(3);
+      for (const model of models) {
+        expect(resolveRemoteProviderEndpoint(String(model.sourceProviderId))).not.toBe("");
+      }
     });
 
     it("returns empty array when no matching provider is configured", () => {

--- a/testing/integration/provider-listing.test.ts
+++ b/testing/integration/provider-listing.test.ts
@@ -24,6 +24,7 @@ const { startProviderFixtures } = require("../fixtures/providers/index.cjs");
 type Fixtures = Awaited<ReturnType<typeof startProviderFixtures>>;
 
 const OPENROUTER_SEED_MODEL_ID = createCanonicalId("openrouter", "openai/gpt-5.4-mini");
+const OPENAI_SEED_MODEL_ID = createCanonicalId("openai", "gpt-5.4-mini");
 
 function buildPluginStub(customProviders: unknown[] = []) {
   return {
@@ -82,6 +83,28 @@ describe("text model catalog (#201 guard)", () => {
     const seed = models.find((model) => model.id === OPENROUTER_SEED_MODEL_ID);
     expect(seed?.piAuthMode).toBe("byok");
     expect(seed?.provider).toBe("openrouter");
+  });
+
+  it("lists the OpenAI seed model when a keyed custom provider is configured (#201)", async () => {
+    const models = await listPiTextCatalogModels(
+      buildPluginStub([
+        {
+          id: "openai",
+          name: "OpenAI",
+          endpoint: "https://api.openai.com/v1",
+          apiKey: "fixture-key",
+          isEnabled: true,
+        },
+      ])
+    );
+
+    const ids = models.map((model) => model.id);
+    expect(ids[0]).toBe(SYSTEMSCULPT_PI_CANONICAL_MODEL_ID);
+    expect(ids).toContain(OPENAI_SEED_MODEL_ID);
+
+    const seed = models.find((model) => model.id === OPENAI_SEED_MODEL_ID);
+    expect(seed?.piAuthMode).toBe("byok");
+    expect(seed?.provider).toBe("openai");
   });
 
   it("drops the seed model when the provider has no API key", async () => {


### PR DESCRIPTION
Fixes the OpenAI half of #201: a saved OpenAI API key now appears in the Chat model dropdown (GPT-5.4 Mini) and runs, on desktop and mobile. Root cause was the remote provider catalog seeding only `openrouter`/`xai` and resolving execution endpoints for only those two.

- Adds an OpenAI seed + execution endpoint through the existing generic OpenAI-compatible runtime (mirrors the `xai` path — no new execution code).
- Regression guard: the #201 integration test now covers OpenAI, plus a contract test asserting every catalog model resolves an execution endpoint (the appears-but-throws failure mode behind #201). Verified the guard fails without the fix.

Claude (#230) and Gemini (#231) use non-OpenAI-compatible APIs and are deferred to the #206 registry rework.

Blocked: #201 stays OPEN pending manual Windows-desktop verification (per the reporter's explicit request — no automated close).

https://claude.ai/code/session_01FXr5BhykqM1CkgfPPr8Pws

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI provider support to the remote provider catalog, enabling users to configure and use OpenAI models when the provider API key is available.

* **Tests**
  * Added comprehensive test coverage for OpenAI provider functionality.
  * Introduced regression test to ensure all catalog models have proper endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->