### PR TITLE
feat(providers): Gemini (Google) BYOK via native generateContent API (#231)

### DIFF
--- a/src/constants/externalServices.ts
+++ b/src/constants/externalServices.ts
@@ -52,6 +52,12 @@ export const AI_PROVIDERS = {
   GROQ: {
     BASE_URL: getExternalUrl("https://api.groq.com/openai/v1"),
     AUDIO_TRANSCRIPTIONS: getExternalUrl("https://api.groq.com/openai/v1/audio/transcriptions")
+  },
+  GOOGLE: {
+    // Gemini native API. The base ends at the API version; the executor builds
+    // the per-call path `${BASE_URL}/models/{model}:streamGenerateContent?alt=sse`
+    // (model + action live in the path, not a /chat/completions suffix).
+    BASE_URL: getExternalUrl("https://generativelanguage.googleapis.com/v1beta")
   }
 } as const;
 

--- a/src/constants/gemini.ts
+++ b/src/constants/gemini.ts
@@ -1,0 +1,33 @@
+// Google Gemini (generativelanguage.googleapis.com) native API constants.
+//
+// Unlike the OpenAI-compatible providers, Gemini puts the model id and the
+// action in the URL path and authenticates with a dedicated header. The base
+// URL (AI_PROVIDERS.GOOGLE.BASE_URL) ends at the API version; per-call the
+// executor builds `${base}/models/{model}:${ACTION}?${QUERY}`.
+
+export const GEMINI_API_VERSION = "v1beta";
+
+// Auth is a dedicated header, NOT `Authorization: Bearer` or `x-api-key`.
+export const GEMINI_API_KEY_HEADER = "x-goog-api-key";
+
+// Streaming generation action + SSE query. `alt=sse` makes the API emit
+// `data: <GenerateContentResponse JSON>` frames instead of a streamed JSON
+// array, which is what GeminiStreamParser consumes.
+export const GEMINI_STREAM_ACTION = "streamGenerateContent";
+export const GEMINI_STREAM_QUERY = "alt=sse";
+
+// Gemini candidate finishReason values we map onto the provider-agnostic
+// stop-reason vocabulary (see StreamPipeline.mapFinishReasonToPiStopReason).
+export const GEMINI_FINISH_REASONS = {
+  STOP: "STOP",
+  MAX_TOKENS: "MAX_TOKENS",
+  SAFETY: "SAFETY",
+  RECITATION: "RECITATION",
+  OTHER: "OTHER",
+} as const;
+
+// Detects whether a configured endpoint targets the Gemini native API.
+export function isGeminiEndpoint(endpoint: string): boolean {
+  const lower = String(endpoint || "").toLowerCase();
+  return lower.includes("generativelanguage.googleapis.com") || lower.includes("ai.google.dev");
+}

--- a/src/services/SystemSculptService.ts
+++ b/src/services/SystemSculptService.ts
@@ -42,6 +42,7 @@ export type { StreamDebugCallbacks } from "./StreamExecutionTypes";
 let localPiStreamExecutorModulePromise: Promise<typeof import("./LocalPiStreamExecutor")> | null = null;
 let remoteProviderStreamExecutorModulePromise: Promise<typeof import("./providerRuntime/OpenRouterRemoteStreamExecutor")> | null = null;
 let anthropicRemoteStreamExecutorModulePromise: Promise<typeof import("./providerRuntime/AnthropicRemoteStreamExecutor")> | null = null;
+let geminiRemoteStreamExecutorModulePromise: Promise<typeof import("./providerRuntime/GeminiRemoteStreamExecutor")> | null = null;
 
 async function loadLocalPiStreamExecutorModule(): Promise<typeof import("./LocalPiStreamExecutor")> {
   if (!localPiStreamExecutorModulePromise) {
@@ -62,6 +63,13 @@ async function loadAnthropicRemoteStreamExecutorModule(): Promise<typeof import(
     anthropicRemoteStreamExecutorModulePromise = import("./providerRuntime/AnthropicRemoteStreamExecutor");
   }
   return await anthropicRemoteStreamExecutorModulePromise;
+}
+
+async function loadGeminiRemoteStreamExecutorModule(): Promise<typeof import("./providerRuntime/GeminiRemoteStreamExecutor")> {
+  if (!geminiRemoteStreamExecutorModulePromise) {
+    geminiRemoteStreamExecutorModulePromise = import("./providerRuntime/GeminiRemoteStreamExecutor");
+  }
+  return await geminiRemoteStreamExecutorModulePromise;
 }
 
 export type CreditsBalanceSnapshot = {
@@ -1239,6 +1247,23 @@ export class SystemSculptService {
           }
           return;
         }
+
+        // Gemini uses the native generateContent streaming API, not the
+        // OpenAI-compatible /chat/completions executor (#231).
+        if (remoteProviderId === "google") {
+          const { executeGeminiRemoteStream } = await loadGeminiRemoteStreamExecutorModule();
+          for await (const event of executeGeminiRemoteStream({
+            plugin: this.plugin,
+            prepared,
+            signal,
+            reasoningEffort,
+            debug,
+          })) {
+            yield event;
+          }
+          return;
+        }
+
 
         const { executeOpenRouterRemoteStream } = await loadRemoteProviderStreamExecutorModule();
         for await (const event of executeOpenRouterRemoteStream({

--- a/src/services/providerRuntime/GeminiRemoteStreamExecutor.ts
+++ b/src/services/providerRuntime/GeminiRemoteStreamExecutor.ts
@@ -34,6 +34,10 @@ type GeminiInlineDataPart = {
 };
 type GeminiFunctionCallPart = {
   functionCall: { name: string; args: Record<string, unknown> };
+  // Gemini 3 validates a thoughtSignature on every functionCall part when
+  // thinking is active (on by default for Gemini 3). Replayed calls we did not
+  // originate a signature for carry GEMINI_THOUGHT_SIGNATURE_SENTINEL instead.
+  thoughtSignature?: string;
 };
 type GeminiFunctionResponsePart = {
   functionResponse: { name: string; response: Record<string, unknown> };
@@ -193,8 +197,23 @@ function buildToolResponsePayload(content: ChatMessage["content"]): Record<strin
  * collapse into `functionResponse` parts on a role `"user"` turn — adjacent tool
  * results merge into one turn, mirroring the Anthropic executor.
  */
-export function toGeminiContents(messages: ChatMessage[]): GeminiContent[] {
+// Gemini 3 requires a thoughtSignature on every functionCall part when thinking
+// is enabled (Gemini 3 thinks by default). For calls we replay without an
+// originating signature, Google's own SDK uses this documented sentinel to skip
+// validation; without it, the next turn of a multi-turn tool loop is rejected.
+// Older Gemini models reject an unexpected thoughtSignature, so it is gated on v3.
+const GEMINI_THOUGHT_SIGNATURE_SENTINEL = "skip_thought_signature_validator";
+
+function modelRequiresThoughtSignature(modelId: string): boolean {
+  return String(modelId || "").trim().toLowerCase().includes("gemini-3");
+}
+
+export function toGeminiContents(
+  messages: ChatMessage[],
+  modelId = "",
+): GeminiContent[] {
   const result: GeminiContent[] = [];
+  const wantsThoughtSignature = modelRequiresThoughtSignature(modelId);
 
   for (const message of messages || []) {
     if (!message || message.role === "system") continue;
@@ -234,7 +253,13 @@ export function toGeminiContents(messages: ChatMessage[]): GeminiContent[] {
         for (const toolCall of message.tool_calls) {
           const fnCall = extractFunctionCallPart(toolCall);
           if (fnCall) {
-            parts.push({ functionCall: { name: fnCall.name, args: fnCall.args } });
+            const functionCallPart: GeminiFunctionCallPart = {
+              functionCall: { name: fnCall.name, args: fnCall.args },
+            };
+            if (wantsThoughtSignature) {
+              functionCallPart.thoughtSignature = GEMINI_THOUGHT_SIGNATURE_SENTINEL;
+            }
+            parts.push(functionCallPart);
           }
         }
       }
@@ -325,7 +350,10 @@ export function buildGeminiRequestBody(
   input: RemoteGeminiStreamInput,
 ): Record<string, unknown> {
   const body: Record<string, unknown> = {
-    contents: toGeminiContents(input.prepared.preparedMessages),
+    contents: toGeminiContents(
+      input.prepared.preparedMessages,
+      input.prepared.actualModelId,
+    ),
   };
 
   const system = input.prepared.finalSystemPrompt;
@@ -516,7 +544,9 @@ export class GeminiStreamParser {
           const name =
             typeof part.functionCall.name === "string" ? part.functionCall.name : "";
           const args =
-            part.functionCall.args && typeof part.functionCall.args === "object"
+            part.functionCall.args &&
+            typeof part.functionCall.args === "object" &&
+            !Array.isArray(part.functionCall.args)
               ? part.functionCall.args
               : {};
           // Gemini sends the complete call in one part and provides no id, so we

--- a/src/services/providerRuntime/GeminiRemoteStreamExecutor.ts
+++ b/src/services/providerRuntime/GeminiRemoteStreamExecutor.ts
@@ -296,6 +296,31 @@ export function toGeminiTools(tools: unknown[]): GeminiFunctionDeclaration[] {
   return result;
 }
 
+// Map the requested reasoning effort onto a Gemini thinking-token budget.
+// `"off"` explicitly disables Gemini's default-on thinking (budget 0); unset or
+// an unrecognized value returns null so thinkingConfig is omitted and the model
+// uses its dynamic default. The effort vocabulary mirrors
+// SystemSculptService.normalizeReasoningEffort
+// ("off"|"minimal"|"low"|"medium"|"high"|"xhigh").
+function resolveGeminiThinkingBudget(reasoningEffort?: string): number | null {
+  switch (String(reasoningEffort || "").trim().toLowerCase()) {
+    case "off":
+      return 0;
+    case "minimal":
+      return 1024;
+    case "low":
+      return 2048;
+    case "medium":
+      return 4096;
+    case "high":
+      return 8192;
+    case "xhigh":
+      return 16384;
+    default:
+      return null;
+  }
+}
+
 export function buildGeminiRequestBody(
   input: RemoteGeminiStreamInput,
 ): Record<string, unknown> {
@@ -315,12 +340,26 @@ export function buildGeminiRequestBody(
     }
   }
 
-  // Gemini does not require maxOutputTokens (unlike Anthropic). Only set it when
-  // the model metadata declares a positive completion cap; otherwise omit
-  // generationConfig entirely rather than inventing a default.
+  // generationConfig carries maxOutputTokens (only when a positive cap is
+  // declared — Gemini does not require it) plus thinkingConfig mapped from the
+  // requested reasoning effort. A reasoning-capable Gemini should actually
+  // reason when the user asks (the catalog advertises it and streamMessage
+  // forwards reasoningEffort); includeThoughts surfaces thought summaries, which
+  // the parser turns into reasoning events. Mirrors the Anthropic executor.
+  const generationConfig: Record<string, unknown> = {};
   const cap = input.prepared.resolvedModel?.top_provider?.max_completion_tokens;
   if (typeof cap === "number" && Number.isFinite(cap) && cap > 0) {
-    body.generationConfig = { maxOutputTokens: Math.floor(cap) };
+    generationConfig.maxOutputTokens = Math.floor(cap);
+  }
+  const thinkingBudget = resolveGeminiThinkingBudget(input.reasoningEffort);
+  if (thinkingBudget !== null) {
+    generationConfig.thinkingConfig =
+      thinkingBudget > 0
+        ? { thinkingBudget, includeThoughts: true }
+        : { thinkingBudget: 0 };
+  }
+  if (Object.keys(generationConfig).length > 0) {
+    body.generationConfig = generationConfig;
   }
 
   return body;

--- a/src/services/providerRuntime/GeminiRemoteStreamExecutor.ts
+++ b/src/services/providerRuntime/GeminiRemoteStreamExecutor.ts
@@ -1,0 +1,709 @@
+import type SystemSculptPlugin from "../../main";
+import type { PreparedChatRequest, StreamDebugCallbacks } from "../StreamExecutionTypes";
+import type { StreamEvent, StreamToolCall } from "../../streaming/types";
+import type { ChatMessage, MultiPartContent } from "../../types";
+import type { OpenAITool } from "../../utils/tooling";
+import { PlatformRequestClient } from "../PlatformRequestClient";
+import { StreamingErrorHandler } from "../StreamingErrorHandler";
+import { resolveStudioPiProviderApiKey } from "../../studio/piAuth/StudioPiAuthStorage";
+import { resolveConfiguredRemoteProviderEndpoint } from "./RemoteProviderCatalog";
+import {
+  GEMINI_API_KEY_HEADER,
+  GEMINI_STREAM_ACTION,
+  GEMINI_STREAM_QUERY,
+} from "../../constants/gemini";
+import { ERROR_CODES, SystemSculptError } from "../../utils/errors";
+
+type RemoteGeminiStreamInput = {
+  plugin: SystemSculptPlugin;
+  prepared: PreparedChatRequest;
+  signal?: AbortSignal;
+  reasoningEffort?: string;
+  debug?: StreamDebugCallbacks;
+};
+
+const GEMINI_PROVIDER_ID = "google";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Gemini request-body construction
+// ────────────────────────────────────────────────────────────────────────────
+
+type GeminiTextPart = { text: string };
+type GeminiInlineDataPart = {
+  inlineData: { mimeType: string; data: string };
+};
+type GeminiFunctionCallPart = {
+  functionCall: { name: string; args: Record<string, unknown> };
+};
+type GeminiFunctionResponsePart = {
+  functionResponse: { name: string; response: Record<string, unknown> };
+};
+type GeminiPart =
+  | GeminiTextPart
+  | GeminiInlineDataPart
+  | GeminiFunctionCallPart
+  | GeminiFunctionResponsePart;
+
+export type GeminiContent = {
+  role: "user" | "model";
+  parts: GeminiPart[];
+};
+
+export type GeminiFunctionDeclaration = {
+  name: string;
+  description?: string;
+  parameters: Record<string, unknown>;
+};
+
+/**
+ * Parse a data URL (or bare base64 payload) into the Gemini inlineData
+ * `mimeType`/`data` pair. Returns null when the value is not a usable base64
+ * image (e.g. a remote https URL, which inlineData cannot carry). Mirrors the
+ * Anthropic executor's `parseImageSource` decision so behaviour stays aligned.
+ */
+function parseImageSource(
+  url: string,
+): { mimeType: string; data: string } | null {
+  if (typeof url !== "string" || url.length === 0) return null;
+
+  const dataUrlMatch = url.match(/^data:([^;,]+)?(?:;base64)?,(.*)$/s);
+  if (dataUrlMatch) {
+    const mimeType = (dataUrlMatch[1] || "image/png").trim();
+    const data = dataUrlMatch[2] || "";
+    if (data.length === 0) return null;
+    return { mimeType, data };
+  }
+
+  // Gemini's inlineData cannot fetch remote URLs; skip those.
+  return null;
+}
+
+function toGeminiParts(parts: MultiPartContent[]): GeminiPart[] {
+  const result: GeminiPart[] = [];
+  for (const part of parts) {
+    if (part && part.type === "text" && typeof part.text === "string") {
+      // Gemini rejects empty text parts; substitute a single space.
+      result.push({ text: part.text.length > 0 ? part.text : " " });
+      continue;
+    }
+    if (
+      part &&
+      part.type === "image_url" &&
+      part.image_url &&
+      typeof part.image_url.url === "string"
+    ) {
+      const source = parseImageSource(part.image_url.url);
+      if (source) {
+        result.push({
+          inlineData: { mimeType: source.mimeType, data: source.data },
+        });
+      }
+    }
+  }
+  return result;
+}
+
+function extractFunctionCallPart(
+  toolCall: unknown,
+): { name: string; args: Record<string, unknown> } | null {
+  if (!toolCall || typeof toolCall !== "object") return null;
+  const tc = toolCall as Record<string, any>;
+  const req: Record<string, any> = (tc.request || tc) ?? {};
+  const fn: Record<string, any> =
+    req.function || tc.function || (req.name ? { name: req.name, arguments: req.arguments } : {});
+  const name = typeof fn?.name === "string" ? fn.name.trim() : "";
+  if (!name) return null;
+
+  let args: Record<string, unknown> = {};
+  const rawArgs = fn?.arguments;
+  if (rawArgs && typeof rawArgs === "object") {
+    args = rawArgs as Record<string, unknown>;
+  } else if (typeof rawArgs === "string" && rawArgs.trim().length > 0) {
+    try {
+      const parsed = JSON.parse(rawArgs);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        args = parsed as Record<string, unknown>;
+      }
+    } catch {
+      args = {};
+    }
+  }
+
+  return { name, args };
+}
+
+function stringifyToolResultContent(content: ChatMessage["content"]): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        part && part.type === "text" && typeof part.text === "string" ? part.text : "",
+      )
+      .filter((text) => text.length > 0)
+      .join("\n");
+  }
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+/**
+ * Resolve the function name a `role: "tool"` message responds to. Gemini
+ * correlates a functionResponse to its call by name (it has no id), so we
+ * prefer the explicit `name`, then fall back to the tool_call_id, then a
+ * non-empty placeholder.
+ */
+function resolveToolResponseName(message: ChatMessage): string {
+  if (typeof message.name === "string" && message.name.trim().length > 0) {
+    return message.name.trim();
+  }
+  if (typeof message.tool_call_id === "string" && message.tool_call_id.trim().length > 0) {
+    return message.tool_call_id.trim();
+  }
+  return "tool";
+}
+
+/**
+ * The Gemini functionResponse `response` field must be an object. If the tool
+ * content already parses to a JSON object we pass it through; otherwise we wrap
+ * the stringified content under `{ result }`.
+ */
+function buildToolResponsePayload(content: ChatMessage["content"]): Record<string, unknown> {
+  const stringified = stringifyToolResultContent(content);
+  if (stringified.trim().length > 0) {
+    try {
+      const parsed = JSON.parse(stringified);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // not JSON; fall through to the wrapped shape
+    }
+  }
+  return { result: stringified };
+}
+
+/**
+ * Translate the repo's `ChatMessage[]` history into Gemini `contents` turns.
+ * System messages are dropped (the system prompt is a top-level
+ * `systemInstruction`), assistant turns become role `"model"`, and tool results
+ * collapse into `functionResponse` parts on a role `"user"` turn — adjacent tool
+ * results merge into one turn, mirroring the Anthropic executor.
+ */
+export function toGeminiContents(messages: ChatMessage[]): GeminiContent[] {
+  const result: GeminiContent[] = [];
+
+  for (const message of messages || []) {
+    if (!message || message.role === "system") continue;
+
+    if (message.role === "tool") {
+      const part: GeminiFunctionResponsePart = {
+        functionResponse: {
+          name: resolveToolResponseName(message),
+          response: buildToolResponsePayload(message.content),
+        },
+      };
+      const last = result[result.length - 1];
+      if (
+        last &&
+        last.role === "user" &&
+        last.parts.every((p) => "functionResponse" in p)
+      ) {
+        last.parts.push(part);
+      } else {
+        result.push({ role: "user", parts: [part] });
+      }
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      const parts: GeminiPart[] = [];
+
+      if (typeof message.content === "string") {
+        if (message.content.length > 0) {
+          parts.push({ text: message.content });
+        }
+      } else if (Array.isArray(message.content)) {
+        parts.push(...toGeminiParts(message.content));
+      }
+
+      if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+        for (const toolCall of message.tool_calls) {
+          const fnCall = extractFunctionCallPart(toolCall);
+          if (fnCall) {
+            parts.push({ functionCall: { name: fnCall.name, args: fnCall.args } });
+          }
+        }
+      }
+
+      // Gemini rejects empty parts; fall back to a single space text part.
+      result.push({ role: "model", parts: parts.length > 0 ? parts : [{ text: " " }] });
+      continue;
+    }
+
+    // role === "user"
+    if (typeof message.content === "string") {
+      result.push({
+        role: "user",
+        parts: [{ text: message.content.length > 0 ? message.content : " " }],
+      });
+    } else if (Array.isArray(message.content)) {
+      const parts = toGeminiParts(message.content);
+      result.push({ role: "user", parts: parts.length > 0 ? parts : [{ text: " " }] });
+    } else {
+      result.push({ role: "user", parts: [{ text: " " }] });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convert OpenAI-style tool definitions (`{type, function:{...}}`) — or the
+ * already-flattened `{name, description, parameters}` shape — into Gemini's
+ * `functionDeclarations` entries (`{name, description?, parameters}`).
+ */
+export function toGeminiTools(tools: unknown[]): GeminiFunctionDeclaration[] {
+  if (!Array.isArray(tools)) return [];
+  const result: GeminiFunctionDeclaration[] = [];
+
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object") continue;
+    const candidate = tool as Record<string, any>;
+    const fn: Record<string, any> = candidate.function || candidate;
+    const name = typeof fn?.name === "string" ? fn.name.trim() : "";
+    if (!name) continue;
+
+    const parameters =
+      fn?.parameters && typeof fn.parameters === "object"
+        ? (fn.parameters as Record<string, unknown>)
+        : fn?.input_schema && typeof fn.input_schema === "object"
+          ? (fn.input_schema as Record<string, unknown>)
+          : { type: "object", properties: {} };
+
+    const description = typeof fn?.description === "string" ? fn.description : undefined;
+
+    result.push({
+      name,
+      ...(description ? { description } : {}),
+      parameters,
+    });
+  }
+
+  return result;
+}
+
+export function buildGeminiRequestBody(
+  input: RemoteGeminiStreamInput,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    contents: toGeminiContents(input.prepared.preparedMessages),
+  };
+
+  const system = input.prepared.finalSystemPrompt;
+  if (typeof system === "string" && system.trim().length > 0) {
+    body.systemInstruction = { parts: [{ text: system }] };
+  }
+
+  if (Array.isArray(input.prepared.tools) && input.prepared.tools.length > 0) {
+    const functionDeclarations = toGeminiTools(input.prepared.tools as OpenAITool[]);
+    if (functionDeclarations.length > 0) {
+      body.tools = [{ functionDeclarations }];
+    }
+  }
+
+  // Gemini does not require maxOutputTokens (unlike Anthropic). Only set it when
+  // the model metadata declares a positive completion cap; otherwise omit
+  // generationConfig entirely rather than inventing a default.
+  const cap = input.prepared.resolvedModel?.top_provider?.max_completion_tokens;
+  if (typeof cap === "number" && Number.isFinite(cap) && cap > 0) {
+    body.generationConfig = { maxOutputTokens: Math.floor(cap) };
+  }
+
+  return body;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Gemini SSE → StreamEvent parser
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Maps Gemini candidate finishReason values onto the SAME stop-reason values
+ * the OpenAI-compatible StreamPipeline emits (see
+ * StreamPipeline.mapFinishReasonToPiStopReason), so downstream turn-loop logic
+ * is provider-agnostic:
+ *   MAX_TOKENS              → "length"
+ *   STOP / STOP_SEQUENCE    → "toolUse" when a functionCall was seen, else "stop"
+ *   SAFETY / RECITATION /
+ *   OTHER / unknown         → "stop"
+ *
+ * Gemini emits `STOP` even when a functionCall is present, so `sawFunctionCall`
+ * is how we surface tool use to the turn loop.
+ */
+function mapGeminiFinishReason(finishReason: string, sawFunctionCall: boolean): string {
+  const uc = String(finishReason || "").trim().toUpperCase();
+  if (!uc) return "stop";
+  if (uc === "MAX_TOKENS") return "length";
+  if (uc === "STOP" || uc === "STOP_SEQUENCE") return sawFunctionCall ? "toolUse" : "stop";
+  // SAFETY / RECITATION / OTHER / anything unknown collapses to a clean stop.
+  return "stop";
+}
+
+/**
+ * Incremental parser for the Gemini `alt=sse` wire format. Mirrors
+ * StreamPipeline's `push`/`flush` interface so it can be unit-tested directly
+ * with raw SSE strings. Gemini emits `data: <GenerateContentResponse JSON>`
+ * frames terminated by a blank line, with NO `event:` lines. A single JSON
+ * object may arrive split across consecutive `data:` lines within one frame, so
+ * we accumulate data lines and dispatch on the blank-line terminator; partial
+ * lines buffer across `push` calls.
+ */
+export class GeminiStreamParser {
+  private buffer = "";
+  private readonly dataLines: string[] = [];
+  private functionCallCounter = 0;
+  private sawFunctionCall = false;
+
+  push(text: string): StreamEvent[] {
+    this.buffer += text;
+    const events: StreamEvent[] = [];
+
+    while (true) {
+      const newlineIndex = this.buffer.indexOf("\n");
+      if (newlineIndex === -1) break;
+
+      let line = this.buffer.slice(0, newlineIndex);
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+
+      events.push(...this.consumeLine(line));
+    }
+
+    return events;
+  }
+
+  flush(): StreamEvent[] {
+    const events: StreamEvent[] = [];
+
+    if (this.buffer.length > 0) {
+      let line = this.buffer;
+      this.buffer = "";
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      events.push(...this.consumeLine(line));
+    }
+
+    // Dispatch any frame whose terminating blank line never arrived.
+    events.push(...this.dispatchFrame());
+
+    return events;
+  }
+
+  private consumeLine(line: string): StreamEvent[] {
+    const trimmed = line.trim();
+
+    // A blank line terminates the current SSE frame.
+    if (trimmed.length === 0) {
+      return this.dispatchFrame();
+    }
+
+    if (trimmed.startsWith(":")) {
+      return []; // SSE comment / keep-alive
+    }
+
+    if (line.startsWith("data:")) {
+      let dataLine = line.slice("data:".length);
+      if (dataLine.startsWith(" ")) dataLine = dataLine.slice(1);
+      this.dataLines.push(dataLine);
+      return [];
+    }
+
+    return [];
+  }
+
+  private dispatchFrame(): StreamEvent[] {
+    if (this.dataLines.length === 0) {
+      return [];
+    }
+
+    // Gemini frames carry a single JSON object. When the server chops that
+    // object across consecutive `data:` lines it is a transport split, not a
+    // logical newline in the value, so we concatenate rather than join on "\n".
+    const payload = this.dataLines.join("");
+    this.dataLines.length = 0;
+
+    if (payload.length === 0) {
+      return [];
+    }
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      return [];
+    }
+
+    return this.handleResponse(parsed);
+  }
+
+  private handleResponse(parsed: any): StreamEvent[] {
+    const events: StreamEvent[] = [];
+
+    // Top-level error object: { error: { code, message, status } }
+    if (parsed && parsed.error && typeof parsed.error === "object") {
+      const error = parsed.error;
+      const message =
+        (typeof error.message === "string" && error.message) || "Gemini stream error";
+      const code = typeof error.code === "number" ? error.code : 500;
+      throw new SystemSculptError(message, ERROR_CODES.STREAM_ERROR, code, {
+        provider: GEMINI_PROVIDER_ID,
+        rawError: error,
+      });
+    }
+
+    const candidate = Array.isArray(parsed?.candidates) ? parsed.candidates[0] : undefined;
+    if (!candidate || typeof candidate !== "object") {
+      return events;
+    }
+
+    const parts = candidate?.content?.parts;
+    if (Array.isArray(parts)) {
+      for (const part of parts) {
+        if (!part || typeof part !== "object") continue;
+
+        if (part.functionCall && typeof part.functionCall === "object") {
+          const name =
+            typeof part.functionCall.name === "string" ? part.functionCall.name : "";
+          const args =
+            part.functionCall.args && typeof part.functionCall.args === "object"
+              ? part.functionCall.args
+              : {};
+          // Gemini sends the complete call in one part and provides no id, so we
+          // synthesize a stable one and emit both delta + final (the turn loop
+          // treats the final, with full arguments, as authoritative).
+          const call: StreamToolCall = {
+            id: `call_${this.functionCallCounter++}_${name}`,
+            type: "function",
+            function: {
+              name,
+              arguments: JSON.stringify(args ?? {}),
+            },
+          };
+          this.sawFunctionCall = true;
+          events.push({ type: "tool-call", phase: "delta", call });
+          events.push({ type: "tool-call", phase: "final", call });
+          continue;
+        }
+
+        if (typeof part.text === "string") {
+          if (part.text.length === 0) continue;
+          if (part.thought === true) {
+            events.push({ type: "reasoning", text: part.text });
+          } else {
+            events.push({ type: "content", text: part.text });
+          }
+        }
+      }
+    }
+
+    if (typeof candidate.finishReason === "string" && candidate.finishReason.length > 0) {
+      events.push({
+        type: "meta",
+        key: "stop-reason",
+        value: mapGeminiFinishReason(candidate.finishReason, this.sawFunctionCall),
+      });
+    }
+
+    return events;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Executor
+// ────────────────────────────────────────────────────────────────────────────
+
+function serializeResponseHeaders(headers: unknown): Record<string, string> {
+  const serialized: Record<string, string> = {};
+  const maybeHeaders = headers as {
+    forEach?: (callback: (value: unknown, key: unknown) => void) => void;
+    entries?: () => Iterable<[unknown, unknown]>;
+  };
+
+  if (typeof maybeHeaders?.forEach === "function") {
+    maybeHeaders.forEach((value, key) => {
+      serialized[String(key)] = String(value);
+    });
+    return serialized;
+  }
+
+  if (typeof maybeHeaders?.entries === "function") {
+    for (const [key, value] of maybeHeaders.entries()) {
+      serialized[String(key)] = String(value);
+    }
+  }
+
+  return serialized;
+}
+
+export async function* executeGeminiRemoteStream(
+  input: RemoteGeminiStreamInput,
+): AsyncGenerator<StreamEvent, void, unknown> {
+  const endpoint = resolveConfiguredRemoteProviderEndpoint(input.plugin, GEMINI_PROVIDER_ID);
+  if (!endpoint) {
+    throw new Error(`No remote endpoint configured for provider "${GEMINI_PROVIDER_ID}".`);
+  }
+
+  const apiKey = await resolveStudioPiProviderApiKey(GEMINI_PROVIDER_ID, {
+    plugin: input.plugin,
+  });
+  if (!apiKey) {
+    throw new Error(`Connect ${GEMINI_PROVIDER_ID} in Providers before using this model.`);
+  }
+
+  const requestBody = buildGeminiRequestBody(input);
+  const client = new PlatformRequestClient();
+  const debugHeaders = {
+    [GEMINI_API_KEY_HEADER]: "[redacted]",
+  };
+
+  try {
+    input.debug?.onRequest?.({
+      provider: GEMINI_PROVIDER_ID,
+      endpoint,
+      headers: debugHeaders,
+      body: requestBody,
+      transport: "remote-provider",
+      canStream: true,
+      isCustomProvider: true,
+    });
+  } catch {}
+
+  const url = `${endpoint.replace(/\/+$/, "")}/models/${encodeURIComponent(
+    input.prepared.actualModelId,
+  )}:${GEMINI_STREAM_ACTION}?${GEMINI_STREAM_QUERY}`;
+
+  const response = await client.request({
+    url,
+    method: "POST",
+    body: requestBody,
+    stream: true,
+    signal: input.signal,
+    headers: {
+      [GEMINI_API_KEY_HEADER]: apiKey,
+      "content-type": "application/json",
+    },
+  });
+
+  try {
+    input.debug?.onResponse?.({
+      provider: GEMINI_PROVIDER_ID,
+      endpoint,
+      status: response.status,
+      headers: serializeResponseHeaders(response.headers),
+      isCustomProvider: true,
+    });
+  } catch {}
+
+  if (!response.ok) {
+    await StreamingErrorHandler.handleStreamError(response, true, {
+      provider: GEMINI_PROVIDER_ID,
+      endpoint,
+      model: input.prepared.actualModelId,
+    });
+  }
+
+  if (!response.body) {
+    throw new SystemSculptError(
+      "Missing response body from streaming API",
+      ERROR_CODES.STREAM_ERROR,
+      response.status,
+    );
+  }
+
+  const parser = new GeminiStreamParser();
+  const decoder = new TextDecoder();
+  const reader = response.body.getReader();
+
+  const readWithAbort = async (): Promise<{
+    done: boolean;
+    value?: Uint8Array;
+    aborted: boolean;
+  }> => {
+    if (!input.signal) {
+      const { done, value } = await reader.read();
+      return { done, value, aborted: false };
+    }
+
+    if (input.signal.aborted) {
+      try {
+        await reader.cancel();
+      } catch {}
+      return { done: true, value: undefined, aborted: true };
+    }
+
+    return await new Promise((resolve, reject) => {
+      const onAbort = () => {
+        try {
+          void reader.cancel();
+        } catch {}
+        resolve({ done: true, value: undefined, aborted: true });
+      };
+
+      input.signal!.addEventListener("abort", onAbort, { once: true });
+
+      reader
+        .read()
+        .then(({ done, value }) => resolve({ done, value, aborted: false }))
+        .catch(reject)
+        .finally(() => {
+          input.signal!.removeEventListener("abort", onAbort);
+        });
+    });
+  };
+
+  let aborted = false;
+
+  try {
+    while (true) {
+      const { done, value, aborted: abortedBySignal } = await readWithAbort();
+      if (abortedBySignal) {
+        aborted = true;
+        break;
+      }
+      if (done) break;
+      if (!value) continue;
+
+      const text = decoder.decode(value, { stream: true });
+      const events = parser.push(text);
+      for (const event of events) {
+        try {
+          input.debug?.onStreamEvent?.({ event });
+        } catch {}
+        yield event;
+      }
+    }
+
+    if (!aborted) {
+      const trailingEvents = parser.flush();
+      for (const event of trailingEvents) {
+        try {
+          input.debug?.onStreamEvent?.({ event });
+        } catch {}
+        yield event;
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {}
+  }
+
+  try {
+    input.debug?.onStreamEnd?.({
+      completed: !aborted,
+      aborted,
+    });
+  } catch {}
+}

--- a/src/services/providerRuntime/RemoteProviderCatalog.ts
+++ b/src/services/providerRuntime/RemoteProviderCatalog.ts
@@ -58,6 +58,18 @@ const REMOTE_PROVIDER_SEEDS: readonly RemoteProviderSeed[] = [
     supportedParameters: ["tools"],
     endpoint: AI_PROVIDERS.ANTHROPIC.BASE_URL,
   },
+  {
+    // Gemini runs through the native generateContent streaming executor (not the
+    // OpenAI-compatible /chat/completions path) — see GeminiRemoteStreamExecutor (#231).
+    providerId: "google",
+    modelId: "gemini-3-flash-preview",
+    name: "Gemini 3 Flash",
+    description: "Google Gemini remote provider model (native generateContent API) for chat, tool use, reasoning, and image-capable turns.",
+    contextLength: 1_000_000,
+    modality: "text+image->text",
+    supportedParameters: ["tools"],
+    endpoint: AI_PROVIDERS.GOOGLE.BASE_URL,
+  },
 ];
 
 export function normalizeProviderId(value: unknown): string {
@@ -159,6 +171,9 @@ export function resolveRemoteProviderEndpoint(providerId: string): string {
   }
   if (normalized === "anthropic") {
     return AI_PROVIDERS.ANTHROPIC.BASE_URL;
+  }
+  if (normalized === "google") {
+    return AI_PROVIDERS.GOOGLE.BASE_URL;
   }
   return "";
 }

--- a/src/services/providerRuntime/__tests__/GeminiRemoteStreamExecutor.test.ts
+++ b/src/services/providerRuntime/__tests__/GeminiRemoteStreamExecutor.test.ts
@@ -1,0 +1,881 @@
+import {
+  GeminiStreamParser,
+  buildGeminiRequestBody,
+  executeGeminiRemoteStream,
+  toGeminiContents,
+  toGeminiTools,
+} from "../GeminiRemoteStreamExecutor";
+import { GEMINI_API_KEY_HEADER, GEMINI_STREAM_ACTION } from "../../../constants/gemini";
+import type { StreamEvent } from "../../../streaming/types";
+
+const mockResolveEndpoint = jest.fn(() => "https://generativelanguage.googleapis.com/v1beta");
+const mockResolveApiKey = jest.fn(async () => "gem-test-key");
+const mockRequest = jest.fn();
+
+jest.mock("../RemoteProviderCatalog", () => ({
+  resolveConfiguredRemoteProviderEndpoint: (_plugin: unknown, ...args: any[]) =>
+    mockResolveEndpoint(...args),
+}));
+
+jest.mock("../../../studio/piAuth/StudioPiAuthStorage", () => ({
+  resolveStudioPiProviderApiKey: (...args: any[]) => mockResolveApiKey(...args),
+}));
+
+jest.mock("../../PlatformRequestClient", () => ({
+  PlatformRequestClient: jest.fn().mockImplementation(() => ({
+    request: (...args: any[]) => mockRequest(...args),
+  })),
+}));
+
+jest.mock("../../StreamingErrorHandler", () => ({
+  StreamingErrorHandler: {
+    handleStreamError: jest.fn(async () => {
+      throw new Error("stream-error-handled");
+    }),
+  },
+}));
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function makePrepared(overrides: Record<string, any> = {}): any {
+  return {
+    resolvedModel: {
+      sourceProviderId: "google",
+      provider: "google",
+      top_provider: { context_length: 1000000, max_completion_tokens: null, is_moderated: false },
+    },
+    actualModelId: "gemini-3-flash-preview",
+    preparedMessages: [{ role: "user", content: "Hello" }],
+    finalSystemPrompt: "",
+    tools: [],
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Record<string, any> = {}): any {
+  return {
+    plugin: { settings: {} },
+    prepared: makePrepared(overrides.prepared),
+    ...overrides,
+  };
+}
+
+/** Build a fake streaming Response whose body streams the given SSE text. */
+function makeStreamingResponse(
+  sse: string,
+  init: { ok?: boolean; status?: number } = {},
+): Response {
+  const encoder = new TextEncoder();
+  // Split into a couple chunks to exercise incremental decoding.
+  const mid = Math.floor(sse.length / 2);
+  const chunks = [sse.slice(0, mid), sse.slice(mid)];
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    headers: new Map(),
+    body,
+  } as unknown as Response;
+}
+
+async function collect(gen: AsyncGenerator<StreamEvent, void, unknown>): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  for await (const event of gen) {
+    events.push(event);
+  }
+  return events;
+}
+
+function pushAll(parser: GeminiStreamParser, sse: string): StreamEvent[] {
+  const events = parser.push(sse);
+  return [...events, ...parser.flush()];
+}
+
+/** Frame a GenerateContentResponse object as an `alt=sse` data frame. */
+function frame(obj: unknown): string {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// buildGeminiRequestBody
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("buildGeminiRequestBody", () => {
+  it("builds a body with translated contents (no top-level stream field)", () => {
+    const body = buildGeminiRequestBody(makeInput());
+    expect(body.contents).toEqual([{ role: "user", parts: [{ text: "Hello" }] }]);
+    // Gemini streams via the :streamGenerateContent action, not a body flag.
+    expect("stream" in body).toBe(false);
+  });
+
+  it("includes systemInstruction from finalSystemPrompt when non-empty", () => {
+    const body = buildGeminiRequestBody(
+      makeInput({ prepared: makePrepared({ finalSystemPrompt: "You are helpful." }) }),
+    );
+    expect(body.systemInstruction).toEqual({ parts: [{ text: "You are helpful." }] });
+    // System must not be injected into contents.
+    expect(body.contents).toEqual([{ role: "user", parts: [{ text: "Hello" }] }]);
+  });
+
+  it("omits systemInstruction when finalSystemPrompt is empty or whitespace", () => {
+    const empty = buildGeminiRequestBody(
+      makeInput({ prepared: makePrepared({ finalSystemPrompt: "" }) }),
+    );
+    expect("systemInstruction" in empty).toBe(false);
+
+    const whitespace = buildGeminiRequestBody(
+      makeInput({ prepared: makePrepared({ finalSystemPrompt: "   " }) }),
+    );
+    expect("systemInstruction" in whitespace).toBe(false);
+  });
+
+  it("omits generationConfig when no completion cap is declared", () => {
+    const body = buildGeminiRequestBody(makeInput());
+    expect("generationConfig" in body).toBe(false);
+  });
+
+  it("sets generationConfig.maxOutputTokens from a positive completion cap (floored)", () => {
+    const body = buildGeminiRequestBody(
+      makeInput({
+        prepared: makePrepared({
+          resolvedModel: {
+            top_provider: { context_length: 1000000, max_completion_tokens: 8192.9, is_moderated: false },
+          },
+        }),
+      }),
+    );
+    expect(body.generationConfig).toEqual({ maxOutputTokens: 8192 });
+  });
+
+  it("omits generationConfig when the declared cap is non-positive", () => {
+    const body = buildGeminiRequestBody(
+      makeInput({
+        prepared: makePrepared({
+          resolvedModel: {
+            top_provider: { context_length: 1000000, max_completion_tokens: 0, is_moderated: false },
+          },
+        }),
+      }),
+    );
+    expect("generationConfig" in body).toBe(false);
+  });
+
+  it("translates tools into functionDeclarations and omits tools when none provided", () => {
+    const withTools = buildGeminiRequestBody(
+      makeInput({
+        prepared: makePrepared({
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "Get weather",
+                parameters: { type: "object", properties: { city: { type: "string" } } },
+              },
+            },
+          ],
+        }),
+      }),
+    );
+    expect(withTools.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "get_weather",
+            description: "Get weather",
+            parameters: { type: "object", properties: { city: { type: "string" } } },
+          },
+        ],
+      },
+    ]);
+
+    const withoutTools = buildGeminiRequestBody(makeInput());
+    expect("tools" in withoutTools).toBe(false);
+  });
+
+  it("omits tools when the provided tools yield no usable declarations", () => {
+    const body = buildGeminiRequestBody(
+      makeInput({
+        prepared: makePrepared({
+          tools: [{ type: "function", function: { description: "no name" } }],
+        }),
+      }),
+    );
+    expect("tools" in body).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// toGeminiContents
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("toGeminiContents", () => {
+  it("drops system messages (system is a top-level field)", () => {
+    const result = toGeminiContents([
+      { role: "system", content: "be terse" } as any,
+      { role: "user", content: "hi" } as any,
+    ]);
+    expect(result).toEqual([{ role: "user", parts: [{ text: "hi" }] }]);
+  });
+
+  it("maps user→user and assistant→model text turns", () => {
+    const result = toGeminiContents([
+      { role: "user", content: "What is 2+2?" } as any,
+      { role: "assistant", content: "4" } as any,
+    ]);
+    expect(result).toEqual([
+      { role: "user", parts: [{ text: "What is 2+2?" }] },
+      { role: "model", parts: [{ text: "4" }] },
+    ]);
+  });
+
+  it("converts assistant tool_calls into functionCall parts with parsed object args", () => {
+    const result = toGeminiContents([
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_01",
+            request: {
+              id: "call_01",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"city":"Paris"}' },
+            },
+          },
+        ],
+      } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "model",
+        parts: [{ functionCall: { name: "get_weather", args: { city: "Paris" } } }],
+      },
+    ]);
+  });
+
+  it("includes a leading text part when an assistant has both text and tool_calls", () => {
+    const result = toGeminiContents([
+      {
+        role: "assistant",
+        content: "Let me check.",
+        tool_calls: [{ id: "call_02", function: { name: "lookup", arguments: '{"q":"x"}' } }],
+      } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "model",
+        parts: [
+          { text: "Let me check." },
+          { functionCall: { name: "lookup", args: { q: "x" } } },
+        ],
+      },
+    ]);
+  });
+
+  it("uses {} args when assistant tool_call arguments are empty or unparseable", () => {
+    const result = toGeminiContents([
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          { id: "c1", function: { name: "a", arguments: "" } },
+          { id: "c2", function: { name: "b", arguments: "not json" } },
+        ],
+      } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "model",
+        parts: [
+          { functionCall: { name: "a", args: {} } },
+          { functionCall: { name: "b", args: {} } },
+        ],
+      },
+    ]);
+  });
+
+  it("converts a tool message into a user functionResponse keyed by name", () => {
+    const result = toGeminiContents([
+      {
+        role: "tool",
+        tool_call_id: "call_01",
+        name: "get_weather",
+        content: '{"temp":20}',
+      } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "user",
+        parts: [{ functionResponse: { name: "get_weather", response: { temp: 20 } } }],
+      },
+    ]);
+  });
+
+  it("wraps non-object tool content under { result } in the functionResponse", () => {
+    const result = toGeminiContents([
+      { role: "tool", name: "echo", content: "plain text" } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "user",
+        parts: [{ functionResponse: { name: "echo", response: { result: "plain text" } } }],
+      },
+    ]);
+  });
+
+  it("derives the functionResponse name from tool_call_id when name is absent", () => {
+    const result = toGeminiContents([
+      { role: "tool", tool_call_id: "call_xyz", content: "{}" } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "user",
+        parts: [{ functionResponse: { name: "call_xyz", response: {} } }],
+      },
+    ]);
+  });
+
+  it("merges adjacent tool messages into a single user turn", () => {
+    const result = toGeminiContents([
+      { role: "tool", name: "a", content: "result-a" } as any,
+      { role: "tool", name: "b", content: "result-b" } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "user",
+        parts: [
+          { functionResponse: { name: "a", response: { result: "result-a" } } },
+          { functionResponse: { name: "b", response: { result: "result-b" } } },
+        ],
+      },
+    ]);
+  });
+
+  it("does not merge a tool result into a preceding plain user turn", () => {
+    const result = toGeminiContents([
+      { role: "user", content: "hello" } as any,
+      { role: "tool", name: "a", content: "result-a" } as any,
+    ]);
+    expect(result).toEqual([
+      { role: "user", parts: [{ text: "hello" }] },
+      {
+        role: "user",
+        parts: [{ functionResponse: { name: "a", response: { result: "result-a" } } }],
+      },
+    ]);
+  });
+
+  it("maps a multimodal user image data URL into an inlineData part", () => {
+    const result = toGeminiContents([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+        ],
+      } as any,
+    ]);
+    expect(result).toEqual([
+      {
+        role: "user",
+        parts: [
+          { text: "What is this?" },
+          { inlineData: { mimeType: "image/png", data: "AAAA" } },
+        ],
+      },
+    ]);
+  });
+
+  it("skips remote (non-base64) image URLs that inlineData cannot carry", () => {
+    const result = toGeminiContents([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look" },
+          { type: "image_url", image_url: { url: "https://example.com/cat.png" } },
+        ],
+      } as any,
+    ]);
+    expect(result).toEqual([{ role: "user", parts: [{ text: "look" }] }]);
+  });
+
+  it("never emits empty parts for a turn (falls back to a single space)", () => {
+    const result = toGeminiContents([
+      { role: "user", content: "" } as any,
+      { role: "assistant", content: "" } as any,
+    ]);
+    expect(result).toEqual([
+      { role: "user", parts: [{ text: " " }] },
+      { role: "model", parts: [{ text: " " }] },
+    ]);
+  });
+
+  it("falls back to a space part when an image-only turn has no carryable parts", () => {
+    const result = toGeminiContents([
+      {
+        role: "user",
+        content: [{ type: "image_url", image_url: { url: "https://example.com/cat.png" } }],
+      } as any,
+    ]);
+    expect(result).toEqual([{ role: "user", parts: [{ text: " " }] }]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// toGeminiTools
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("toGeminiTools", () => {
+  it("maps OpenAI function tools to functionDeclarations", () => {
+    const result = toGeminiTools([
+      {
+        type: "function",
+        function: {
+          name: "search",
+          description: "Search the web",
+          parameters: { type: "object", properties: { q: { type: "string" } }, required: ["q"] },
+        },
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        name: "search",
+        description: "Search the web",
+        parameters: { type: "object", properties: { q: { type: "string" } }, required: ["q"] },
+      },
+    ]);
+  });
+
+  it("handles tools already in the flattened {name, description, parameters} shape", () => {
+    const result = toGeminiTools([
+      {
+        name: "calc",
+        description: "Do math",
+        parameters: { type: "object", properties: { expr: { type: "string" } } },
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        name: "calc",
+        description: "Do math",
+        parameters: { type: "object", properties: { expr: { type: "string" } } },
+      },
+    ]);
+  });
+
+  it("falls back to input_schema when parameters are absent", () => {
+    const result = toGeminiTools([
+      {
+        type: "function",
+        function: {
+          name: "fromSchema",
+          input_schema: { type: "object", properties: { a: { type: "number" } } },
+        },
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        name: "fromSchema",
+        parameters: { type: "object", properties: { a: { type: "number" } } },
+      },
+    ]);
+  });
+
+  it("defaults parameters to an empty object schema when none provided", () => {
+    const result = toGeminiTools([{ type: "function", function: { name: "noargs" } }]);
+    expect(result).toEqual([
+      { name: "noargs", parameters: { type: "object", properties: {} } },
+    ]);
+  });
+
+  it("skips entries without a usable name and non-object entries", () => {
+    const result = toGeminiTools([
+      { type: "function", function: { description: "no name" } },
+      null,
+      "nonsense",
+    ] as any);
+    expect(result).toEqual([]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// GeminiStreamParser
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("GeminiStreamParser", () => {
+  it("parses text-delta frames into content events and a stop-reason meta", () => {
+    const sse =
+      frame({ candidates: [{ content: { parts: [{ text: "Hello" }] } }] }) +
+      frame({ candidates: [{ content: { parts: [{ text: ", world" }] } }] }) +
+      frame({ candidates: [{ content: { parts: [] }, finishReason: "STOP" }] });
+
+    const parser = new GeminiStreamParser();
+    expect(pushAll(parser, sse)).toEqual([
+      { type: "content", text: "Hello" },
+      { type: "content", text: ", world" },
+      { type: "meta", key: "stop-reason", value: "stop" },
+    ]);
+  });
+
+  it("emits reasoning events for thought parts and skips empty text", () => {
+    const sse =
+      frame({ candidates: [{ content: { parts: [{ thought: true, text: "hmm " }] } }] }) +
+      frame({ candidates: [{ content: { parts: [{ thought: true, text: "" }] } }] }) +
+      frame({ candidates: [{ content: { parts: [{ thought: true, text: "let me think" }] } }] });
+
+    const parser = new GeminiStreamParser();
+    expect(pushAll(parser, sse)).toEqual([
+      { type: "reasoning", text: "hmm " },
+      { type: "reasoning", text: "let me think" },
+    ]);
+  });
+
+  it("emits both delta and final tool-call events for a functionCall part", () => {
+    const sse = frame({
+      candidates: [
+        {
+          content: {
+            parts: [{ functionCall: { name: "get_weather", args: { city: "Paris" } } }],
+          },
+        },
+      ],
+    });
+
+    const parser = new GeminiStreamParser();
+    const events = pushAll(parser, sse);
+
+    expect(events).toEqual([
+      {
+        type: "tool-call",
+        phase: "delta",
+        call: {
+          id: "call_0_get_weather",
+          type: "function",
+          function: { name: "get_weather", arguments: '{"city":"Paris"}' },
+        },
+      },
+      {
+        type: "tool-call",
+        phase: "final",
+        call: {
+          id: "call_0_get_weather",
+          type: "function",
+          function: { name: "get_weather", arguments: '{"city":"Paris"}' },
+        },
+      },
+    ]);
+  });
+
+  it("serializes missing functionCall args as an empty object", () => {
+    const sse = frame({
+      candidates: [{ content: { parts: [{ functionCall: { name: "ping" } }] } }],
+    });
+    const parser = new GeminiStreamParser();
+    const finalEvent = pushAll(parser, sse).find(
+      (e) => e.type === "tool-call" && e.phase === "final",
+    );
+    expect(finalEvent).toEqual({
+      type: "tool-call",
+      phase: "final",
+      call: { id: "call_0_ping", type: "function", function: { name: "ping", arguments: "{}" } },
+    });
+  });
+
+  it("maps STOP to toolUse once a functionCall has been seen", () => {
+    const sse =
+      frame({
+        candidates: [
+          { content: { parts: [{ functionCall: { name: "lookup", args: { q: "hi" } } }] } },
+        ],
+      }) + frame({ candidates: [{ content: { parts: [] }, finishReason: "STOP" }] });
+
+    const parser = new GeminiStreamParser();
+    const events = pushAll(parser, sse);
+    expect(events[events.length - 1]).toEqual({
+      type: "meta",
+      key: "stop-reason",
+      value: "toolUse",
+    });
+  });
+
+  it("maps a bare STOP (no functionCall) to stop", () => {
+    const sse = frame({ candidates: [{ finishReason: "STOP" }] });
+    const parser = new GeminiStreamParser();
+    expect(pushAll(parser, sse)).toEqual([
+      { type: "meta", key: "stop-reason", value: "stop" },
+    ]);
+  });
+
+  it("maps MAX_TOKENS to length", () => {
+    const sse = frame({ candidates: [{ finishReason: "MAX_TOKENS" }] });
+    const parser = new GeminiStreamParser();
+    expect(pushAll(parser, sse)).toEqual([
+      { type: "meta", key: "stop-reason", value: "length" },
+    ]);
+  });
+
+  it("maps SAFETY/RECITATION/OTHER/unknown finish reasons to stop", () => {
+    for (const reason of ["SAFETY", "RECITATION", "OTHER", "SOMETHING_NEW"]) {
+      const parser = new GeminiStreamParser();
+      expect(pushAll(parser, frame({ candidates: [{ finishReason: reason }] }))).toEqual([
+        { type: "meta", key: "stop-reason", value: "stop" },
+      ]);
+    }
+  });
+
+  it("ignores usageMetadata / modelVersion / promptFeedback frames", () => {
+    const sse =
+      frame({ usageMetadata: { totalTokenCount: 12 }, modelVersion: "gemini-3-flash" }) +
+      frame({ promptFeedback: { blockReason: "OTHER" } });
+    const parser = new GeminiStreamParser();
+    expect(pushAll(parser, sse)).toEqual([]);
+  });
+
+  it("throws a SystemSculptError carrying the message on an error frame", () => {
+    const sse = frame({
+      error: { code: 429, message: "Resource exhausted", status: "RESOURCE_EXHAUSTED" },
+    });
+    const parser = new GeminiStreamParser();
+    expect(() => parser.push(sse)).toThrow("Resource exhausted");
+  });
+
+  it("buffers an SSE frame split across two push calls (mid-JSON)", () => {
+    const parser = new GeminiStreamParser();
+    const full = frame({ candidates: [{ content: { parts: [{ text: "chunked" }] } }] });
+    const cut = Math.floor(full.length / 2);
+
+    expect(parser.push(full.slice(0, cut))).toEqual([]);
+    expect(parser.push(full.slice(cut))).toEqual([{ type: "content", text: "chunked" }]);
+  });
+
+  it("joins a single JSON object split across consecutive data lines", () => {
+    const json = JSON.stringify({ candidates: [{ content: { parts: [{ text: "split" }] } }] });
+    const half = Math.floor(json.length / 2);
+    // Two data lines within one frame; the parser joins them before parsing.
+    const sse = `data: ${json.slice(0, half)}\ndata: ${json.slice(half)}\n\n`;
+
+    const parser = new GeminiStreamParser();
+    expect(pushAll(parser, sse)).toEqual([{ type: "content", text: "split" }]);
+  });
+
+  it("flushes an unterminated frame whose trailing blank line never arrived", () => {
+    const parser = new GeminiStreamParser();
+    // No terminating blank line — only flush should dispatch it.
+    const sse = `data: ${JSON.stringify({
+      candidates: [{ content: { parts: [{ text: "tail" }] } }],
+    })}`;
+    expect(parser.push(sse)).toEqual([]);
+    expect(parser.flush()).toEqual([{ type: "content", text: "tail" }]);
+  });
+
+  it("ignores SSE comment lines", () => {
+    const sse =
+      `: keep-alive\n` + frame({ candidates: [{ content: { parts: [{ text: "ok" }] } }] });
+    const parser = new GeminiStreamParser();
+    expect(pushAll(parser, sse)).toEqual([{ type: "content", text: "ok" }]);
+  });
+
+  it("handles \\r\\n line endings", () => {
+    const json = JSON.stringify({ candidates: [{ content: { parts: [{ text: "crlf" }] } }] });
+    const sse = `data: ${json}\r\n\r\n`;
+    const parser = new GeminiStreamParser();
+    expect(pushAll(parser, sse)).toEqual([{ type: "content", text: "crlf" }]);
+  });
+
+  it("synthesizes incrementing ids for multiple function calls", () => {
+    const sse =
+      frame({ candidates: [{ content: { parts: [{ functionCall: { name: "a", args: {} } }] } }] }) +
+      frame({ candidates: [{ content: { parts: [{ functionCall: { name: "b", args: {} } }] } }] });
+    const parser = new GeminiStreamParser();
+    const finals = pushAll(parser, sse).filter(
+      (e) => e.type === "tool-call" && e.phase === "final",
+    );
+    expect(finals.map((e) => (e as any).call.id)).toEqual(["call_0_a", "call_1_b"]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// executeGeminiRemoteStream
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("executeGeminiRemoteStream", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveEndpoint.mockReturnValue("https://generativelanguage.googleapis.com/v1beta");
+    mockResolveApiKey.mockResolvedValue("gem-test-key");
+  });
+
+  it("throws when no endpoint is configured", async () => {
+    mockResolveEndpoint.mockReturnValue("");
+    const gen = executeGeminiRemoteStream(makeInput());
+    await expect(gen.next()).rejects.toThrow(
+      /No remote endpoint configured for provider "google"/,
+    );
+  });
+
+  it("throws the connect message when no API key is available", async () => {
+    mockResolveApiKey.mockResolvedValue("");
+    const gen = executeGeminiRemoteStream(makeInput());
+    await expect(gen.next()).rejects.toThrow(
+      /Connect google in Providers before using this model/,
+    );
+  });
+
+  it("POSTs to the streamGenerateContent endpoint with the api-key header and yields events", async () => {
+    const sse =
+      frame({ candidates: [{ content: { parts: [{ text: "hi" }] } }] }) +
+      frame({ candidates: [{ content: { parts: [] }, finishReason: "STOP" }] });
+
+    mockRequest.mockResolvedValue(makeStreamingResponse(sse));
+
+    const events = await collect(executeGeminiRemoteStream(makeInput()));
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    const callArgs = mockRequest.mock.calls[0][0];
+    expect(callArgs.url).toBe(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:${GEMINI_STREAM_ACTION}?alt=sse`,
+    );
+    expect(callArgs.method).toBe("POST");
+    expect(callArgs.stream).toBe(true);
+    expect(callArgs.headers[GEMINI_API_KEY_HEADER]).toBe("gem-test-key");
+    expect(callArgs.headers["content-type"]).toBe("application/json");
+    // No Authorization / Bearer / x-api-key auth schemes.
+    expect(callArgs.headers.Authorization).toBeUndefined();
+    expect(callArgs.headers["x-api-key"]).toBeUndefined();
+    // Transport flag only; the request body carries no stream field.
+    expect("stream" in callArgs.body).toBe(false);
+    expect(callArgs.body.contents).toEqual([{ role: "user", parts: [{ text: "Hello" }] }]);
+
+    expect(events).toEqual([
+      { type: "content", text: "hi" },
+      { type: "meta", key: "stop-reason", value: "stop" },
+    ]);
+  });
+
+  it("trims trailing slashes on the endpoint and url-encodes the model id", async () => {
+    mockResolveEndpoint.mockReturnValue("https://proxy.example.com/v1beta/");
+    mockRequest.mockResolvedValue(
+      makeStreamingResponse(frame({ candidates: [{ finishReason: "STOP" }] })),
+    );
+
+    await collect(
+      executeGeminiRemoteStream(
+        makeInput({ prepared: makePrepared({ actualModelId: "models/gemini-pro" }) }),
+      ),
+    );
+
+    expect(mockRequest.mock.calls[0][0].url).toBe(
+      `https://proxy.example.com/v1beta/models/models%2Fgemini-pro:${GEMINI_STREAM_ACTION}?alt=sse`,
+    );
+  });
+
+  it("redacts the api key in the debug onRequest headers", async () => {
+    const debug = { onRequest: jest.fn() };
+    mockRequest.mockResolvedValue(
+      makeStreamingResponse(frame({ candidates: [{ finishReason: "STOP" }] })),
+    );
+
+    await collect(executeGeminiRemoteStream(makeInput({ debug })));
+
+    const debugCall = debug.onRequest.mock.calls[0][0];
+    expect(debugCall.headers[GEMINI_API_KEY_HEADER]).toBe("[redacted]");
+    expect(debugCall.headers.Authorization).toBeUndefined();
+  });
+
+  it("fires debug callbacks in order", async () => {
+    const callOrder: string[] = [];
+    const debug = {
+      onRequest: jest.fn(() => callOrder.push("request")),
+      onResponse: jest.fn(() => callOrder.push("response")),
+      onStreamEvent: jest.fn(() => callOrder.push("streamEvent")),
+      onStreamEnd: jest.fn(() => callOrder.push("streamEnd")),
+    };
+    const sse = frame({ candidates: [{ content: { parts: [{ text: "x" }] } }] });
+    mockRequest.mockResolvedValue(makeStreamingResponse(sse));
+
+    await collect(executeGeminiRemoteStream(makeInput({ debug })));
+
+    expect(callOrder).toEqual(["request", "response", "streamEvent", "streamEnd"]);
+    expect(debug.onStreamEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ completed: true, aborted: false }),
+    );
+  });
+
+  it("delegates to StreamingErrorHandler when the response is not ok", async () => {
+    mockRequest.mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: new Map(),
+      text: async () => JSON.stringify({ error: { message: "bad key" } }),
+    });
+
+    const gen = executeGeminiRemoteStream(makeInput());
+    await expect(collect(gen)).rejects.toThrow("stream-error-handled");
+
+    const { StreamingErrorHandler } = require("../../StreamingErrorHandler");
+    expect(StreamingErrorHandler.handleStreamError).toHaveBeenCalledTimes(1);
+    const [, isCustomProvider, context] = StreamingErrorHandler.handleStreamError.mock.calls[0];
+    expect(isCustomProvider).toBe(true);
+    expect(context).toEqual({
+      provider: "google",
+      endpoint: "https://generativelanguage.googleapis.com/v1beta",
+      model: "gemini-3-flash-preview",
+    });
+  });
+
+  it("streams an assistant tool call end-to-end (delta + final + toolUse)", async () => {
+    const sse =
+      frame({
+        candidates: [
+          { content: { parts: [{ functionCall: { name: "lookup", args: { q: "hi" } } }] } },
+        ],
+      }) + frame({ candidates: [{ content: { parts: [] }, finishReason: "STOP" }] });
+
+    mockRequest.mockResolvedValue(makeStreamingResponse(sse));
+
+    const events = await collect(executeGeminiRemoteStream(makeInput()));
+    const finalCall = events.find((e) => e.type === "tool-call" && e.phase === "final");
+    expect(finalCall).toEqual({
+      type: "tool-call",
+      phase: "final",
+      call: {
+        id: "call_0_lookup",
+        type: "function",
+        function: { name: "lookup", arguments: '{"q":"hi"}' },
+      },
+    });
+    expect(events[events.length - 1]).toEqual({
+      type: "meta",
+      key: "stop-reason",
+      value: "toolUse",
+    });
+  });
+
+  it("stops yielding and reports aborted when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const debug = { onStreamEnd: jest.fn() };
+    mockRequest.mockResolvedValue(
+      makeStreamingResponse(frame({ candidates: [{ content: { parts: [{ text: "nope" }] } }] })),
+    );
+
+    const events = await collect(
+      executeGeminiRemoteStream(makeInput({ signal: controller.signal, debug })),
+    );
+
+    expect(events).toEqual([]);
+    expect(debug.onStreamEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ completed: false, aborted: true }),
+    );
+  });
+});

--- a/src/services/providerRuntime/__tests__/GeminiRemoteStreamExecutor.test.ts
+++ b/src/services/providerRuntime/__tests__/GeminiRemoteStreamExecutor.test.ts
@@ -307,6 +307,46 @@ describe("toGeminiContents", () => {
     ]);
   });
 
+  it("attaches the Gemini 3 thoughtSignature sentinel to replayed functionCall parts (#231 multi-turn tool use)", () => {
+    // Gemini 3 validates a thoughtSignature on every functionCall when thinking
+    // is active (on by default for Gemini 3). Calls we replay without an
+    // originating signature must carry the documented skip sentinel, or the next
+    // tool-loop turn is rejected. Older models must NOT receive it.
+    const message = {
+      role: "assistant",
+      content: "",
+      tool_calls: [
+        {
+          id: "call_01",
+          request: {
+            id: "call_01",
+            type: "function",
+            function: { name: "get_weather", arguments: '{"city":"Paris"}' },
+          },
+        },
+      ],
+    } as any;
+
+    const gemini3 = toGeminiContents([message], "gemini-3-flash-preview");
+    expect(gemini3).toEqual([
+      {
+        role: "model",
+        parts: [
+          {
+            functionCall: { name: "get_weather", args: { city: "Paris" } },
+            thoughtSignature: "skip_thought_signature_validator",
+          },
+        ],
+      },
+    ]);
+
+    // A non-Gemini-3 model (or unknown id) must not receive the sentinel.
+    const gemini2 = toGeminiContents([message], "gemini-2.5-flash");
+    expect(gemini2[0].parts[0]).toEqual({
+      functionCall: { name: "get_weather", args: { city: "Paris" } },
+    });
+  });
+
   it("includes a leading text part when an assistant has both text and tool_calls", () => {
     const result = toGeminiContents([
       {
@@ -623,6 +663,27 @@ describe("GeminiStreamParser", () => {
   it("serializes missing functionCall args as an empty object", () => {
     const sse = frame({
       candidates: [{ content: { parts: [{ functionCall: { name: "ping" } }] } }],
+    });
+    const parser = new GeminiStreamParser();
+    const finalEvent = pushAll(parser, sse).find(
+      (e) => e.type === "tool-call" && e.phase === "final",
+    );
+    expect(finalEvent).toEqual({
+      type: "tool-call",
+      phase: "final",
+      call: { id: "call_0_ping", type: "function", function: { name: "ping", arguments: "{}" } },
+    });
+  });
+
+  it("serializes array functionCall args as an empty object, not a JSON array", () => {
+    // Tool arguments must be a JSON object. An array is `typeof === "object"`,
+    // so without an Array.isArray guard it would serialize as "[1,2,3]" and
+    // mis-parse downstream. Gemini does not emit array args, but the parser
+    // must not trust that.
+    const sse = frame({
+      candidates: [
+        { content: { parts: [{ functionCall: { name: "ping", args: [1, 2, 3] } }] } },
+      ],
     });
     const parser = new GeminiStreamParser();
     const finalEvent = pushAll(parser, sse).find(

--- a/src/services/providerRuntime/__tests__/GeminiRemoteStreamExecutor.test.ts
+++ b/src/services/providerRuntime/__tests__/GeminiRemoteStreamExecutor.test.ts
@@ -169,6 +169,50 @@ describe("buildGeminiRequestBody", () => {
     expect("generationConfig" in body).toBe(false);
   });
 
+  it("omits thinkingConfig when no reasoning effort is requested (#231)", () => {
+    const body = buildGeminiRequestBody(
+      makeInput({
+        prepared: makePrepared({
+          resolvedModel: {
+            top_provider: { context_length: 1000000, max_completion_tokens: 8192, is_moderated: false },
+          },
+        }),
+      }),
+    );
+    expect(body.generationConfig).toEqual({ maxOutputTokens: 8192 });
+  });
+
+  it("enables thinking with thought summaries for a requested reasoning effort (#231)", () => {
+    // A reasoning-capable Gemini must actually reason; includeThoughts surfaces
+    // the thought summaries the parser turns into reasoning events.
+    const body = buildGeminiRequestBody(makeInput({ reasoningEffort: "medium" }));
+    expect(body.generationConfig).toEqual({
+      thinkingConfig: { thinkingBudget: 4096, includeThoughts: true },
+    });
+  });
+
+  it("disables thinking (budget 0, no thoughts) when reasoning effort is 'off' (#231)", () => {
+    const body = buildGeminiRequestBody(makeInput({ reasoningEffort: "off" }));
+    expect(body.generationConfig).toEqual({ thinkingConfig: { thinkingBudget: 0 } });
+  });
+
+  it("merges maxOutputTokens and thinkingConfig when both apply (#231)", () => {
+    const body = buildGeminiRequestBody(
+      makeInput({
+        reasoningEffort: "high",
+        prepared: makePrepared({
+          resolvedModel: {
+            top_provider: { context_length: 1000000, max_completion_tokens: 8192, is_moderated: false },
+          },
+        }),
+      }),
+    );
+    expect(body.generationConfig).toEqual({
+      maxOutputTokens: 8192,
+      thinkingConfig: { thinkingBudget: 8192, includeThoughts: true },
+    });
+  });
+
   it("translates tools into functionDeclarations and omits tools when none provided", () => {
     const withTools = buildGeminiRequestBody(
       makeInput({

--- a/src/services/providerRuntime/__tests__/ProviderRuntime.test.ts
+++ b/src/services/providerRuntime/__tests__/ProviderRuntime.test.ts
@@ -156,6 +156,30 @@ describe("ProviderRuntime", () => {
       });
     });
 
+    it("resolves a remote BYOK plan for a configured Gemini model (#231)", async () => {
+      // #231 acceptance: a configured Google/Gemini key yields a Chat model that
+      // resolves an executable plan (not just appears in the dropdown).
+      mockedResolveEndpoint.mockReturnValue("https://generativelanguage.googleapis.com/v1beta");
+      const model = makeRemoteModel({
+        id: "google@@gemini-3-flash-preview",
+        piExecutionModelId: "gemini-3-flash-preview",
+        sourceProviderId: "google",
+        provider: "google",
+      });
+
+      const plan = await resolveProviderRuntimePlan(model, {} as any);
+
+      expect(plan).toEqual({
+        mode: "remote",
+        actualModelId: "gemini-3-flash-preview",
+        providerId: "google",
+        authMode: "byok",
+        endpoint: "https://generativelanguage.googleapis.com/v1beta",
+        supportsTools: true,
+        supportsImages: true,
+      });
+    });
+
     it("falls back to Pi provider auth when plugin has no stored key", async () => {
       mockedGetApiKey.mockReturnValue("");
       mockResolveStudioPiProviderApiKey.mockResolvedValue(null);

--- a/src/services/providerRuntime/__tests__/RemoteProviderCatalog.test.ts
+++ b/src/services/providerRuntime/__tests__/RemoteProviderCatalog.test.ts
@@ -45,6 +45,12 @@ describe("RemoteProviderCatalog", () => {
       );
     });
 
+    it("returns the Google base URL for the google provider (#231)", () => {
+      expect(resolveRemoteProviderEndpoint("google")).toBe(
+        AI_PROVIDERS.GOOGLE.BASE_URL
+      );
+    });
+
     it("is case-insensitive", () => {
       expect(resolveRemoteProviderEndpoint("OpenRouter")).toBe(
         AI_PROVIDERS.OPENROUTER.BASE_URL
@@ -325,6 +331,38 @@ describe("RemoteProviderCatalog", () => {
       );
     });
 
+    it("returns Gemini 3 Flash when Google is configured (#231)", () => {
+      const plugin = makePlugin([
+        {
+          id: "google",
+          name: "Google Gemini",
+          endpoint: "https://generativelanguage.googleapis.com/v1beta",
+          apiKey: "gemini-key",
+          isEnabled: true,
+        },
+      ]);
+
+      const models = listConfiguredRemoteProviderModels(plugin);
+      const gemini = models.find((model) => model.id === "google@@gemini-3-flash-preview");
+
+      expect(gemini).toMatchObject({
+        id: "google@@gemini-3-flash-preview",
+        name: "Gemini 3 Flash",
+        provider: "google",
+        sourceMode: "custom_endpoint",
+        sourceProviderId: "google",
+        piRemoteAvailable: true,
+        piLocalAvailable: false,
+        piAuthMode: "byok",
+        piExecutionModelId: "gemini-3-flash-preview",
+        context_length: 1_000_000,
+      });
+      expect(gemini?.supported_parameters).toContain("tools");
+      expect(gemini?.capabilities).toEqual(
+        expect.arrayContaining(["chat", "reasoning", "vision"])
+      );
+    });
+
     it("gives every configured remote provider model a resolvable execution endpoint (#201 contract)", () => {
       // The core #201 failure mode: a model appears in the Chat dropdown but
       // has no execution endpoint, so selecting it throws "No remote endpoint
@@ -335,10 +373,11 @@ describe("RemoteProviderCatalog", () => {
         { id: "xai", name: "xAI", endpoint: "https://api.x.ai/v1", apiKey: "k", isEnabled: true },
         { id: "openai", name: "OpenAI", endpoint: "https://api.openai.com/v1", apiKey: "k", isEnabled: true },
         { id: "anthropic", name: "Anthropic", endpoint: "https://api.anthropic.com/v1", apiKey: "k", isEnabled: true },
+        { id: "google", name: "Google Gemini", endpoint: "https://generativelanguage.googleapis.com/v1beta", apiKey: "k", isEnabled: true },
       ]);
 
       const models = listConfiguredRemoteProviderModels(plugin);
-      expect(models.length).toBeGreaterThanOrEqual(4);
+      expect(models.length).toBeGreaterThanOrEqual(5);
       for (const model of models) {
         expect(resolveRemoteProviderEndpoint(String(model.sourceProviderId))).not.toBe("");
       }

--- a/testing/integration/provider-listing.test.ts
+++ b/testing/integration/provider-listing.test.ts
@@ -26,6 +26,7 @@ type Fixtures = Awaited<ReturnType<typeof startProviderFixtures>>;
 const OPENROUTER_SEED_MODEL_ID = createCanonicalId("openrouter", "openai/gpt-5.4-mini");
 const OPENAI_SEED_MODEL_ID = createCanonicalId("openai", "gpt-5.4-mini");
 const ANTHROPIC_SEED_MODEL_ID = createCanonicalId("anthropic", "claude-sonnet-4-6");
+const GOOGLE_SEED_MODEL_ID = createCanonicalId("google", "gemini-3-flash-preview");
 
 function buildPluginStub(customProviders: unknown[] = []) {
   return {
@@ -128,6 +129,28 @@ describe("text model catalog (#201 guard)", () => {
     const seed = models.find((model) => model.id === ANTHROPIC_SEED_MODEL_ID);
     expect(seed?.piAuthMode).toBe("byok");
     expect(seed?.provider).toBe("anthropic");
+  });
+
+  it("lists the Gemini seed model when a keyed Google provider is configured (#231)", async () => {
+    const models = await listPiTextCatalogModels(
+      buildPluginStub([
+        {
+          id: "google",
+          name: "Google Gemini",
+          endpoint: "https://generativelanguage.googleapis.com/v1beta",
+          apiKey: "fixture-key",
+          isEnabled: true,
+        },
+      ])
+    );
+
+    const ids = models.map((model) => model.id);
+    expect(ids[0]).toBe(SYSTEMSCULPT_PI_CANONICAL_MODEL_ID);
+    expect(ids).toContain(GOOGLE_SEED_MODEL_ID);
+
+    const seed = models.find((model) => model.id === GOOGLE_SEED_MODEL_ID);
+    expect(seed?.piAuthMode).toBe("byok");
+    expect(seed?.provider).toBe("google");
   });
 
   it("drops the seed model when the provider has no API key", async () => {


### PR DESCRIPTION
- Adds Google/Gemini BYOK through the native `generateContent` streaming API (not the OpenAI-compatible /chat/completions path): new `GeminiRemoteStreamExecutor` mirroring the Anthropic/OpenRouter executors, wired into the catalog (Gemini 3 Flash seed) and `SystemSculptService` dispatch via the shared `normalizeProviderId`.
- Honors reasoning effort via `generationConfig.thinkingConfig` (with `includeThoughts` so thought summaries surface as reasoning events), matching the Anthropic reasoning behavior.
- Tests: executor (request/translation/tool-translation/SSE parser + thinking), catalog appears + resolvable endpoint, runtime resolves an executable plan, built-bundle listing guard — all unioned with the #230 provider coverage.

Closes #231. Refs #201, #215, #230.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Google Gemini model support with streaming response capabilities
  * Integrated Gemini as a configurable remote provider option
  * Enabled tool calling and advanced reasoning features with Gemini models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->