### PR TITLE
fix(windows-e2e): retry transient live-provider stream errors in clean-install parity

### DIFF
--- a/testing/native/device/windows/clean-install-parity.mjs
+++ b/testing/native/device/windows/clean-install-parity.mjs
@@ -142,6 +142,7 @@ export function isTransientError(error) {
   const message = String(error?.message || error || "").toLowerCase();
   return (
     /\b429\b/.test(message) ||
+    /\b50[234]\b/.test(message) ||
     [
       "http 429",
       "status 429",
@@ -152,6 +153,20 @@ export function isTransientError(error) {
       "retry shortly",
       "retry after",
       "upstream error",
+      // Live-provider stream/network hiccups (recurring windows-e2e flake, PRs
+      // #239/#240): the plugin surfaces a transient upstream stream failure as a
+      // generic "Error in streaming response. Please try again." The chat-send
+      // retry (retryTransient) must treat that — and the usual gateway/socket
+      // transients — as retryable so a single provider blip does not fail the
+      // lane. Genuine regressions carry distinct messages and still fail fast.
+      "error in streaming response",
+      "bad gateway",
+      "service unavailable",
+      "gateway timeout",
+      "socket hang up",
+      "econnreset",
+      "etimedout",
+      "fetch failed",
     ].some((needle) => message.includes(needle))
   );
 }

--- a/testing/native/device/windows/clean-install-parity.test.mjs
+++ b/testing/native/device/windows/clean-install-parity.test.mjs
@@ -149,3 +149,24 @@ test("isTransientError matches 429 and retryable upstream conditions", () => {
   assert.equal(isTransientError(new Error("retry after 10 seconds")), true);
   assert.equal(isTransientError(new Error("providers tab not found")), false);
 });
+
+test("isTransientError treats live-provider stream + gateway hiccups as transient (windows-e2e flake guard)", () => {
+  // Recurring windows-e2e flake (PRs #239, #240): the plugin wraps a transient
+  // upstream stream failure as this generic message. The chat-send retry must
+  // recognize it (and the usual gateway/socket transients) so one live-provider
+  // blip does not fail the lane. Without this, retryTransient threw on the first
+  // failure and the job died at the chat round-trip.
+  assert.equal(isTransientError(new Error("Error in streaming response. Please try again.")), true);
+  assert.equal(isTransientError(new Error("upstream connect error: 503 Service Unavailable")), true);
+  assert.equal(isTransientError(new Error("502 Bad Gateway")), true);
+  assert.equal(isTransientError(new Error("504 Gateway Timeout")), true);
+  assert.equal(isTransientError(new Error("socket hang up")), true);
+  assert.equal(isTransientError(new Error("read ECONNRESET")), true);
+  assert.equal(isTransientError(new Error("connect ETIMEDOUT 1.2.3.4:443")), true);
+  assert.equal(isTransientError(new Error("fetch failed")), true);
+
+  // Genuine regressions must still fail fast — never retried away.
+  assert.equal(isTransientError(new Error("Model grok-4.3 did not echo the expected token")), false);
+  assert.equal(isTransientError(new Error("Invalid API key")), false);
+  assert.equal(isTransientError(new Error("Managed SystemSculpt model was not present")), false);
+});


### PR DESCRIPTION
- The Windows clean-install parity lane does a live chat round-trip (xAI/grok). `retryTransient` already wraps the send, but `isTransientError` didn't classify the plugin's generic `Error in streaming response. Please try again.` as retryable — so a single upstream blip failed the lane (recurring on #239, #240).
- Teach `isTransientError` that signature plus the usual gateway/socket transients (502/503/504, bad gateway, service unavailable, gateway timeout, socket hang up, ECONNRESET, ETIMEDOUT, fetch failed); genuine regressions (token mismatch, auth, missing model) still fail fast.
- Adds a deterministic unit guard (runs in the CI lane via `check:plugin:fast`, no live provider needed).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM