### PR TITLE
feat(providers): Claude (Anthropic) BYOK via native Messages API (#230)

### DIFF
--- a/src/services/SystemSculptService.ts
+++ b/src/services/SystemSculptService.ts
@@ -40,6 +40,7 @@ export type { StreamDebugCallbacks } from "./StreamExecutionTypes";
 
 let localPiStreamExecutorModulePromise: Promise<typeof import("./LocalPiStreamExecutor")> | null = null;
 let remoteProviderStreamExecutorModulePromise: Promise<typeof import("./providerRuntime/OpenRouterRemoteStreamExecutor")> | null = null;
+let anthropicRemoteStreamExecutorModulePromise: Promise<typeof import("./providerRuntime/AnthropicRemoteStreamExecutor")> | null = null;
 
 async function loadLocalPiStreamExecutorModule(): Promise<typeof import("./LocalPiStreamExecutor")> {
   if (!localPiStreamExecutorModulePromise) {
@@ -53,6 +54,13 @@ async function loadRemoteProviderStreamExecutorModule(): Promise<typeof import("
     remoteProviderStreamExecutorModulePromise = import("./providerRuntime/OpenRouterRemoteStreamExecutor");
   }
   return await remoteProviderStreamExecutorModulePromise;
+}
+
+async function loadAnthropicRemoteStreamExecutorModule(): Promise<typeof import("./providerRuntime/AnthropicRemoteStreamExecutor")> {
+  if (!anthropicRemoteStreamExecutorModulePromise) {
+    anthropicRemoteStreamExecutorModulePromise = import("./providerRuntime/AnthropicRemoteStreamExecutor");
+  }
+  return await anthropicRemoteStreamExecutorModulePromise;
 }
 
 export type CreditsBalanceSnapshot = {
@@ -1211,6 +1219,28 @@ export class SystemSculptService {
       }
 
       if (prepared.modelSource === "custom_endpoint") {
+        const remoteProviderId = String(
+          prepared.resolvedModel.sourceProviderId || prepared.resolvedModel.provider || "",
+        )
+          .trim()
+          .toLowerCase();
+
+        // Anthropic/Claude runs through the native Messages API executor; the
+        // OpenAI-compatible /chat/completions path cannot serve it (#230).
+        if (remoteProviderId === "anthropic") {
+          const { executeAnthropicRemoteStream } = await loadAnthropicRemoteStreamExecutorModule();
+          for await (const event of executeAnthropicRemoteStream({
+            plugin: this.plugin,
+            prepared,
+            signal,
+            reasoningEffort,
+            debug,
+          })) {
+            yield event;
+          }
+          return;
+        }
+
         const { executeOpenRouterRemoteStream } = await loadRemoteProviderStreamExecutorModule();
         for await (const event of executeOpenRouterRemoteStream({
           plugin: this.plugin,

--- a/src/services/SystemSculptService.ts
+++ b/src/services/SystemSculptService.ts
@@ -35,6 +35,7 @@ import { errorLogger } from "../utils/errorLogger";
 import type { PreparedChatRequest, StreamDebugCallbacks } from "./StreamExecutionTypes";
 import { MCPService } from "../mcp/MCPService";
 import type { ToolCall, ToolCallRequest, ToolCallResult } from "../types/toolCalls";
+import { normalizeProviderId } from "./providerRuntime/RemoteProviderCatalog";
 
 export type { StreamDebugCallbacks } from "./StreamExecutionTypes";
 
@@ -1219,11 +1220,9 @@ export class SystemSculptService {
       }
 
       if (prepared.modelSource === "custom_endpoint") {
-        const remoteProviderId = String(
-          prepared.resolvedModel.sourceProviderId || prepared.resolvedModel.provider || "",
-        )
-          .trim()
-          .toLowerCase();
+        const remoteProviderId = normalizeProviderId(
+          String(prepared.resolvedModel.sourceProviderId || prepared.resolvedModel.provider || ""),
+        );
 
         // Anthropic/Claude runs through the native Messages API executor; the
         // OpenAI-compatible /chat/completions path cannot serve it (#230).

--- a/src/services/providerRuntime/AnthropicRemoteStreamExecutor.ts
+++ b/src/services/providerRuntime/AnthropicRemoteStreamExecutor.ts
@@ -1,0 +1,733 @@
+import type SystemSculptPlugin from "../../main";
+import type { PreparedChatRequest, StreamDebugCallbacks } from "../StreamExecutionTypes";
+import type { StreamEvent, StreamToolCall } from "../../streaming/types";
+import type { ChatMessage, MultiPartContent } from "../../types";
+import type { OpenAITool } from "../../utils/tooling";
+import { PlatformRequestClient } from "../PlatformRequestClient";
+import { StreamingErrorHandler } from "../StreamingErrorHandler";
+import { resolveStudioPiProviderApiKey } from "../../studio/piAuth/StudioPiAuthStorage";
+import { resolveConfiguredRemoteProviderEndpoint } from "./RemoteProviderCatalog";
+import { ANTHROPIC_API_VERSION, ANTHROPIC_STREAM_EVENTS } from "../../constants/anthropic";
+import { ERROR_CODES, SystemSculptError } from "../../utils/errors";
+
+type RemoteAnthropicStreamInput = {
+  plugin: SystemSculptPlugin;
+  prepared: PreparedChatRequest;
+  signal?: AbortSignal;
+  reasoningEffort?: string;
+  debug?: StreamDebugCallbacks;
+};
+
+const ANTHROPIC_PROVIDER_ID = "anthropic";
+// Anthropic's Messages API requires an explicit `max_tokens`. When the model
+// metadata does not declare a completion cap we fall back to a conservative
+// value that every current Claude model supports.
+const DEFAULT_MAX_TOKENS = 8192;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Anthropic request-body construction
+// ────────────────────────────────────────────────────────────────────────────
+
+type AnthropicTextBlock = { type: "text"; text: string };
+type AnthropicImageBlock = {
+  type: "image";
+  source: { type: "base64"; media_type: string; data: string };
+};
+type AnthropicToolUseBlock = {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+};
+type AnthropicToolResultBlock = {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+};
+type AnthropicContentBlock =
+  | AnthropicTextBlock
+  | AnthropicImageBlock
+  | AnthropicToolUseBlock
+  | AnthropicToolResultBlock;
+
+type AnthropicMessage = {
+  role: "user" | "assistant";
+  content: string | AnthropicContentBlock[];
+};
+
+type AnthropicTool = {
+  name: string;
+  description?: string;
+  input_schema: Record<string, unknown>;
+};
+
+function resolveMaxTokens(prepared: PreparedChatRequest): number {
+  const cap = prepared.resolvedModel?.top_provider?.max_completion_tokens;
+  if (typeof cap === "number" && Number.isFinite(cap) && cap > 0) {
+    return Math.floor(cap);
+  }
+  return DEFAULT_MAX_TOKENS;
+}
+
+/**
+ * Parse a data URL (or bare base64 payload) into the Anthropic image-block
+ * `media_type`/`data` pair. Returns null when the value is not a usable base64
+ * image (e.g. a remote https URL, which the Messages API base64 source cannot
+ * carry).
+ */
+function parseImageSource(
+  url: string,
+): { media_type: string; data: string } | null {
+  if (typeof url !== "string" || url.length === 0) return null;
+
+  const dataUrlMatch = url.match(/^data:([^;,]+)?(?:;base64)?,(.*)$/s);
+  if (dataUrlMatch) {
+    const mediaType = (dataUrlMatch[1] || "image/png").trim();
+    const data = dataUrlMatch[2] || "";
+    if (data.length === 0) return null;
+    return { media_type: mediaType, data };
+  }
+
+  // Anthropic's base64 source cannot fetch remote URLs; skip those.
+  return null;
+}
+
+function toAnthropicContentBlocks(parts: MultiPartContent[]): AnthropicContentBlock[] {
+  const blocks: AnthropicContentBlock[] = [];
+  for (const part of parts) {
+    if (part && part.type === "text" && typeof part.text === "string") {
+      blocks.push({ type: "text", text: part.text });
+      continue;
+    }
+    if (
+      part &&
+      part.type === "image_url" &&
+      part.image_url &&
+      typeof part.image_url.url === "string"
+    ) {
+      const source = parseImageSource(part.image_url.url);
+      if (source) {
+        blocks.push({
+          type: "image",
+          source: { type: "base64", media_type: source.media_type, data: source.data },
+        });
+      }
+    }
+  }
+  return blocks;
+}
+
+function extractToolCallParts(
+  toolCall: unknown,
+): { id: string; name: string; input: Record<string, unknown> } | null {
+  if (!toolCall || typeof toolCall !== "object") return null;
+  const tc = toolCall as Record<string, any>;
+  const req: Record<string, any> = (tc.request || tc) ?? {};
+  const fn: Record<string, any> =
+    req.function || tc.function || (req.name ? { name: req.name, arguments: req.arguments } : {});
+  const name = typeof fn?.name === "string" ? fn.name.trim() : "";
+  if (!name) return null;
+
+  const id =
+    typeof tc.id === "string" && tc.id.length > 0
+      ? tc.id
+      : typeof req.id === "string" && req.id.length > 0
+        ? req.id
+        : `toolu_${name}`;
+
+  let input: Record<string, unknown> = {};
+  const rawArgs = fn?.arguments;
+  if (rawArgs && typeof rawArgs === "object") {
+    input = rawArgs as Record<string, unknown>;
+  } else if (typeof rawArgs === "string" && rawArgs.trim().length > 0) {
+    try {
+      const parsed = JSON.parse(rawArgs);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        input = parsed as Record<string, unknown>;
+      }
+    } catch {
+      input = {};
+    }
+  }
+
+  return { id, name, input };
+}
+
+function stringifyToolResultContent(content: ChatMessage["content"]): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        part && part.type === "text" && typeof part.text === "string" ? part.text : "",
+      )
+      .filter((text) => text.length > 0)
+      .join("\n");
+  }
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+/**
+ * Translate the repo's `ChatMessage[]` history into Anthropic Messages API
+ * turns. System messages are dropped (the system prompt is a top-level field),
+ * tool results collapse into `tool_result` blocks, and adjacent tool results
+ * merge into a single user turn as Anthropic requires.
+ */
+export function toAnthropicMessages(messages: ChatMessage[]): AnthropicMessage[] {
+  const result: AnthropicMessage[] = [];
+
+  for (const message of messages || []) {
+    if (!message || message.role === "system") continue;
+
+    if (message.role === "tool") {
+      const block: AnthropicToolResultBlock = {
+        type: "tool_result",
+        tool_use_id: typeof message.tool_call_id === "string" ? message.tool_call_id : "",
+        content: stringifyToolResultContent(message.content),
+      };
+      const last = result[result.length - 1];
+      if (
+        last &&
+        last.role === "user" &&
+        Array.isArray(last.content) &&
+        last.content.every((b) => b.type === "tool_result")
+      ) {
+        last.content.push(block);
+      } else {
+        result.push({ role: "user", content: [block] });
+      }
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      const hasToolCalls =
+        Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
+
+      // Plain text assistant turns stay a string (matches the user-turn shape);
+      // only build a content-block array when tool_use or multimodal blocks are
+      // present.
+      if (!hasToolCalls && typeof message.content === "string") {
+        result.push({
+          role: "assistant",
+          content: message.content.length > 0 ? message.content : " ",
+        });
+        continue;
+      }
+
+      const blocks: AnthropicContentBlock[] = [];
+
+      if (typeof message.content === "string") {
+        if (message.content.length > 0) {
+          blocks.push({ type: "text", text: message.content });
+        }
+      } else if (Array.isArray(message.content)) {
+        blocks.push(...toAnthropicContentBlocks(message.content));
+      }
+
+      if (hasToolCalls) {
+        for (const toolCall of message.tool_calls!) {
+          const parts = extractToolCallParts(toolCall);
+          if (parts) {
+            blocks.push({
+              type: "tool_use",
+              id: parts.id,
+              name: parts.name,
+              input: parts.input,
+            });
+          }
+        }
+      }
+
+      // Anthropic rejects empty assistant content; fall back to a single space.
+      if (blocks.length === 0) {
+        result.push({ role: "assistant", content: " " });
+      } else {
+        result.push({ role: "assistant", content: blocks });
+      }
+      continue;
+    }
+
+    // role === "user"
+    if (typeof message.content === "string") {
+      result.push({ role: "user", content: message.content.length > 0 ? message.content : " " });
+    } else if (Array.isArray(message.content)) {
+      const blocks = toAnthropicContentBlocks(message.content);
+      result.push({ role: "user", content: blocks.length > 0 ? blocks : " " });
+    } else {
+      result.push({ role: "user", content: " " });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convert OpenAI-style tool definitions (`{type, function:{...}}`) — or the
+ * already-flattened `{name, description, parameters}` shape — into Anthropic's
+ * `{name, description, input_schema}` tool format.
+ */
+export function toAnthropicTools(tools: unknown[]): AnthropicTool[] {
+  if (!Array.isArray(tools)) return [];
+  const result: AnthropicTool[] = [];
+
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object") continue;
+    const candidate = tool as Record<string, any>;
+    const fn: Record<string, any> = candidate.function || candidate;
+    const name = typeof fn?.name === "string" ? fn.name.trim() : "";
+    if (!name) continue;
+
+    const parameters =
+      fn?.parameters && typeof fn.parameters === "object"
+        ? (fn.parameters as Record<string, unknown>)
+        : fn?.input_schema && typeof fn.input_schema === "object"
+          ? (fn.input_schema as Record<string, unknown>)
+          : { type: "object", properties: {} };
+
+    const description = typeof fn?.description === "string" ? fn.description : undefined;
+
+    result.push({
+      name,
+      ...(description ? { description } : {}),
+      input_schema: parameters,
+    });
+  }
+
+  return result;
+}
+
+export function buildAnthropicMessagesRequestBody(
+  input: RemoteAnthropicStreamInput,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: input.prepared.actualModelId,
+    max_tokens: resolveMaxTokens(input.prepared),
+    messages: toAnthropicMessages(input.prepared.preparedMessages),
+    stream: true,
+  };
+
+  const system = input.prepared.finalSystemPrompt;
+  if (typeof system === "string" && system.trim().length > 0) {
+    body.system = system;
+  }
+
+  if (Array.isArray(input.prepared.tools) && input.prepared.tools.length > 0) {
+    body.tools = toAnthropicTools(input.prepared.tools as OpenAITool[]);
+  }
+
+  return body;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Anthropic SSE → StreamEvent parser
+// ────────────────────────────────────────────────────────────────────────────
+
+interface AnthropicToolUseState {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+/**
+ * Maps Anthropic stop reasons onto the SAME stop-reason values the
+ * OpenAI-compatible StreamPipeline emits (see
+ * StreamPipeline.mapFinishReasonToPiStopReason), so downstream turn-loop logic
+ * is provider-agnostic:
+ *   end_turn / stop_sequence → "stop"
+ *   max_tokens               → "length"
+ *   tool_use                 → "toolUse"
+ */
+function mapAnthropicStopReason(stopReason: string): string {
+  const lc = String(stopReason || "").trim().toLowerCase();
+  if (!lc) return stopReason;
+  if (lc === "end_turn" || lc === "stop_sequence") return "stop";
+  if (lc === "max_tokens") return "length";
+  if (lc === "tool_use") return "toolUse";
+  return stopReason;
+}
+
+function buildStreamToolCall(state: AnthropicToolUseState): StreamToolCall {
+  return {
+    id: state.id,
+    type: "function",
+    function: {
+      name: state.name,
+      arguments: state.arguments,
+    },
+  };
+}
+
+/**
+ * Incremental parser for the Anthropic Messages API SSE wire format. Mirrors
+ * StreamPipeline's `push`/`flush` interface so it can be unit-tested directly
+ * with raw SSE strings. Anthropic frames each event as an `event: <type>` line
+ * followed by a `data: <json>` line and a blank-line terminator; we buffer
+ * partial lines across `push` calls.
+ */
+export class AnthropicStreamParser {
+  private buffer = "";
+  private currentEvent: string | null = null;
+  private readonly dataLines: string[] = [];
+  private readonly toolUseBlocks = new Map<number, AnthropicToolUseState>();
+
+  push(text: string): StreamEvent[] {
+    this.buffer += text;
+    const events: StreamEvent[] = [];
+
+    while (true) {
+      const newlineIndex = this.buffer.indexOf("\n");
+      if (newlineIndex === -1) break;
+
+      let line = this.buffer.slice(0, newlineIndex);
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+
+      events.push(...this.consumeLine(line));
+    }
+
+    return events;
+  }
+
+  flush(): StreamEvent[] {
+    const events: StreamEvent[] = [];
+
+    if (this.buffer.length > 0) {
+      let line = this.buffer;
+      this.buffer = "";
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      events.push(...this.consumeLine(line));
+    }
+
+    // Dispatch any event whose terminating blank line never arrived.
+    events.push(...this.dispatchEvent());
+
+    return events;
+  }
+
+  private consumeLine(line: string): StreamEvent[] {
+    const trimmed = line.trim();
+
+    // A blank line terminates the current SSE event.
+    if (trimmed.length === 0) {
+      return this.dispatchEvent();
+    }
+
+    if (trimmed.startsWith(":")) {
+      return []; // SSE comment / keep-alive
+    }
+
+    if (line.startsWith("event:")) {
+      this.currentEvent = line.slice("event:".length).trim();
+      return [];
+    }
+
+    if (line.startsWith("data:")) {
+      let dataLine = line.slice("data:".length);
+      if (dataLine.startsWith(" ")) dataLine = dataLine.slice(1);
+      this.dataLines.push(dataLine);
+      return [];
+    }
+
+    return [];
+  }
+
+  private dispatchEvent(): StreamEvent[] {
+    if (this.currentEvent === null && this.dataLines.length === 0) {
+      return [];
+    }
+
+    const eventType = this.currentEvent;
+    const payload = this.dataLines.join("\n");
+    this.currentEvent = null;
+    this.dataLines.length = 0;
+
+    if (payload.length === 0) {
+      return [];
+    }
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      return [];
+    }
+
+    // Prefer the explicit SSE event name, but fall back to the payload `type`
+    // so a well-formed data block is still routed if the event line was lost.
+    const type = eventType || (typeof parsed?.type === "string" ? parsed.type : "");
+    return this.handleEvent(type, parsed);
+  }
+
+  private handleEvent(type: string, parsed: any): StreamEvent[] {
+    const events: StreamEvent[] = [];
+
+    switch (type) {
+      case ANTHROPIC_STREAM_EVENTS.CONTENT_BLOCK_START: {
+        const index = typeof parsed?.index === "number" ? parsed.index : 0;
+        const block = parsed?.content_block;
+        if (block && block.type === "tool_use") {
+          const state: AnthropicToolUseState = {
+            id: typeof block.id === "string" ? block.id : `toolu_${index}`,
+            name: typeof block.name === "string" ? block.name : "",
+            arguments: "",
+          };
+          this.toolUseBlocks.set(index, state);
+          events.push({ type: "tool-call", phase: "delta", call: buildStreamToolCall(state) });
+        }
+        break;
+      }
+
+      case ANTHROPIC_STREAM_EVENTS.CONTENT_BLOCK_DELTA: {
+        const index = typeof parsed?.index === "number" ? parsed.index : 0;
+        const delta = parsed?.delta;
+        if (!delta || typeof delta !== "object") break;
+
+        if (delta.type === "text_delta" && typeof delta.text === "string" && delta.text.length > 0) {
+          events.push({ type: "content", text: delta.text });
+        } else if (
+          delta.type === "thinking_delta" &&
+          typeof delta.thinking === "string" &&
+          delta.thinking.length > 0
+        ) {
+          events.push({ type: "reasoning", text: delta.thinking });
+        } else if (delta.type === "input_json_delta" && typeof delta.partial_json === "string") {
+          const state = this.toolUseBlocks.get(index);
+          if (state) {
+            state.arguments += delta.partial_json;
+            events.push({ type: "tool-call", phase: "delta", call: buildStreamToolCall(state) });
+          }
+        }
+        break;
+      }
+
+      case ANTHROPIC_STREAM_EVENTS.CONTENT_BLOCK_STOP: {
+        const index = typeof parsed?.index === "number" ? parsed.index : 0;
+        const state = this.toolUseBlocks.get(index);
+        if (state) {
+          events.push({ type: "tool-call", phase: "final", call: buildStreamToolCall(state) });
+          this.toolUseBlocks.delete(index);
+        }
+        break;
+      }
+
+      case ANTHROPIC_STREAM_EVENTS.MESSAGE_DELTA: {
+        const stopReason = parsed?.delta?.stop_reason;
+        if (typeof stopReason === "string" && stopReason.length > 0) {
+          events.push({
+            type: "meta",
+            key: "stop-reason",
+            value: mapAnthropicStopReason(stopReason),
+          });
+        }
+        break;
+      }
+
+      case ANTHROPIC_STREAM_EVENTS.ERROR: {
+        const message =
+          (parsed?.error && typeof parsed.error.message === "string" && parsed.error.message) ||
+          (typeof parsed?.message === "string" && parsed.message) ||
+          "Anthropic stream error";
+        throw new SystemSculptError(message, ERROR_CODES.STREAM_ERROR, 500, {
+          provider: ANTHROPIC_PROVIDER_ID,
+          rawError: parsed?.error ?? parsed,
+        });
+      }
+
+      // message_start / message_stop / ping carry no StreamEvent payload.
+      default:
+        break;
+    }
+
+    return events;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Executor
+// ────────────────────────────────────────────────────────────────────────────
+
+function serializeResponseHeaders(headers: unknown): Record<string, string> {
+  const serialized: Record<string, string> = {};
+  const maybeHeaders = headers as {
+    forEach?: (callback: (value: unknown, key: unknown) => void) => void;
+    entries?: () => Iterable<[unknown, unknown]>;
+  };
+
+  if (typeof maybeHeaders?.forEach === "function") {
+    maybeHeaders.forEach((value, key) => {
+      serialized[String(key)] = String(value);
+    });
+    return serialized;
+  }
+
+  if (typeof maybeHeaders?.entries === "function") {
+    for (const [key, value] of maybeHeaders.entries()) {
+      serialized[String(key)] = String(value);
+    }
+  }
+
+  return serialized;
+}
+
+export async function* executeAnthropicRemoteStream(
+  input: RemoteAnthropicStreamInput,
+): AsyncGenerator<StreamEvent, void, unknown> {
+  const endpoint = resolveConfiguredRemoteProviderEndpoint(input.plugin, ANTHROPIC_PROVIDER_ID);
+  if (!endpoint) {
+    throw new Error(`No remote endpoint configured for provider "${ANTHROPIC_PROVIDER_ID}".`);
+  }
+
+  const apiKey = await resolveStudioPiProviderApiKey(ANTHROPIC_PROVIDER_ID, {
+    plugin: input.plugin,
+  });
+  if (!apiKey) {
+    throw new Error(`Connect ${ANTHROPIC_PROVIDER_ID} in Providers before using this model.`);
+  }
+
+  const requestBody = buildAnthropicMessagesRequestBody(input);
+  const client = new PlatformRequestClient();
+  const debugHeaders = {
+    "x-api-key": "[redacted]",
+    "anthropic-version": ANTHROPIC_API_VERSION,
+  };
+
+  try {
+    input.debug?.onRequest?.({
+      provider: ANTHROPIC_PROVIDER_ID,
+      endpoint,
+      headers: debugHeaders,
+      body: requestBody,
+      transport: "remote-provider",
+      canStream: true,
+      isCustomProvider: true,
+    });
+  } catch {}
+
+  const response = await client.request({
+    url: `${endpoint.replace(/\/$/, "")}/messages`,
+    method: "POST",
+    body: requestBody,
+    stream: true,
+    signal: input.signal,
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": ANTHROPIC_API_VERSION,
+      "content-type": "application/json",
+    },
+  });
+
+  try {
+    input.debug?.onResponse?.({
+      provider: ANTHROPIC_PROVIDER_ID,
+      endpoint,
+      status: response.status,
+      headers: serializeResponseHeaders(response.headers),
+      isCustomProvider: true,
+    });
+  } catch {}
+
+  if (!response.ok) {
+    await StreamingErrorHandler.handleStreamError(response, true, {
+      provider: ANTHROPIC_PROVIDER_ID,
+      endpoint,
+      model: input.prepared.actualModelId,
+    });
+  }
+
+  if (!response.body) {
+    throw new SystemSculptError(
+      "Missing response body from streaming API",
+      ERROR_CODES.STREAM_ERROR,
+      response.status,
+    );
+  }
+
+  const parser = new AnthropicStreamParser();
+  const decoder = new TextDecoder();
+  const reader = response.body.getReader();
+
+  const readWithAbort = async (): Promise<{
+    done: boolean;
+    value?: Uint8Array;
+    aborted: boolean;
+  }> => {
+    if (!input.signal) {
+      const { done, value } = await reader.read();
+      return { done, value, aborted: false };
+    }
+
+    if (input.signal.aborted) {
+      try {
+        await reader.cancel();
+      } catch {}
+      return { done: true, value: undefined, aborted: true };
+    }
+
+    return await new Promise((resolve, reject) => {
+      const onAbort = () => {
+        try {
+          void reader.cancel();
+        } catch {}
+        resolve({ done: true, value: undefined, aborted: true });
+      };
+
+      input.signal!.addEventListener("abort", onAbort, { once: true });
+
+      reader
+        .read()
+        .then(({ done, value }) => resolve({ done, value, aborted: false }))
+        .catch(reject)
+        .finally(() => {
+          input.signal!.removeEventListener("abort", onAbort);
+        });
+    });
+  };
+
+  let aborted = false;
+
+  try {
+    while (true) {
+      const { done, value, aborted: abortedBySignal } = await readWithAbort();
+      if (abortedBySignal) {
+        aborted = true;
+        break;
+      }
+      if (done) break;
+      if (!value) continue;
+
+      const text = decoder.decode(value, { stream: true });
+      const events = parser.push(text);
+      for (const event of events) {
+        try {
+          input.debug?.onStreamEvent?.({ event });
+        } catch {}
+        yield event;
+      }
+    }
+
+    if (!aborted) {
+      const trailingEvents = parser.flush();
+      for (const event of trailingEvents) {
+        try {
+          input.debug?.onStreamEvent?.({ event });
+        } catch {}
+        yield event;
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {}
+  }
+
+  try {
+    input.debug?.onStreamEnd?.({
+      completed: !aborted,
+      aborted,
+    });
+  } catch {}
+}

--- a/src/services/providerRuntime/AnthropicRemoteStreamExecutor.ts
+++ b/src/services/providerRuntime/AnthropicRemoteStreamExecutor.ts
@@ -69,6 +69,28 @@ function resolveMaxTokens(prepared: PreparedChatRequest): number {
   return DEFAULT_MAX_TOKENS;
 }
 
+// Map the requested reasoning effort onto an Anthropic extended-thinking token
+// budget. Anthropic requires `budget_tokens >= 1024`; `"off"`/unset (or any
+// unrecognized value) disables thinking. The effort vocabulary mirrors
+// SystemSculptService.normalizeReasoningEffort
+// ("off"|"minimal"|"low"|"medium"|"high"|"xhigh").
+function resolveAnthropicThinkingBudget(reasoningEffort?: string): number | null {
+  switch (String(reasoningEffort || "").trim().toLowerCase()) {
+    case "minimal":
+      return 1024;
+    case "low":
+      return 2048;
+    case "medium":
+      return 4096;
+    case "high":
+      return 8192;
+    case "xhigh":
+      return 16384;
+    default:
+      return null;
+  }
+}
+
 /**
  * Parse a data URL (or bare base64 payload) into the Anthropic image-block
  * `media_type`/`data` pair. Returns null when the value is not a usable base64
@@ -184,9 +206,22 @@ export function toAnthropicMessages(messages: ChatMessage[]): AnthropicMessage[]
     if (!message || message.role === "system") continue;
 
     if (message.role === "tool") {
+      const toolUseId =
+        typeof message.tool_call_id === "string" ? message.tool_call_id.trim() : "";
+      // An empty tool_use_id yields an uncorrelatable tool_result that breaks
+      // Anthropic's turn contract; fall back to a plain user text turn instead
+      // (CodeRabbit, #230).
+      if (!toolUseId) {
+        const fallback = stringifyToolResultContent(message.content).trim();
+        if (fallback.length > 0) {
+          result.push({ role: "user", content: fallback });
+        }
+        continue;
+      }
+
       const block: AnthropicToolResultBlock = {
         type: "tool_result",
-        tool_use_id: typeof message.tool_call_id === "string" ? message.tool_call_id : "",
+        tool_use_id: toolUseId,
         content: stringifyToolResultContent(message.content),
       };
       const last = result[result.length - 1];
@@ -303,9 +338,18 @@ export function toAnthropicTools(tools: unknown[]): AnthropicTool[] {
 export function buildAnthropicMessagesRequestBody(
   input: RemoteAnthropicStreamInput,
 ): Record<string, unknown> {
+  const thinkingBudget = resolveAnthropicThinkingBudget(input.reasoningEffort);
+  let maxTokens = resolveMaxTokens(input.prepared);
+  // Anthropic requires max_tokens to exceed budget_tokens, leaving room for the
+  // visible answer on top of the thinking budget. Bump it when the requested
+  // budget would otherwise crowd out the response.
+  if (thinkingBudget !== null && maxTokens <= thinkingBudget) {
+    maxTokens = thinkingBudget + DEFAULT_MAX_TOKENS;
+  }
+
   const body: Record<string, unknown> = {
     model: input.prepared.actualModelId,
-    max_tokens: resolveMaxTokens(input.prepared),
+    max_tokens: maxTokens,
     messages: toAnthropicMessages(input.prepared.preparedMessages),
     stream: true,
   };
@@ -317,6 +361,16 @@ export function buildAnthropicMessagesRequestBody(
 
   if (Array.isArray(input.prepared.tools) && input.prepared.tools.length > 0) {
     body.tools = toAnthropicTools(input.prepared.tools as OpenAITool[]);
+  }
+
+  // Extended thinking: a reasoning-capable Claude should actually reason when
+  // the user requests it. The catalog advertises reasoning and streamMessage
+  // forwards reasoningEffort, so without this the Messages API silently returns
+  // a non-thinking response (#230, Codex P2). Thinking deltas surface via the
+  // parser's `thinking_delta` → reasoning events. Temperature is intentionally
+  // never sent (Anthropic requires it unset/1 when thinking is enabled).
+  if (thinkingBudget !== null) {
+    body.thinking = { type: "enabled", budget_tokens: thinkingBudget };
   }
 
   return body;

--- a/src/services/providerRuntime/RemoteProviderCatalog.ts
+++ b/src/services/providerRuntime/RemoteProviderCatalog.ts
@@ -46,6 +46,18 @@ const REMOTE_PROVIDER_SEEDS: readonly RemoteProviderSeed[] = [
     supportedParameters: ["tools"],
     endpoint: AI_PROVIDERS.OPENAI.BASE_URL,
   },
+  {
+    // Anthropic runs through the native Messages API executor (not the
+    // OpenAI-compatible /chat/completions path) — see AnthropicRemoteStreamExecutor (#230).
+    providerId: "anthropic",
+    modelId: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    description: "Anthropic Claude remote provider model (native Messages API) for chat, tool use, and reasoning.",
+    contextLength: 200_000,
+    modality: "text+image->text",
+    supportedParameters: ["tools"],
+    endpoint: AI_PROVIDERS.ANTHROPIC.BASE_URL,
+  },
 ];
 
 function normalizeProviderId(value: unknown): string {
@@ -144,6 +156,9 @@ export function resolveRemoteProviderEndpoint(providerId: string): string {
   }
   if (normalized === "openai") {
     return AI_PROVIDERS.OPENAI.BASE_URL;
+  }
+  if (normalized === "anthropic") {
+    return AI_PROVIDERS.ANTHROPIC.BASE_URL;
   }
   return "";
 }

--- a/src/services/providerRuntime/RemoteProviderCatalog.ts
+++ b/src/services/providerRuntime/RemoteProviderCatalog.ts
@@ -60,7 +60,7 @@ const REMOTE_PROVIDER_SEEDS: readonly RemoteProviderSeed[] = [
   },
 ];
 
-function normalizeProviderId(value: unknown): string {
+export function normalizeProviderId(value: unknown): string {
   return String(value || "").trim().toLowerCase();
 }
 

--- a/src/services/providerRuntime/__tests__/AnthropicRemoteStreamExecutor.test.ts
+++ b/src/services/providerRuntime/__tests__/AnthropicRemoteStreamExecutor.test.ts
@@ -1,0 +1,765 @@
+import {
+  AnthropicStreamParser,
+  buildAnthropicMessagesRequestBody,
+  executeAnthropicRemoteStream,
+  toAnthropicMessages,
+  toAnthropicTools,
+} from "../AnthropicRemoteStreamExecutor";
+import { ANTHROPIC_API_VERSION } from "../../../constants/anthropic";
+import type { StreamEvent } from "../../../streaming/types";
+
+const mockResolveEndpoint = jest.fn(() => "https://api.anthropic.com/v1");
+const mockResolveApiKey = jest.fn(async () => "sk-ant-test-key");
+const mockRequest = jest.fn();
+
+jest.mock("../RemoteProviderCatalog", () => ({
+  resolveConfiguredRemoteProviderEndpoint: (_plugin: unknown, ...args: any[]) =>
+    mockResolveEndpoint(...args),
+}));
+
+jest.mock("../../../studio/piAuth/StudioPiAuthStorage", () => ({
+  resolveStudioPiProviderApiKey: (...args: any[]) => mockResolveApiKey(...args),
+}));
+
+jest.mock("../../PlatformRequestClient", () => ({
+  PlatformRequestClient: jest.fn().mockImplementation(() => ({
+    request: (...args: any[]) => mockRequest(...args),
+  })),
+}));
+
+jest.mock("../../StreamingErrorHandler", () => ({
+  StreamingErrorHandler: {
+    handleStreamError: jest.fn(async () => {
+      throw new Error("stream-error-handled");
+    }),
+  },
+}));
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function makePrepared(overrides: Record<string, any> = {}): any {
+  return {
+    resolvedModel: {
+      sourceProviderId: "anthropic",
+      provider: "anthropic",
+      top_provider: { context_length: 200000, max_completion_tokens: null, is_moderated: false },
+    },
+    actualModelId: "claude-sonnet-4-6",
+    preparedMessages: [{ role: "user", content: "Hello" }],
+    finalSystemPrompt: "",
+    tools: [],
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Record<string, any> = {}): any {
+  return {
+    plugin: { settings: {} },
+    prepared: makePrepared(overrides.prepared),
+    ...overrides,
+  };
+}
+
+/** Build a fake streaming Response whose body streams the given SSE text. */
+function makeStreamingResponse(
+  sse: string,
+  init: { ok?: boolean; status?: number } = {},
+): Response {
+  const encoder = new TextEncoder();
+  // Split into a couple chunks to exercise incremental decoding.
+  const mid = Math.floor(sse.length / 2);
+  const chunks = [sse.slice(0, mid), sse.slice(mid)];
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    headers: new Map(),
+    body,
+  } as unknown as Response;
+}
+
+async function collect(gen: AsyncGenerator<StreamEvent, void, unknown>): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  for await (const event of gen) {
+    events.push(event);
+  }
+  return events;
+}
+
+function pushAll(parser: AnthropicStreamParser, sse: string): StreamEvent[] {
+  const events = parser.push(sse);
+  return [...events, ...parser.flush()];
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// buildAnthropicMessagesRequestBody
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("buildAnthropicMessagesRequestBody", () => {
+  it("builds a streaming body with model, messages, and stream:true", () => {
+    const body = buildAnthropicMessagesRequestBody(makeInput());
+    expect(body.model).toBe("claude-sonnet-4-6");
+    expect(body.stream).toBe(true);
+    expect(body.messages).toEqual([{ role: "user", content: "Hello" }]);
+  });
+
+  it("includes system from finalSystemPrompt when non-empty", () => {
+    const body = buildAnthropicMessagesRequestBody(
+      makeInput({ prepared: makePrepared({ finalSystemPrompt: "You are helpful." }) }),
+    );
+    expect(body.system).toBe("You are helpful.");
+    // System must not be injected into messages.
+    expect(body.messages).toEqual([{ role: "user", content: "Hello" }]);
+  });
+
+  it("omits the system key when finalSystemPrompt is empty or whitespace", () => {
+    const empty = buildAnthropicMessagesRequestBody(
+      makeInput({ prepared: makePrepared({ finalSystemPrompt: "" }) }),
+    );
+    expect("system" in empty).toBe(false);
+
+    const whitespace = buildAnthropicMessagesRequestBody(
+      makeInput({ prepared: makePrepared({ finalSystemPrompt: "   " }) }),
+    );
+    expect("system" in whitespace).toBe(false);
+  });
+
+  it("defaults max_tokens to 8192 when no completion cap is declared", () => {
+    const body = buildAnthropicMessagesRequestBody(makeInput());
+    expect(body.max_tokens).toBe(8192);
+  });
+
+  it("uses top_provider.max_completion_tokens when it is a positive number", () => {
+    const body = buildAnthropicMessagesRequestBody(
+      makeInput({
+        prepared: makePrepared({
+          resolvedModel: {
+            top_provider: { context_length: 200000, max_completion_tokens: 64000, is_moderated: false },
+          },
+        }),
+      }),
+    );
+    expect(body.max_tokens).toBe(64000);
+  });
+
+  it("falls back to default max_tokens when the declared cap is non-positive", () => {
+    const body = buildAnthropicMessagesRequestBody(
+      makeInput({
+        prepared: makePrepared({
+          resolvedModel: {
+            top_provider: { context_length: 200000, max_completion_tokens: 0, is_moderated: false },
+          },
+        }),
+      }),
+    );
+    expect(body.max_tokens).toBe(8192);
+  });
+
+  it("translates tools and omits the tools key when none are provided", () => {
+    const withTools = buildAnthropicMessagesRequestBody(
+      makeInput({
+        prepared: makePrepared({
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "Get weather",
+                parameters: { type: "object", properties: { city: { type: "string" } } },
+              },
+            },
+          ],
+        }),
+      }),
+    );
+    expect(withTools.tools).toEqual([
+      {
+        name: "get_weather",
+        description: "Get weather",
+        input_schema: { type: "object", properties: { city: { type: "string" } } },
+      },
+    ]);
+
+    const withoutTools = buildAnthropicMessagesRequestBody(makeInput());
+    expect("tools" in withoutTools).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// toAnthropicMessages
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("toAnthropicMessages", () => {
+  it("drops system messages (system is a top-level field)", () => {
+    const result = toAnthropicMessages([
+      { role: "system", content: "be terse" } as any,
+      { role: "user", content: "hi" } as any,
+    ]);
+    expect(result).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("passes through user and assistant text turns", () => {
+    const result = toAnthropicMessages([
+      { role: "user", content: "What is 2+2?" } as any,
+      { role: "assistant", content: "4" } as any,
+    ]);
+    expect(result).toEqual([
+      { role: "user", content: "What is 2+2?" },
+      { role: "assistant", content: "4" },
+    ]);
+  });
+
+  it("converts assistant tool_calls into tool_use blocks with parsed input", () => {
+    const result = toAnthropicMessages([
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "toolu_01",
+            request: {
+              id: "toolu_01",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"city":"Paris"}' },
+            },
+          },
+        ],
+      } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_01", name: "get_weather", input: { city: "Paris" } }],
+      },
+    ]);
+  });
+
+  it("includes a leading text block when an assistant has both text and tool_calls", () => {
+    const result = toAnthropicMessages([
+      {
+        role: "assistant",
+        content: "Let me check.",
+        tool_calls: [
+          {
+            id: "toolu_02",
+            function: { name: "lookup", arguments: '{"q":"x"}' },
+          },
+        ],
+      } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          { type: "tool_use", id: "toolu_02", name: "lookup", input: { q: "x" } },
+        ],
+      },
+    ]);
+  });
+
+  it("converts a tool message into a user tool_result block keyed by tool_use_id", () => {
+    const result = toAnthropicMessages([
+      {
+        role: "tool",
+        tool_call_id: "toolu_01",
+        name: "get_weather",
+        content: '{"temp":20}',
+      } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_01", content: '{"temp":20}' }],
+      },
+    ]);
+  });
+
+  it("merges adjacent tool results into a single user turn", () => {
+    const result = toAnthropicMessages([
+      { role: "tool", tool_call_id: "toolu_a", content: "result-a" } as any,
+      { role: "tool", tool_call_id: "toolu_b", content: "result-b" } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_a", content: "result-a" },
+          { type: "tool_result", tool_use_id: "toolu_b", content: "result-b" },
+        ],
+      },
+    ]);
+  });
+
+  it("does not merge a tool result into a preceding non-tool-result user turn", () => {
+    const result = toAnthropicMessages([
+      { role: "user", content: "hello" } as any,
+      { role: "tool", tool_call_id: "toolu_a", content: "result-a" } as any,
+    ]);
+    expect(result).toEqual([
+      { role: "user", content: "hello" },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_a", content: "result-a" }],
+      },
+    ]);
+  });
+
+  it("maps a multimodal user image part into an Anthropic base64 image block", () => {
+    const result = toAnthropicMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+        ],
+      } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: "AAAA" },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("skips remote (non-base64) image URLs that the base64 source cannot carry", () => {
+    const result = toAnthropicMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look" },
+          { type: "image_url", image_url: { url: "https://example.com/cat.png" } },
+        ],
+      } as any,
+    ]);
+    expect(result).toEqual([{ role: "user", content: [{ type: "text", text: "look" }] }]);
+  });
+
+  it("never emits empty content for a turn (falls back to a single space)", () => {
+    const result = toAnthropicMessages([
+      { role: "user", content: "" } as any,
+      { role: "assistant", content: "" } as any,
+    ]);
+    expect(result).toEqual([
+      { role: "user", content: " " },
+      { role: "assistant", content: " " },
+    ]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// toAnthropicTools
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("toAnthropicTools", () => {
+  it("maps OpenAI function tools to Anthropic input_schema tools", () => {
+    const result = toAnthropicTools([
+      {
+        type: "function",
+        function: {
+          name: "search",
+          description: "Search the web",
+          parameters: { type: "object", properties: { q: { type: "string" } }, required: ["q"] },
+        },
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        name: "search",
+        description: "Search the web",
+        input_schema: { type: "object", properties: { q: { type: "string" } }, required: ["q"] },
+      },
+    ]);
+  });
+
+  it("handles tools already in the flattened {name, description, parameters} shape", () => {
+    const result = toAnthropicTools([
+      {
+        name: "calc",
+        description: "Do math",
+        parameters: { type: "object", properties: { expr: { type: "string" } } },
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        name: "calc",
+        description: "Do math",
+        input_schema: { type: "object", properties: { expr: { type: "string" } } },
+      },
+    ]);
+  });
+
+  it("defaults input_schema to an empty object schema when parameters are missing", () => {
+    const result = toAnthropicTools([{ type: "function", function: { name: "noargs" } }]);
+    expect(result).toEqual([
+      { name: "noargs", input_schema: { type: "object", properties: {} } },
+    ]);
+  });
+
+  it("skips entries without a usable name", () => {
+    const result = toAnthropicTools([
+      { type: "function", function: { description: "no name" } },
+      null,
+      "nonsense",
+    ] as any);
+    expect(result).toEqual([]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// AnthropicStreamParser
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("AnthropicStreamParser", () => {
+  it("parses a text transcript into content events and a stop-reason meta", () => {
+    const sse = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_1","role":"assistant"}}',
+      '',
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":", world"}}',
+      '',
+      'event: content_block_stop',
+      'data: {"type":"content_block_stop","index":0}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}',
+      '',
+      'event: message_stop',
+      'data: {"type":"message_stop"}',
+      '',
+    ].join("\n");
+
+    const parser = new AnthropicStreamParser();
+    const events = pushAll(parser, sse);
+
+    expect(events).toEqual([
+      { type: "content", text: "Hello" },
+      { type: "content", text: ", world" },
+      { type: "meta", key: "stop-reason", value: "stop" },
+    ]);
+  });
+
+  it("emits reasoning events for thinking deltas", () => {
+    const sse = [
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm "}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"let me think"}}',
+      '',
+    ].join("\n");
+
+    const parser = new AnthropicStreamParser();
+    expect(pushAll(parser, sse)).toEqual([
+      { type: "reasoning", text: "hmm " },
+      { type: "reasoning", text: "let me think" },
+    ]);
+  });
+
+  it("assembles a tool_use transcript into a final tool-call with concatenated JSON args", () => {
+    const sse = [
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_99","name":"get_weather","input":{}}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"city\\":"}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"Paris\\"}"}}',
+      '',
+      'event: content_block_stop',
+      'data: {"type":"content_block_stop","index":0}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}',
+      '',
+    ].join("\n");
+
+    const parser = new AnthropicStreamParser();
+    const events = pushAll(parser, sse);
+
+    // First a delta with empty args at block start, then accumulating deltas,
+    // and finally the assembled tool call.
+    expect(events[0]).toEqual({
+      type: "tool-call",
+      phase: "delta",
+      call: { id: "toolu_99", type: "function", function: { name: "get_weather", arguments: "" } },
+    });
+
+    const finalEvent = events.find((e) => e.type === "tool-call" && e.phase === "final");
+    expect(finalEvent).toEqual({
+      type: "tool-call",
+      phase: "final",
+      call: {
+        id: "toolu_99",
+        type: "function",
+        function: { name: "get_weather", arguments: '{"city":"Paris"}' },
+      },
+    });
+
+    expect(events[events.length - 1]).toEqual({
+      type: "meta",
+      key: "stop-reason",
+      value: "toolUse",
+    });
+  });
+
+  it("maps max_tokens stop reason to length", () => {
+    const sse =
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"max_tokens"}}\n\n';
+    const parser = new AnthropicStreamParser();
+    expect(pushAll(parser, sse)).toEqual([
+      { type: "meta", key: "stop-reason", value: "length" },
+    ]);
+  });
+
+  it("maps stop_sequence stop reason to stop", () => {
+    const sse =
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"stop_sequence"}}\n\n';
+    const parser = new AnthropicStreamParser();
+    expect(pushAll(parser, sse)).toEqual([
+      { type: "meta", key: "stop-reason", value: "stop" },
+    ]);
+  });
+
+  it("ignores ping events and produces no output for them", () => {
+    const sse = 'event: ping\ndata: {"type":"ping"}\n\n';
+    const parser = new AnthropicStreamParser();
+    expect(pushAll(parser, sse)).toEqual([]);
+  });
+
+  it("buffers an SSE event split across two push calls", () => {
+    const parser = new AnthropicStreamParser();
+    // Cut the data line in half mid-JSON, and even mid-event-name.
+    const first = 'event: content_block_de';
+    const second =
+      'lta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"chunked"}}\n\n';
+
+    const firstEvents = parser.push(first);
+    expect(firstEvents).toEqual([]);
+
+    const secondEvents = parser.push(second);
+    expect(secondEvents).toEqual([{ type: "content", text: "chunked" }]);
+  });
+
+  it("buffers when a chunk cuts the JSON payload in half", () => {
+    const parser = new AnthropicStreamParser();
+    const part1 =
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_';
+    const part2 = 'delta","text":"split"}}\n\n';
+
+    expect(parser.push(part1)).toEqual([]);
+    expect(parser.push(part2)).toEqual([{ type: "content", text: "split" }]);
+  });
+
+  it("throws a SystemSculptError carrying the message on an error event", () => {
+    const sse =
+      'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n';
+    const parser = new AnthropicStreamParser();
+    expect(() => parser.push(sse)).toThrow("Overloaded");
+  });
+
+  it("handles \\r\\n line endings", () => {
+    const sse =
+      'event: content_block_delta\r\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"crlf"}}\r\n\r\n';
+    const parser = new AnthropicStreamParser();
+    expect(pushAll(parser, sse)).toEqual([{ type: "content", text: "crlf" }]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// executeAnthropicRemoteStream
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("executeAnthropicRemoteStream", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveEndpoint.mockReturnValue("https://api.anthropic.com/v1");
+    mockResolveApiKey.mockResolvedValue("sk-ant-test-key");
+  });
+
+  it("throws when no endpoint is configured", async () => {
+    mockResolveEndpoint.mockReturnValue("");
+    const gen = executeAnthropicRemoteStream(makeInput());
+    await expect(gen.next()).rejects.toThrow(
+      /No remote endpoint configured for provider "anthropic"/,
+    );
+  });
+
+  it("throws the connect message when no API key is available", async () => {
+    mockResolveApiKey.mockResolvedValue("");
+    const gen = executeAnthropicRemoteStream(makeInput());
+    await expect(gen.next()).rejects.toThrow(
+      /Connect anthropic in Providers before using this model/,
+    );
+  });
+
+  it("POSTs to the /messages endpoint with Anthropic headers and yields events", async () => {
+    const sse = [
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+      '',
+    ].join("\n");
+
+    mockRequest.mockResolvedValue(makeStreamingResponse(sse));
+
+    const events = await collect(executeAnthropicRemoteStream(makeInput()));
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    const callArgs = mockRequest.mock.calls[0][0];
+    expect(callArgs.url).toBe("https://api.anthropic.com/v1/messages");
+    expect(callArgs.method).toBe("POST");
+    expect(callArgs.stream).toBe(true);
+    expect(callArgs.headers["x-api-key"]).toBe("sk-ant-test-key");
+    expect(callArgs.headers["anthropic-version"]).toBe(ANTHROPIC_API_VERSION);
+    expect(callArgs.headers["content-type"]).toBe("application/json");
+    expect(callArgs.headers.Authorization).toBeUndefined();
+    expect(callArgs.body.model).toBe("claude-sonnet-4-6");
+    expect(callArgs.body.stream).toBe(true);
+
+    expect(events).toEqual([
+      { type: "content", text: "hi" },
+      { type: "meta", key: "stop-reason", value: "stop" },
+    ]);
+  });
+
+  it("trims a trailing slash on the endpoint before appending /messages", async () => {
+    mockResolveEndpoint.mockReturnValue("https://proxy.example.com/v1/");
+    mockRequest.mockResolvedValue(makeStreamingResponse('event: ping\ndata: {"type":"ping"}\n\n'));
+
+    await collect(executeAnthropicRemoteStream(makeInput()));
+
+    expect(mockRequest.mock.calls[0][0].url).toBe("https://proxy.example.com/v1/messages");
+  });
+
+  it("redacts the api key in the debug onRequest headers", async () => {
+    const debug = { onRequest: jest.fn() };
+    mockRequest.mockResolvedValue(makeStreamingResponse('event: ping\ndata: {"type":"ping"}\n\n'));
+
+    await collect(executeAnthropicRemoteStream(makeInput({ debug })));
+
+    const debugCall = debug.onRequest.mock.calls[0][0];
+    expect(debugCall.headers["x-api-key"]).toBe("[redacted]");
+    expect(debugCall.headers["anthropic-version"]).toBe(ANTHROPIC_API_VERSION);
+  });
+
+  it("fires debug callbacks in order", async () => {
+    const callOrder: string[] = [];
+    const debug = {
+      onRequest: jest.fn(() => callOrder.push("request")),
+      onResponse: jest.fn(() => callOrder.push("response")),
+      onStreamEvent: jest.fn(() => callOrder.push("streamEvent")),
+      onStreamEnd: jest.fn(() => callOrder.push("streamEnd")),
+    };
+    const sse =
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}\n\n';
+    mockRequest.mockResolvedValue(makeStreamingResponse(sse));
+
+    await collect(executeAnthropicRemoteStream(makeInput({ debug })));
+
+    expect(callOrder).toEqual(["request", "response", "streamEvent", "streamEnd"]);
+    expect(debug.onStreamEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ completed: true, aborted: false }),
+    );
+  });
+
+  it("delegates to StreamingErrorHandler when the response is not ok", async () => {
+    mockRequest.mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Map(),
+      text: async () => JSON.stringify({ error: { message: "bad key" } }),
+    });
+
+    const gen = executeAnthropicRemoteStream(makeInput());
+    await expect(collect(gen)).rejects.toThrow("stream-error-handled");
+
+    const { StreamingErrorHandler } = require("../../StreamingErrorHandler");
+    expect(StreamingErrorHandler.handleStreamError).toHaveBeenCalledTimes(1);
+    const [, isCustomProvider, context] = StreamingErrorHandler.handleStreamError.mock.calls[0];
+    expect(isCustomProvider).toBe(true);
+    expect(context).toEqual({
+      provider: "anthropic",
+      endpoint: "https://api.anthropic.com/v1",
+      model: "claude-sonnet-4-6",
+    });
+  });
+
+  it("streams an assistant tool call end-to-end", async () => {
+    const sse = [
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_7","name":"lookup","input":{}}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"q\\":\\"hi\\"}"}}',
+      '',
+      'event: content_block_stop',
+      'data: {"type":"content_block_stop","index":0}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}',
+      '',
+    ].join("\n");
+
+    mockRequest.mockResolvedValue(makeStreamingResponse(sse));
+
+    const events = await collect(executeAnthropicRemoteStream(makeInput()));
+    const finalCall = events.find((e) => e.type === "tool-call" && e.phase === "final");
+    expect(finalCall).toEqual({
+      type: "tool-call",
+      phase: "final",
+      call: { id: "toolu_7", type: "function", function: { name: "lookup", arguments: '{"q":"hi"}' } },
+    });
+    expect(events[events.length - 1]).toEqual({
+      type: "meta",
+      key: "stop-reason",
+      value: "toolUse",
+    });
+  });
+
+  it("stops yielding and reports aborted when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const debug = { onStreamEnd: jest.fn() };
+    mockRequest.mockResolvedValue(
+      makeStreamingResponse(
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"nope"}}\n\n',
+      ),
+    );
+
+    const events = await collect(
+      executeAnthropicRemoteStream(makeInput({ signal: controller.signal, debug })),
+    );
+
+    expect(events).toEqual([]);
+    expect(debug.onStreamEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ completed: false, aborted: true }),
+    );
+  });
+});

