### PR TITLE
test(integration): mobile-emulation bundle-load smoke (#215)

### DIFF
--- a/testing/integration/bundle-load.mobile.test.ts
+++ b/testing/integration/bundle-load.mobile.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Built-bundle load smoke on MOBILE emulation (issue #215). Mirrors
+ * bundle-load.test.ts, but flips the Obsidian Platform flags to mobile before
+ * loading the compiled `main.js`, proving the shipped artifact constructs and
+ * survives `onload()` on phones/tablets — not just desktop.
+ *
+ * Why this exists: the desktop bundle-load smoke never exercises the mobile
+ * code paths (Platform.isDesktop defaults true in the mock), and the real
+ * device harness (`test:native:android/ios`) is local-only and never gates a
+ * PR. A v5 mobile-startup regression (the #207 class) can therefore ship green.
+ * This test runs in the required `ci.yml` integration job — no device, no
+ * secrets — so a broken mobile onload red-builds immediately.
+ *
+ * Run `npm run build` first (npm run test:integration does this for you).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { Platform } from "obsidian";
+
+const BUNDLE_PATH = path.resolve(__dirname, "..", "..", "main.js");
+const MANIFEST_PATH = path.resolve(__dirname, "..", "..", "manifest.json");
+
+describe("built bundle (main.js) on mobile emulation", () => {
+  const platformAny = Platform as unknown as Record<string, boolean>;
+  let savedFlags: Record<string, boolean>;
+
+  beforeAll(() => {
+    if (!existsSync(BUNDLE_PATH)) {
+      throw new Error(
+        `Built bundle not found at ${BUNDLE_PATH} — run \`npm run build\` first ` +
+          "(or use `npm run test:integration`, which builds before testing)."
+      );
+    }
+    // Emulate a mobile host before the bundle is required/onloaded, so any
+    // desktop-only branch taken at module-eval or onload runs under mobile
+    // flags. Mirrors the flip used by the #201 provider-listing guard.
+    savedFlags = { ...platformAny };
+    platformAny.isDesktop = false;
+    platformAny.isDesktopApp = false;
+    platformAny.isMobile = true;
+    platformAny.isMobileApp = true;
+  });
+
+  afterAll(() => {
+    Object.assign(platformAny, savedFlags);
+  });
+
+  it("loads, constructs, and onloads on mobile with its core surface registered", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const bundleModule = require(BUNDLE_PATH);
+    const PluginClass = bundleModule?.default ?? bundleModule;
+    expect(typeof PluginClass).toBe("function");
+
+    const { App, Plugin } = require("obsidian");
+    expect(PluginClass.prototype instanceof Plugin).toBe(true);
+
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    const plugin = new PluginClass(new App(), manifest);
+
+    // The core regression guard: onload must not throw on mobile. A
+    // desktop-only path reached under mobile flags would reject one of these.
+    await plugin.onload();
+    await plugin.criticalInitializationPromise;
+    await plugin.deferredInitializationPromise;
+
+    // Settings still migrate + defaults apply under mobile flags.
+    expect(plugin.settings).toBeDefined();
+    expect(typeof plugin.settings).toBe("object");
+    expect(plugin.settings.settingsMode).toBe("standard");
+    expect(Array.isArray(plugin.settings.customProviders)).toBe(true);
+    expect(plugin.settings.selectedModelId).toBe("systemsculpt@@systemsculpt/ai-agent");
+
+    // Core surface still registers on mobile.
+    expect(plugin._commands.length).toBeGreaterThan(0);
+    expect(plugin._settingTabs.length).toBeGreaterThan(0);
+
+    const commandIds = plugin._commands.map((command: { id: string }) => command.id);
+    expect(new Set(commandIds).size).toBe(commandIds.length);
+
+    plugin.unload();
+  });
+});


### PR DESCRIPTION
Starts #215 (test-infra foundation) with its highest-value missing slice: a mobile-emulation built-bundle load smoke.

- Mirrors the existing desktop `bundle-load.test.ts`, flipping `Platform` to mobile before `require`/`onload` of the compiled `main.js`.
- Closes the one #215 coverage hole that is both named ("plugin loads … mobile emulation") and currently un-automated: the real device harness is local-only and never gates a PR. This runs in the required `ci.yml` integration job, so a broken mobile onload red-builds immediately.
- No new infra — reuses the integration harness and the Platform-flip pattern already in the repo.

Gap analysis found #215's other three parts (integration harness, provider fixtures, release-smoke round-trips, TDD convention) already substantially built; remaining slices can follow.

https://claude.ai/code/session_01FXr5BhykqM1CkgfPPr8Pws

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for mobile platform bundle loading and plugin initialization validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->