### PR TITLE
fix(providers): model-catalog status state machine — chat dropdown never silently empty (#206)

### DIFF
--- a/src/css/views/chat.css
+++ b/src/css/views/chat.css
@@ -813,6 +813,23 @@
   line-height: 1.45;
 }
 
+.systemsculpt-chat-model-modal-empty-retry {
+  margin-top: 4px;
+  padding: 6px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--interactive-accent);
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.systemsculpt-chat-model-modal-empty-retry:hover {
+  background: var(--interactive-accent-hover);
+  border-color: var(--interactive-accent-hover);
+}
+
 .systemsculpt-chat-composer-attachments {
   display: flex;
   flex-wrap: wrap;

--- a/src/services/__tests__/UnifiedModelService.test.ts
+++ b/src/services/__tests__/UnifiedModelService.test.ts
@@ -150,4 +150,23 @@ describe("UnifiedModelService", () => {
     expect(recovered.length).toBeGreaterThan(0);
     expect(service.getCatalogStatus()).toEqual({ state: "ready", reason: null });
   });
+
+  it("re-attempts the catalog on the next getModels after an error instead of serving a cached empty list (#206)", async () => {
+    const plugin = buildPlugin();
+    listPiTextCatalogModels.mockRejectedValueOnce(new Error("endpoint unreachable"));
+    const service = UnifiedModelService.getInstance(plugin);
+
+    // First load fails: error recorded, empty list returned.
+    await service.getModels();
+    expect(service.getCatalogStatus().state).toBe("error");
+
+    // The chat picker's Retry path calls getModels() WITHOUT forcing a refresh.
+    // A failed load must not cache an empty list (truthy []), or retry would
+    // reuse it and re-throw the same error without ever hitting the catalog (#206).
+    const recovered = await service.getModels();
+
+    expect(listPiTextCatalogModels).toHaveBeenCalledTimes(2);
+    expect(recovered.map((model: { id: string }) => model.id)).toContain(MANAGED_MODEL.id);
+    expect(service.getCatalogStatus()).toEqual({ state: "ready", reason: null });
+  });
 });

--- a/src/services/__tests__/UnifiedModelService.test.ts
+++ b/src/services/__tests__/UnifiedModelService.test.ts
@@ -110,4 +110,44 @@ describe("UnifiedModelService", () => {
       localPi: true,
     });
   });
+
+  it("starts in a loading status before the first load resolves", () => {
+    const plugin = buildPlugin();
+    const service = UnifiedModelService.getInstance(plugin);
+    expect(service.getCatalogStatus()).toEqual({ state: "loading", reason: null });
+  });
+
+  it("reports a ready status after a successful catalog load", async () => {
+    const plugin = buildPlugin();
+    const service = UnifiedModelService.getInstance(plugin);
+    await service.getModels();
+    expect(service.getCatalogStatus()).toEqual({ state: "ready", reason: null });
+  });
+
+  it("records an error status with a reason instead of a silent empty list", async () => {
+    const plugin = buildPlugin();
+    listPiTextCatalogModels.mockRejectedValue(new Error("endpoint unreachable"));
+    const service = UnifiedModelService.getInstance(plugin);
+
+    const models = await service.getModels();
+
+    expect(models).toEqual([]);
+    expect(service.getCatalogStatus()).toEqual({
+      state: "error",
+      reason: "endpoint unreachable",
+    });
+  });
+
+  it("recovers to a ready status after a failed load is retried successfully", async () => {
+    const plugin = buildPlugin();
+    listPiTextCatalogModels.mockRejectedValueOnce(new Error("endpoint unreachable"));
+    const service = UnifiedModelService.getInstance(plugin);
+
+    await service.getModels();
+    expect(service.getCatalogStatus().state).toBe("error");
+
+    const recovered = await service.refreshModels();
+    expect(recovered.length).toBeGreaterThan(0);
+    expect(service.getCatalogStatus()).toEqual({ state: "ready", reason: null });
+  });
 });

