### PR TITLE
ci(windows-e2e): assert OpenAI BYOK clean-install parity on real Windows (#201)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Unit Tests
         run: npm test
 
+      - name: Native Shared Unit Tests
+        run: npm run test:native:shared
+
       - name: Embeddings Tests
         run: npm run test:embeddings
 

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -28,6 +28,11 @@ jobs:
       SYSTEMSCULPT_DESKTOP_PROVIDER_MODEL_ID: xai@@grok-4.3
       SYSTEMSCULPT_DESKTOP_PROVIDER_API_KEY: ${{ secrets.XAI_API_KEY }}
       XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+      # OpenAI BYOK lane (#201): asserts a configured OpenAI provider surfaces its
+      # model in Chat and completes a real chat. Soft-gated on the secret so the
+      # job stays green until OPENAI_API_KEY is added, then activates as a hard lane.
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      HAS_OPENAI: ${{ secrets.OPENAI_API_KEY != '' }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -179,6 +184,11 @@ jobs:
       - name: Run Windows clean-install parity
         run: |
           node testing/native/device/windows/run-clean-install-parity.mjs --provider-id xai --provider-model-id xai@@grok-4.3 --api-key-env XAI_API_KEY --require-provider
+
+      - name: Run Windows clean-install parity (OpenAI BYOK, #201)
+        if: env.HAS_OPENAI == 'true'
+        run: |
+          node testing/native/device/windows/run-clean-install-parity.mjs --provider-id openai --provider-model-id openai@@gpt-5.4-mini --api-key-env OPENAI_API_KEY --require-provider
 
       - name: Run Windows desktop baselines
         run: npm run test:native:windows:baselines

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Windows clean-install parity (OpenAI BYOK, #201)
         if: env.HAS_OPENAI == 'true'
         run: |
-          node testing/native/device/windows/run-clean-install-parity.mjs --provider-id openai --provider-model-id openai@@gpt-5.4-mini --api-key-env OPENAI_API_KEY --require-provider
+          node testing/native/device/windows/run-clean-install-parity.mjs --provider-id openai --provider-model-id openai@@gpt-5.4-mini --api-key-env OPENAI_API_KEY --require-provider --require-provider-model
 
       - name: Run Windows desktop baselines
         run: npm run test:native:windows:baselines

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "test:integration:ci": "node scripts/jest.mjs --config jest.integration.config.cjs --runInBand --forceExit",
     "test:embeddings:serial": "node scripts/jest.mjs --config jest.embeddings.config.cjs --runInBand --passWithNoTests",
     "test:release-script": "node --test scripts/release-plugin.test.mjs scripts/check-release-surfaces.test.mjs",
+    "test:native:shared": "node --test testing/native/shared/model-inventory.test.mjs",
     "check:release-surfaces": "node scripts/check-release-surfaces.mjs",
     "release:plugin": "node scripts/release-plugin.mjs"
   },

--- a/testing/native/device/windows/clean-install-parity.mjs
+++ b/testing/native/device/windows/clean-install-parity.mjs
@@ -33,6 +33,7 @@ export function parseCleanInstallParityArgs(argv, env = process.env) {
       .split(",")
       .map((entry) => String(entry || "").trim())
       .filter((entry) => entry.length > 0),
+    requireProviderModel: false,
     apiKeyFile: "",
     apiKey: "",
     waitTimeoutMs: numberOption(env.SYSTEMSCULPT_WINDOWS_WAIT_TIMEOUT_MS, DEFAULT_WAIT_TIMEOUT_MS),
@@ -62,6 +63,10 @@ export function parseCleanInstallParityArgs(argv, env = process.env) {
         .map((entry) => String(entry || "").trim())
         .filter((entry) => entry.length > 0);
       index += 1;
+      continue;
+    }
+    if (arg === "--require-provider-model") {
+      options.requireProviderModel = true;
       continue;
     }
     if (arg === "--api-key-file") {
@@ -232,6 +237,7 @@ export function findProviderModel(inventory, providerId, authenticated, options 
       providerId,
       options.preferredModelIds
     ),
+    requirePreferred: options.requirePreferred,
   });
 }
 
@@ -506,6 +512,7 @@ export async function runCleanInstallParityAgainstRecord(record, options = {}) {
       const inventory = await request(record, "/v1/chat/models?refresh=1", { timeoutMs: 60_000 });
       const option = findProviderModel(inventory, options.providerId, true, {
         preferredModelIds: options.preferredProviderModelIds,
+        requirePreferred: options.requireProviderModel,
       });
       return option ? { inventory, option } : null;
     },

--- a/testing/native/device/windows/run-clean-install-parity.mjs
+++ b/testing/native/device/windows/run-clean-install-parity.mjs
@@ -153,6 +153,10 @@ export function parseArgs(argv, env = process.env) {
       options.requireProvider = true;
       continue;
     }
+    if (arg === "--require-provider-model") {
+      options.requireProviderModel = true;
+      continue;
+    }
     if (arg === "--help" || arg === "-h") {
       options.help = true;
       continue;
@@ -402,6 +406,9 @@ export function buildRemoteCleanInstallParityArgs(options = {}) {
   }
   if (Array.isArray(options.preferredProviderModelIds) && options.preferredProviderModelIds.length > 0) {
     args.push("--provider-model-id", options.preferredProviderModelIds.map((entry) => String(entry || "").trim()).filter(Boolean).join(","));
+  }
+  if (options.requireProviderModel) {
+    args.push("--require-provider-model");
   }
   if (String(options.apiKey || "").trim()) {
     args.push("--api-key", String(options.apiKey).trim());

--- a/testing/native/shared/model-inventory.mjs
+++ b/testing/native/shared/model-inventory.mjs
@@ -116,6 +116,7 @@ export function findProviderModelOption(inventory, providerId, options = {}) {
   const requiredAuthenticated =
     typeof options.authenticated === "boolean" ? options.authenticated : undefined;
   const requiredModelId = String(options.modelId || "").trim() || null;
+  const requirePreferred = Boolean(options.requirePreferred);
 
   const models = Array.isArray(inventory?.options) ? inventory.options : [];
   const matches = models.filter((option) => {
@@ -148,6 +149,14 @@ export function findProviderModelOption(inventory, providerId, options = {}) {
       if (preferredMatch) {
         return preferredMatch;
       }
+    }
+    if (requirePreferred) {
+      // The caller demanded one of preferredModelIds specifically (e.g. the
+      // #201 OpenAI lane asserting openai@@gpt-5.4-mini). Refuse to fall back
+      // to an unrelated model of the same provider or to the preferredSections
+      // default: a vanished seed must fail the gate, not silently pass on
+      // whatever else the provider happens to expose.
+      return null;
     }
   }
   if (preferredSections) {

--- a/testing/native/shared/model-inventory.test.mjs
+++ b/testing/native/shared/model-inventory.test.mjs
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { findProviderModelOption } from "./model-inventory.mjs";
+
+// Guards the model-selection helper that both Windows clean-install parity
+// lanes (xAI and the #201 OpenAI BYOK lane) rely on to pick which model to
+// chat against. The key behavior under test is `requirePreferred`: the #201
+// lane must FAIL if openai@@gpt-5.4-mini stops surfacing, instead of silently
+// passing on some other OpenAI model the provider exposes.
+
+const SEED = "openai@@gpt-5.4-mini";
+const OTHER = "openai@@gpt-4.1";
+
+function inventory(...values) {
+  return {
+    options: values.map((value) => ({
+      providerId: "openai",
+      value,
+      label: value,
+      section: "pi",
+      providerAuthenticated: true,
+    })),
+  };
+}
+
+test("returns the preferred model when present (default soft mode)", () => {
+  const option = findProviderModelOption(inventory(OTHER, SEED), "openai", {
+    preferredModelIds: [SEED],
+  });
+  assert.equal(option?.value, SEED);
+});
+
+test("returns the preferred model when present (requirePreferred)", () => {
+  const option = findProviderModelOption(inventory(OTHER, SEED), "openai", {
+    preferredModelIds: [SEED],
+    requirePreferred: true,
+  });
+  assert.equal(option?.value, SEED);
+});
+
+test("soft mode falls back to another provider model when the preferred is absent", () => {
+  // Documents exactly the gap the #201 lane must not depend on: the seed is
+  // gone, yet a different OpenAI model is happily returned.
+  const option = findProviderModelOption(inventory(OTHER), "openai", {
+    preferredModelIds: [SEED],
+  });
+  assert.equal(option?.value, OTHER);
+});
+
+test("requirePreferred returns null when the preferred model is absent (#201 gate)", () => {
+  const option = findProviderModelOption(inventory(OTHER), "openai", {
+    preferredModelIds: [SEED],
+    requirePreferred: true,
+  });
+  assert.equal(option, null);
+});
+
+test("requirePreferred overrides the preferredSections fallback (mirrors the real wrapper)", () => {
+  // The clean-install wrapper always passes preferredSections: ["pi","local"].
+  // requirePreferred must still fail closed when the specific seed is missing.
+  const option = findProviderModelOption(inventory(OTHER), "openai", {
+    preferredModelIds: [SEED],
+    preferredSections: ["pi", "local"],
+    requirePreferred: true,
+  });
+  assert.equal(option, null);
+});
+
+test("requirePreferred fails closed when the provider exposes no models at all", () => {
+  const option = findProviderModelOption(inventory(), "openai", {
+    preferredModelIds: [SEED],
+    requirePreferred: true,
+  });
+  assert.equal(option, null);
+});
+
+test("requirePreferred without any preferredModelIds keeps default selection", () => {
+  // No preference specified -> requirePreferred has nothing to enforce, so the
+  // first provider match is still returned. This keeps the xAI lane and any
+  // caller that omits --provider-model-id behaving exactly as before.
+  const option = findProviderModelOption(inventory(SEED), "openai", {
+    requirePreferred: true,
+  });
+  assert.equal(option?.value, SEED);
+});


### PR DESCRIPTION
Makes the canonical Windows E2E lane prove the #201 OpenAI fix end to end, instead of relying on a manual check.

- Adds a clean-install parity step for a configured **OpenAI** provider: it must surface GPT-5.4 Mini in Chat and complete a **real chat** on a real Windows runner (mirrors the existing xAI/Grok lane; harness was already provider-generic).
- **Soft-gated** on `OPENAI_API_KEY`: the step skips and CI stays green until the secret is added, then activates as a hard `--require-provider` lane.
- If the seed id `gpt-5.4-mini` ever fails to complete a real OpenAI chat, this lane goes red — catching the residual risk instead of a user.

Blocked: needs the `OPENAI_API_KEY` repo secret to actually exercise OpenAI; until then the step is inert. Does not close #201 (manual/human closure per the reporter).

https://claude.ai/code/session_01FXr5BhykqM1CkgfPPr8Pws

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAI BYOK Windows end-to-end test lane, including a clean-install parity run for the OpenAI provider when an API key is present.
  * Enhanced Windows clean-install parity tooling with a `--require-provider-model` option to tighten provider model selection during authentication.
* **Tests**
  * Added a new native shared unit test suite for provider model inventory behavior, including “fail-closed” coverage when preferred models are required but unavailable.
  * Updated CI to run these native shared unit tests before embeddings tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->