--- a/src/services/providerRuntime/__tests__/AnthropicRemoteStreamExecutor.test.ts
+++ b/src/services/providerRuntime/__tests__/AnthropicRemoteStreamExecutor.test.ts
@@ -192,6 +192,38 @@ describe("buildAnthropicMessagesRequestBody", () => {
     const withoutTools = buildAnthropicMessagesRequestBody(makeInput());
     expect("tools" in withoutTools).toBe(false);
   });
+
+  it("omits extended thinking when no reasoning effort is requested (#230)", () => {
+    const body = buildAnthropicMessagesRequestBody(makeInput());
+    expect("thinking" in body).toBe(false);
+    expect(body.max_tokens).toBe(8192);
+  });
+
+  it("omits extended thinking when reasoning effort is 'off' (#230)", () => {
+    const body = buildAnthropicMessagesRequestBody(makeInput({ reasoningEffort: "off" }));
+    expect("thinking" in body).toBe(false);
+  });
+
+  it("enables extended thinking for a requested reasoning effort (#230)", () => {
+    // Codex P2: a reasoning-capable Claude must actually reason. medium fits
+    // under the default 8192 cap, so max_tokens is left untouched.
+    const body = buildAnthropicMessagesRequestBody(makeInput({ reasoningEffort: "medium" }));
+    expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 4096 });
+    expect(body.max_tokens).toBe(8192);
+  });
+
+  it("bumps max_tokens above the thinking budget when the effort crowds the cap (#230)", () => {
+    // high → 8192 budget, which is not below the default 8192 cap, so max_tokens
+    // is raised to leave room for the visible answer (Anthropic requires
+    // max_tokens > budget_tokens).
+    const high = buildAnthropicMessagesRequestBody(makeInput({ reasoningEffort: "high" }));
+    expect(high.thinking).toEqual({ type: "enabled", budget_tokens: 8192 });
+    expect(high.max_tokens).toBe(16384);
+
+    const xhigh = buildAnthropicMessagesRequestBody(makeInput({ reasoningEffort: "xhigh" }));
+    expect(xhigh.thinking).toEqual({ type: "enabled", budget_tokens: 16384 });
+    expect(xhigh.max_tokens).toBe(24576);
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -298,6 +330,20 @@ describe("toAnthropicMessages", () => {
         ],
       },
     ]);
+  });
+
+  it("falls back to a plain user turn for a tool message missing a tool_call_id (#230)", () => {
+    // An empty tool_use_id is uncorrelatable and breaks Anthropic's turn
+    // contract; emit the content as plain user text instead (CodeRabbit).
+    const result = toAnthropicMessages([
+      { role: "tool", content: "orphan-result" } as any,
+    ]);
+    expect(result).toEqual([{ role: "user", content: "orphan-result" }]);
+  });
+
+  it("drops a tool message with neither tool_call_id nor content (#230)", () => {
+    const result = toAnthropicMessages([{ role: "tool", content: "" } as any]);
+    expect(result).toEqual([]);
   });
 
   it("does not merge a tool result into a preceding non-tool-result user turn", () => {

--- a/src/services/providerRuntime/__tests__/ProviderRuntime.test.ts
+++ b/src/services/providerRuntime/__tests__/ProviderRuntime.test.ts
@@ -132,6 +132,30 @@ describe("ProviderRuntime", () => {
       });
     });
 
+    it("resolves a remote BYOK plan for a configured Anthropic model (#230)", async () => {
+      // #230 acceptance: a configured Anthropic key yields a Chat model that
+      // resolves an executable plan (not just appears in the dropdown).
+      mockedResolveEndpoint.mockReturnValue("https://api.anthropic.com/v1");
+      const model = makeRemoteModel({
+        id: "anthropic@@claude-sonnet-4-6",
+        piExecutionModelId: "claude-sonnet-4-6",
+        sourceProviderId: "anthropic",
+        provider: "anthropic",
+      });
+
+      const plan = await resolveProviderRuntimePlan(model, {} as any);
+
+      expect(plan).toEqual({
+        mode: "remote",
+        actualModelId: "claude-sonnet-4-6",
+        providerId: "anthropic",
+        authMode: "byok",
+        endpoint: "https://api.anthropic.com/v1",
+        supportsTools: true,
+        supportsImages: true,
+      });
+    });
+
     it("falls back to Pi provider auth when plugin has no stored key", async () => {
       mockedGetApiKey.mockReturnValue("");
       mockResolveStudioPiProviderApiKey.mockResolvedValue(null);

--- a/src/services/providerRuntime/__tests__/RemoteProviderCatalog.test.ts
+++ b/src/services/providerRuntime/__tests__/RemoteProviderCatalog.test.ts
@@ -39,6 +39,12 @@ describe("RemoteProviderCatalog", () => {
       );
     });
 
+    it("returns the Anthropic base URL for the anthropic provider (#230)", () => {
+      expect(resolveRemoteProviderEndpoint("anthropic")).toBe(
+        AI_PROVIDERS.ANTHROPIC.BASE_URL
+      );
+    });
+
     it("is case-insensitive", () => {
       expect(resolveRemoteProviderEndpoint("OpenRouter")).toBe(
         AI_PROVIDERS.OPENROUTER.BASE_URL
@@ -49,7 +55,7 @@ describe("RemoteProviderCatalog", () => {
     });
 
     it("returns empty string for unknown providers", () => {
-      expect(resolveRemoteProviderEndpoint("anthropic")).toBe("");
+      expect(resolveRemoteProviderEndpoint("cohere")).toBe("");
       expect(resolveRemoteProviderEndpoint("")).toBe("");
     });
   });
@@ -287,6 +293,38 @@ describe("RemoteProviderCatalog", () => {
       expect(gpt?.supported_parameters).toContain("tools");
     });
 
+    it("returns Claude Sonnet 4.6 when Anthropic is configured (#230)", () => {
+      const plugin = makePlugin([
+        {
+          id: "anthropic",
+          name: "Anthropic",
+          endpoint: "https://api.anthropic.com/v1",
+          apiKey: "sk-ant-key",
+          isEnabled: true,
+        },
+      ]);
+
+      const models = listConfiguredRemoteProviderModels(plugin);
+      const claude = models.find((model) => model.id === "anthropic@@claude-sonnet-4-6");
+
+      expect(claude).toMatchObject({
+        id: "anthropic@@claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        provider: "anthropic",
+        sourceMode: "custom_endpoint",
+        sourceProviderId: "anthropic",
+        piRemoteAvailable: true,
+        piLocalAvailable: false,
+        piAuthMode: "byok",
+        piExecutionModelId: "claude-sonnet-4-6",
+        context_length: 200_000,
+      });
+      expect(claude?.supported_parameters).toContain("tools");
+      expect(claude?.capabilities).toEqual(
+        expect.arrayContaining(["chat", "reasoning", "vision"])
+      );
+    });
+
     it("gives every configured remote provider model a resolvable execution endpoint (#201 contract)", () => {
       // The core #201 failure mode: a model appears in the Chat dropdown but
       // has no execution endpoint, so selecting it throws "No remote endpoint
@@ -296,10 +334,11 @@ describe("RemoteProviderCatalog", () => {
         { id: "openrouter", name: "OpenRouter", endpoint: "https://openrouter.ai/api/v1", apiKey: "k", isEnabled: true },
         { id: "xai", name: "xAI", endpoint: "https://api.x.ai/v1", apiKey: "k", isEnabled: true },
         { id: "openai", name: "OpenAI", endpoint: "https://api.openai.com/v1", apiKey: "k", isEnabled: true },
+        { id: "anthropic", name: "Anthropic", endpoint: "https://api.anthropic.com/v1", apiKey: "k", isEnabled: true },
       ]);
 
       const models = listConfiguredRemoteProviderModels(plugin);
-      expect(models.length).toBeGreaterThanOrEqual(3);
+      expect(models.length).toBeGreaterThanOrEqual(4);
       for (const model of models) {
         expect(resolveRemoteProviderEndpoint(String(model.sourceProviderId))).not.toBe("");
       }

--- a/testing/integration/provider-listing.test.ts
+++ b/testing/integration/provider-listing.test.ts
@@ -25,6 +25,7 @@ type Fixtures = Awaited<ReturnType<typeof startProviderFixtures>>;
 
 const OPENROUTER_SEED_MODEL_ID = createCanonicalId("openrouter", "openai/gpt-5.4-mini");
 const OPENAI_SEED_MODEL_ID = createCanonicalId("openai", "gpt-5.4-mini");
+const ANTHROPIC_SEED_MODEL_ID = createCanonicalId("anthropic", "claude-sonnet-4-6");
 
 function buildPluginStub(customProviders: unknown[] = []) {
   return {
@@ -105,6 +106,28 @@ describe("text model catalog (#201 guard)", () => {
     const seed = models.find((model) => model.id === OPENAI_SEED_MODEL_ID);
     expect(seed?.piAuthMode).toBe("byok");
     expect(seed?.provider).toBe("openai");
+  });
+
+  it("lists the Claude seed model when a keyed Anthropic provider is configured (#230)", async () => {
+    const models = await listPiTextCatalogModels(
+      buildPluginStub([
+        {
+          id: "anthropic",
+          name: "Anthropic",
+          endpoint: "https://api.anthropic.com/v1",
+          apiKey: "fixture-key",
+          isEnabled: true,
+        },
+      ])
+    );
+
+    const ids = models.map((model) => model.id);
+    expect(ids[0]).toBe(SYSTEMSCULPT_PI_CANONICAL_MODEL_ID);
+    expect(ids).toContain(ANTHROPIC_SEED_MODEL_ID);
+
+    const seed = models.find((model) => model.id === ANTHROPIC_SEED_MODEL_ID);
+    expect(seed?.piAuthMode).toBe("byok");
+    expect(seed?.provider).toBe("anthropic");
   });
 
   it("drops the seed model when the provider has no API key", async () => {


### PR DESCRIPTION
Claude can't run through the OpenAI-compatible `/chat/completions` path — it uses the **Messages API**. A catalog seed alone would make Claude *appear* in the dropdown but throw on use, so this adds the full native execution path.

- New `AnthropicRemoteStreamExecutor`: `/v1/messages` request builder (top-level `system`, required `max_tokens`, message + tool_use/tool_result translation, data-URL images), OpenAI→Anthropic tool translation, and an incremental Anthropic-SSE→`StreamEvent` parser. Stop reasons map to the same values `StreamPipeline` emits, so the turn loop stays provider-agnostic.
- Catalog seed (`claude-sonnet-4-6`) + endpoint; `SystemSculptService` routes `anthropic` to the native executor.
- Tests: executor (request/translation/tool-translation/SSE parser), catalog appears + resolvable endpoint, runtime resolves an executable plan, built-bundle listing guard.

Known v1 gaps (not in #230's acceptance): remote (non-data-URL) image inputs are skipped, and extended-thinking *request* params aren't sent yet (thinking deltas are parsed if returned).

Closes #230. Refs #201, #206.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Anthropic/Claude remote streaming support for custom endpoints, including streaming text, reasoning deltas, tool-call streaming, and image inputs.
  * Expanded the remote provider catalog with an Anthropic seed model and Anthropic endpoint resolution.

* **Bug Fixes**
  * Fixed custom-endpoint streaming routing to use the Anthropic streaming implementation when the resolved provider is Anthropic.

* **Tests**
  * Added/expanded Jest and integration coverage for Anthropic request/response translation, SSE parsing, abort/error handling, and provider listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->