--- a/src/services/providers/UnifiedModelService.ts
+++ b/src/services/providers/UnifiedModelService.ts
@@ -97,7 +97,11 @@ export class UnifiedModelService {
         state: "error",
         reason: error instanceof Error ? error.message : String(error || "Unknown error"),
       };
-      this.cachedModels = [];
+      // Do NOT cache an empty list here: an empty array is truthy, so caching it
+      // would make the Retry path (getModels() without forceRefresh) reuse the
+      // failed result and re-throw without ever re-hitting the catalog. Clearing
+      // the cache lets the very next getModels() re-attempt the load (#206).
+      this.cachedModels = null;
       return [];
     }
   }

--- a/src/services/providers/UnifiedModelService.ts
+++ b/src/services/providers/UnifiedModelService.ts
@@ -14,12 +14,25 @@ async function loadPiTextCatalogModule(): Promise<typeof import("../pi-native/Pi
   return await import("../pi-native/PiTextCatalog");
 }
 
+export type ModelCatalogState = "loading" | "ready" | "error";
+
+/**
+ * Deterministic catalog state so the chat model dropdown is never silently
+ * empty: a `ready` catalog has models, and an empty/failed catalog reports an
+ * `error` with a human-readable reason the UI can show alongside a retry (#206).
+ */
+export type ModelCatalogStatus = {
+  state: ModelCatalogState;
+  reason: string | null;
+};
+
 export class UnifiedModelService {
   private static instance: UnifiedModelService | null = null;
   private favoritesService: FavoritesService;
   private cachedModels: SystemSculptModel[] | null = null;
   private loadingPromise: Promise<SystemSculptModel[]> | null = null;
   private isInitialLoadDone = false;
+  private catalogStatus: ModelCatalogStatus = { state: "loading", reason: null };
 
   private constructor(private readonly plugin: SystemSculptPlugin) {
     this.favoritesService = FavoritesService.getInstance(plugin);
@@ -45,6 +58,7 @@ export class UnifiedModelService {
     }
 
     this.loadingPromise = (async () => {
+      this.catalogStatus = { state: "loading", reason: null };
       const { listPiTextCatalogModels } = await loadPiTextCatalogModule();
       const models = await listPiTextCatalogModels(this.plugin);
       this.favoritesService.processFavorites(models);
@@ -61,6 +75,7 @@ export class UnifiedModelService {
         this.isInitialLoadDone = true;
       }
 
+      this.catalogStatus = { state: "ready", reason: null };
       return modelsWithRuntimeFlags;
     })();
 
@@ -74,10 +89,25 @@ export class UnifiedModelService {
   public async getModels(forceRefresh: boolean = false): Promise<SystemSculptModel[]> {
     try {
       return await this.loadModels(forceRefresh);
-    } catch {
+    } catch (error) {
+      // Never collapse a failure into a silent empty dropdown: record the
+      // reason so the picker can surface it with a retry instead of an
+      // unexplained blank list (#206).
+      this.catalogStatus = {
+        state: "error",
+        reason: error instanceof Error ? error.message : String(error || "Unknown error"),
+      };
       this.cachedModels = [];
       return [];
     }
+  }
+
+  /**
+   * Current catalog state for the model dropdown. `ready` means the list is
+   * trustworthy; `error` carries a reason to show the user with a retry (#206).
+   */
+  public getCatalogStatus(): ModelCatalogStatus {
+    return { ...this.catalogStatus };
   }
 
   public async getModelById(modelId: string): Promise<SystemSculptModel | undefined> {
@@ -226,5 +256,6 @@ export class UnifiedModelService {
   public clearAllCaches(): void {
     this.cachedModels = null;
     this.loadingPromise = null;
+    this.catalogStatus = { state: "loading", reason: null };
   }
 }

--- a/src/views/chatview/ChatModelPickerModal.ts
+++ b/src/views/chatview/ChatModelPickerModal.ts
@@ -143,17 +143,34 @@ export class ChatModelPickerModal extends StandardModal {
     });
   }
 
-  private showEmptyState(message: string, icon: string = "search-x"): void {
+  private showEmptyState(
+    message: string,
+    options: { icon?: string; showRetry?: boolean } = {},
+  ): void {
     this.listEl.style.display = "none";
     this.emptyStateEl.style.display = "flex";
     this.emptyStateEl.empty();
 
     const iconEl = this.emptyStateEl.createDiv({ cls: "systemsculpt-chat-model-modal-empty-icon" });
-    setIcon(iconEl, icon);
+    setIcon(iconEl, options.icon || "search-x");
     this.emptyStateEl.createDiv({
       cls: "systemsculpt-chat-model-modal-empty-text",
       text: message,
     });
+
+    // An empty/failed dropdown must never be a dead end — always offer a retry
+    // so a transient catalog failure is recoverable in place (#206).
+    if (options.showRetry) {
+      const retryButtonEl = this.emptyStateEl.createEl("button", {
+        cls: "systemsculpt-chat-model-modal-empty-retry",
+        text: "Retry",
+        attr: { type: "button" },
+      });
+      this.registerDomEvent(retryButtonEl, "click", () => {
+        this.renderLoadingState();
+        void this.reloadOptions();
+      });
+    }
   }
 
   private hideEmptyState(): void {
@@ -170,7 +187,10 @@ export class ChatModelPickerModal extends StandardModal {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error || "Unknown error");
       this.loading = false;
-      this.showEmptyState(`Unable to load models (${message}).`, "alert-triangle");
+      this.showEmptyState(`Couldn't load models — ${message}`, {
+        icon: "alert-triangle",
+        showRetry: true,
+      });
     }
   }
 
@@ -212,11 +232,10 @@ export class ChatModelPickerModal extends StandardModal {
     if (this.filteredOptions.length === 0) {
       if (this.loading) {
         this.renderLoadingState();
+      } else if (query) {
+        this.showEmptyState(`No models found matching "${query}".`);
       } else {
-        const message = query
-          ? `No models found matching "${query}".`
-          : "No chat models are available right now.";
-        this.showEmptyState(message);
+        this.showEmptyState("No chat models are available right now.", { showRetry: true });
       }
       return;
     }

--- a/src/views/chatview/__tests__/ChatModelPickerModal.test.ts
+++ b/src/views/chatview/__tests__/ChatModelPickerModal.test.ts
@@ -415,7 +415,7 @@ describe("ChatModelPickerModal", () => {
     expect(activeOption?.dataset.modelValue).toBe("openai@@gpt-4.1");
   });
 
-  it("shows an empty state when the model list loads without options", async () => {
+  it("shows an empty state with a retry action when the model list loads without options", async () => {
     const modal = new ChatModelPickerModal(new App(), {
       currentValue: "missing-model",
       loadOptions: async () => [],
@@ -432,5 +432,45 @@ describe("ChatModelPickerModal", () => {
     expect(
       (modal.contentEl.querySelector(".systemsculpt-chat-model-modal-list") as HTMLElement | null)?.style.display
     ).toBe("none");
+    // An empty dropdown must never be a dead end — it must offer a retry (#206).
+    expect(
+      modal.contentEl.querySelector(".systemsculpt-chat-model-modal-empty-retry")
+    ).not.toBeNull();
+  });
+
+  it("shows the failure reason and a working Retry action when loading fails (#206)", async () => {
+    const loadOptions = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("OpenRouter endpoint unreachable"))
+      .mockResolvedValueOnce([buildOption({ value: "openai@@gpt-4.1", label: "GPT-4.1" })]);
+
+    const modal = new ChatModelPickerModal(new App(), {
+      currentValue: "openai@@gpt-4.1",
+      loadOptions,
+      onSelect: jest.fn(),
+      onOpenSetup: jest.fn(),
+    });
+
+    modal.onOpen();
+    await flush();
+
+    // The reason is visible, not a generic "unavailable".
+    expect(
+      modal.contentEl.querySelector(".systemsculpt-chat-model-modal-empty-text")?.textContent
+    ).toContain("OpenRouter endpoint unreachable");
+
+    const retryButton = modal.contentEl.querySelector(
+      ".systemsculpt-chat-model-modal-empty-retry"
+    ) as HTMLButtonElement | null;
+    expect(retryButton).not.toBeNull();
+
+    retryButton!.dispatchEvent(new window.Event("click", { bubbles: true }));
+    await flush();
+
+    expect(loadOptions).toHaveBeenCalledTimes(2);
+    const optionTitles = Array.from(
+      modal.contentEl.querySelectorAll(".systemsculpt-chat-model-modal-option-title")
+    ).map((el) => el.textContent?.trim());
+    expect(optionTitles).toContain("GPT-4.1");
   });
 });

--- a/src/views/chatview/__tests__/modelSelection.test.ts
+++ b/src/views/chatview/__tests__/modelSelection.test.ts
@@ -202,4 +202,42 @@ describe("chat model setup helpers", () => {
       })
     );
   });
+
+  it("surfaces the catalog error reason instead of returning a silent empty list", async () => {
+    const plugin = {
+      modelService: {
+        getModels: jest.fn().mockResolvedValue([]),
+        getCatalogStatus: jest.fn(() => ({
+          state: "error",
+          reason: "OpenRouter endpoint unreachable",
+        })),
+      },
+      settings: {},
+    } as any;
+
+    await expect(loadChatModelPickerOptions(plugin)).rejects.toThrow(
+      "OpenRouter endpoint unreachable"
+    );
+  });
+
+  it("returns an empty list without throwing when the catalog is ready but empty", async () => {
+    const plugin = {
+      modelService: {
+        getModels: jest.fn().mockResolvedValue([]),
+        getCatalogStatus: jest.fn(() => ({ state: "ready", reason: null })),
+      },
+      settings: {},
+    } as any;
+
+    await expect(loadChatModelPickerOptions(plugin)).resolves.toEqual([]);
+  });
+
+  it("returns an empty list when the model service exposes no catalog status", async () => {
+    const plugin = {
+      modelService: { getModels: jest.fn().mockResolvedValue([]) },
+      settings: {},
+    } as any;
+
+    await expect(loadChatModelPickerOptions(plugin)).resolves.toEqual([]);
+  });
 });

--- a/src/views/chatview/modelSelection.ts
+++ b/src/views/chatview/modelSelection.ts
@@ -322,9 +322,20 @@ export function getChatModelPickerSearchText(option: ChatModelPickerOption): str
 export async function loadChatModelPickerOptions(
   plugin: Pick<SystemSculptPlugin, "modelService" | "settings">,
 ): Promise<ChatModelPickerOption[]> {
-  const models = plugin.modelService?.getModels
-    ? await plugin.modelService.getModels().catch(() => [] as SystemSculptModel[])
+  const modelService = plugin.modelService;
+  const models = modelService?.getModels
+    ? await modelService.getModels().catch(() => [] as SystemSculptModel[])
     : [];
+
+  // A failed catalog load must not masquerade as "no models available": surface
+  // the reason so the picker can show it with a retry instead of a silent,
+  // unexplained empty dropdown (#206).
+  if (models.length === 0) {
+    const status = modelService?.getCatalogStatus?.();
+    if (status?.state === "error") {
+      throw new Error(status.reason || "The model catalog is unavailable.");
+    }
+  }
 
   const providerHints = Array.from(
     new Set(


### PR DESCRIPTION
Root-causes the #201-class empty model dropdown by making catalog state explicit instead of swallowed.

- `UnifiedModelService` now exposes a `loading → ready | error(reason)` state machine and `getCatalogStatus()`; a failed load records the reason instead of collapsing to a silent `[]`.
- The chat model picker surfaces that reason and a **Retry** action — an empty or failed dropdown is never an unexplained dead end.
- TDD: registry state-machine + recovery, options error-surfacing, and modal reason/retry rendering.

Refs #201, #206.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry button to model picker modal—users can now easily re-attempt loading available models after a failure.

* **Bug Fixes**
  * Improved error handling in model loading with clearer error messages and better status tracking.
  * Enhanced empty-state UI to display specific error reasons when model loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->