### PR TITLE
ci(e2e): redact secrets from failure artifacts + least-privilege tokens

### DIFF
--- a/.github/workflows/linux-e2e.yml
+++ b/.github/workflows/linux-e2e.yml
@@ -322,40 +322,9 @@ jobs:
           cp -R "${HOME}/Documents/SystemSculptLinuxQA/.obsidian/plugins/systemsculpt-ai" diagnostics/plugin-dir 2>/dev/null || true
           cp -R "${HOME}/.systemsculpt/obsidian-automation" diagnostics/bridge-discovery 2>/dev/null || true
 
-          # Redact secrets from any JSON we are about to upload. GitHub log
-          # masking does NOT protect artifact contents, so the seeded license
-          # (data.json) and the bridge bearer token (discovery files) must be
-          # scrubbed before upload.
-          node --input-type=module -e "
-            import fs from 'node:fs';
-            // Broad on purpose: over-redacting a diagnostics dump is safe, and
-            // serverUrl/endpoints are seeded from secrets too (CodeRabbit #5).
-            const SECRET = /key|token|secret|license|password|url|server|host|endpoint|credential/i;
-            const redact = (v) => {
-              if (Array.isArray(v)) return v.map(redact);
-              if (v && typeof v === 'object') {
-                for (const k of Object.keys(v)) {
-                  v[k] = SECRET.test(k) && typeof v[k] === 'string' ? '[REDACTED]' : redact(v[k]);
-                }
-              }
-              return v;
-            };
-            const targets = [
-              'diagnostics/plugin-dir/data.json',
-              ...(fs.existsSync('diagnostics/bridge-discovery')
-                ? fs.readdirSync('diagnostics/bridge-discovery')
-                    .filter((f) => f.endsWith('.json'))
-                    .map((f) => 'diagnostics/bridge-discovery/' + f)
-                : []),
-            ];
-            for (const p of targets) {
-              try {
-                const d = redact(JSON.parse(fs.readFileSync(p, 'utf8')));
-                fs.writeFileSync(p, JSON.stringify(d, null, 2));
-                console.log('Redacted secrets in', p);
-              } catch {}
-            }
-          "
+          # Scrub secrets (seeded license in data.json, bridge bearer token)
+          # from the JSON we upload — log masking does not cover artifact files.
+          node testing/native/shared/redact-diagnostics.mjs diagnostics
           echo "Diagnostics collected"
 
       - name: Upload failure diagnostics

--- a/.github/workflows/macos-e2e.yml
+++ b/.github/workflows/macos-e2e.yml
@@ -15,17 +15,26 @@ concurrency:
   group: macos-e2e-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: this lane only reads the repo. The smoke license/server
+# secrets are scoped to the "Seed plugin settings" step's env, not the job env,
+# so they aren't present in the environment of the install/build/test steps or
+# the Obsidian launch step. (The plugin reads the license from the seeded
+# data.json by design — that file is redacted before any artifact upload.)
+permissions:
+  contents: read
+
 jobs:
   desktop-baselines:
     runs-on: macos-latest
     timeout-minutes: 15
     env:
       OBSIDIAN_VERSION: ${{ inputs.obsidian_version || '1.8.9' }}
-      SYSTEMSCULPT_RUNTIME_SMOKE_LICENSE_KEY: ${{ secrets.SYSTEMSCULPT_E2E_LICENSE_KEY }}
-      SYSTEMSCULPT_RUNTIME_SMOKE_SERVER_URL: ${{ secrets.SYSTEMSCULPT_RUNTIME_SMOKE_SERVER_URL }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Don't leave the GITHUB_TOKEN in .git/config for later PR-controlled steps.
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -110,7 +119,13 @@ jobs:
           fi
           cat "${state_file}"
 
-      - name: Prepare vault and launch Obsidian
+      - name: Seed plugin settings
+        # The smoke license/server secrets are scoped to THIS step only — they
+        # are consumed solely by the data.json seed below and never reach the
+        # install/build/test steps or the launched Electron process.
+        env:
+          SYSTEMSCULPT_RUNTIME_SMOKE_LICENSE_KEY: ${{ secrets.SYSTEMSCULPT_E2E_LICENSE_KEY }}
+          SYSTEMSCULPT_RUNTIME_SMOKE_SERVER_URL: ${{ secrets.SYSTEMSCULPT_RUNTIME_SMOKE_SERVER_URL }}
         run: |
           vault_path="${HOME}/Documents/SystemSculptMacQA"
           plugin_dir="${vault_path}/.obsidian/plugins/systemsculpt-ai"
@@ -173,6 +188,10 @@ jobs:
             console.log('Registered vault:', key, '->', vaultPath);
           "
 
+      - name: Launch Obsidian
+        # No secret env here: the license already lives in data.json (seeded
+        # above), so the Obsidian/Electron process is launched without it.
+        run: |
           # Clear Pi-related env vars for clean-install parity
           unset PI_CODING_AGENT_DIR OPENAI_API_KEY ANTHROPIC_API_KEY \
                 GEMINI_API_KEY GOOGLE_API_KEY GROQ_API_KEY MISTRAL_API_KEY \
@@ -268,6 +287,10 @@ jobs:
           cp -R "${HOME}/Library/Application Support/obsidian/logs" diagnostics/obsidian-logs 2>/dev/null || true
           cp -R "${HOME}/Documents/SystemSculptMacQA/.obsidian/plugins/systemsculpt-ai" diagnostics/plugin-dir 2>/dev/null || true
           cp -R "${HOME}/.systemsculpt/obsidian-automation" diagnostics/bridge-discovery 2>/dev/null || true
+
+          # Scrub secrets (seeded license in data.json, bridge bearer token)
+          # from the JSON we upload — log masking does not cover artifact files.
+          node testing/native/shared/redact-diagnostics.mjs diagnostics
           echo "Diagnostics collected"
 
       - name: Upload failure diagnostics

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -15,6 +15,13 @@ concurrency:
   group: windows-e2e-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: this lane only reads the repo. (The provider/smoke secrets
+# stay at job scope because the device scripts consume them indirectly across
+# several steps; the leak vector was the failure artifact, which is now redacted
+# before upload — see "Redact Windows diagnostics".)
+permissions:
+  contents: read
+
 jobs:
   windows-e2e:
     name: windows-e2e
@@ -36,6 +43,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Don't leave the GITHUB_TOKEN in .git/config for later PR-controlled steps.
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -217,6 +227,14 @@ jobs:
             Select-Object Id, Path, StartTime |
             ConvertTo-Json -Depth 3 |
             Out-File -FilePath (Join-Path $diag "obsidian-processes.json") -Encoding utf8
+
+      - name: Redact Windows diagnostics
+        if: failure()
+        shell: pwsh
+        run: |
+          # Scrub secrets (seeded license in data.json, bridge bearer token)
+          # from the JSON we upload — log masking does not cover artifact files.
+          node testing/native/shared/redact-diagnostics.mjs "$env:RUNNER_TEMP\systemsculpt-windows-diagnostics"
 
       - name: Upload Windows diagnostics
         if: failure()

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "test:integration:ci": "node scripts/jest.mjs --config jest.integration.config.cjs --runInBand --forceExit",
     "test:embeddings:serial": "node scripts/jest.mjs --config jest.embeddings.config.cjs --runInBand --passWithNoTests",
     "test:release-script": "node --test scripts/release-plugin.test.mjs scripts/check-release-surfaces.test.mjs",
-    "test:native:shared": "node --test testing/native/shared/model-inventory.test.mjs",
+    "test:native:shared": "node --test testing/native/shared/*.test.mjs",
     "check:release-surfaces": "node scripts/check-release-surfaces.mjs",
     "release:plugin": "node scripts/release-plugin.mjs"
   },

--- a/testing/native/shared/redact-diagnostics.mjs
+++ b/testing/native/shared/redact-diagnostics.mjs
@@ -52,18 +52,49 @@ function collectJsonFiles(dir, acc) {
  * untouched — they're never the secret vector (the seeded credentials live in
  * data.json / the bridge discovery JSON).
  */
+const UNPARSEABLE_MARKER = {
+  _redacted: "unparseable JSON replaced to avoid leaking unredacted secrets",
+};
+
 export function redactDiagnosticsDir(diagDir) {
   if (!diagDir || !fs.existsSync(diagDir)) {
     return [];
   }
   const redacted = [];
   for (const file of collectJsonFiles(diagDir, [])) {
+    let parsed;
     try {
-      const obj = redactSecrets(JSON.parse(fs.readFileSync(file, "utf8")));
-      fs.writeFileSync(file, JSON.stringify(obj, null, 2));
+      parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+    } catch {
+      // Fail closed: a *.json we can't read/parse might still contain secrets,
+      // so we must never ship its raw contents. Replace it with a marker (or, if
+      // that also fails, delete it) instead of leaving it in the artifact.
+      try {
+        fs.writeFileSync(file, JSON.stringify(UNPARSEABLE_MARKER, null, 2));
+        redacted.push(file);
+      } catch {
+        try {
+          fs.rmSync(file, { force: true });
+          redacted.push(file);
+        } catch {
+          // Nothing more we can safely do; surface it rather than hide it.
+          console.error("WARNING: could not redact or remove", file);
+        }
+      }
+      continue;
+    }
+    try {
+      fs.writeFileSync(file, JSON.stringify(redactSecrets(parsed), null, 2));
       redacted.push(file);
     } catch {
-      // Not JSON / unreadable — leave it; not a credential carrier.
+      // Couldn't write the redacted form — remove the original so the unredacted
+      // file is never uploaded.
+      try {
+        fs.rmSync(file, { force: true });
+        redacted.push(file);
+      } catch {
+        console.error("WARNING: could not redact or remove", file);
+      }
     }
   }
   return redacted;

--- a/testing/native/shared/redact-diagnostics.mjs
+++ b/testing/native/shared/redact-diagnostics.mjs
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Secret redaction for CI failure-diagnostics artifacts (issue: E2E lanes
+ * uploaded the seeded license key inside data.json).
+ *
+ * GitHub log masking does NOT protect artifact file contents, so any secret we
+ * copy into the diagnostics tree (the seeded plugin data.json license/serverUrl,
+ * the bridge discovery bearer token) would be downloadable from the run's
+ * artifacts. This module scrubs those before upload. Shared by every desktop
+ * E2E lane (linux/macos/windows) so the redaction can never drift between them.
+ */
+
+// Keys whose string values are secrets or secret-derived. Broad on purpose:
+// over-redacting a diagnostics dump is safe; missing one leaks a credential.
+export const SECRET_KEY_PATTERN =
+  /key|token|secret|license|password|url|server|host|endpoint|credential/i;
+
+/** Recursively replace secret-keyed string values with "[REDACTED]" in place. */
+export function redactSecrets(value) {
+  if (Array.isArray(value)) {
+    return value.map(redactSecrets);
+  }
+  if (value && typeof value === "object") {
+    for (const key of Object.keys(value)) {
+      value[key] =
+        SECRET_KEY_PATTERN.test(key) && typeof value[key] === "string"
+          ? "[REDACTED]"
+          : redactSecrets(value[key]);
+    }
+  }
+  return value;
+}
+
+function collectJsonFiles(dir, acc) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectJsonFiles(full, acc);
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Redact every *.json under a diagnostics directory (best-effort). Returns the
+ * list of files actually rewritten. Files that don't parse as JSON are skipped
+ * untouched — they're never the secret vector (the seeded credentials live in
+ * data.json / the bridge discovery JSON).
+ */
+export function redactDiagnosticsDir(diagDir) {
+  if (!diagDir || !fs.existsSync(diagDir)) {
+    return [];
+  }
+  const redacted = [];
+  for (const file of collectJsonFiles(diagDir, [])) {
+    try {
+      const obj = redactSecrets(JSON.parse(fs.readFileSync(file, "utf8")));
+      fs.writeFileSync(file, JSON.stringify(obj, null, 2));
+      redacted.push(file);
+    } catch {
+      // Not JSON / unreadable — leave it; not a credential carrier.
+    }
+  }
+  return redacted;
+}
+
+// CLI: `node redact-diagnostics.mjs <diagnostics-dir>` (used by the E2E lanes).
+const isMain =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMain) {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error("usage: redact-diagnostics.mjs <diagnostics-dir>");
+    process.exit(2);
+  }
+  for (const file of redactDiagnosticsDir(dir)) {
+    console.log("Redacted secrets in", file);
+  }
+}

--- a/testing/native/shared/redact-diagnostics.test.mjs
+++ b/testing/native/shared/redact-diagnostics.test.mjs
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { redactSecrets, redactDiagnosticsDir } from "./redact-diagnostics.mjs";
+
+test("redactSecrets redacts secret-keyed string values recursively", () => {
+  const out = redactSecrets({
+    licenseKey: "live-license-uuid",
+    serverUrl: "https://secret-staging.example.com",
+    licenseValid: true,
+    settingsMode: "advanced",
+    vaultInstanceId: "id-1",
+    nested: { providerApiKey: "sk-xyz", bearerToken: "t0ken", note: "keep-me" },
+    arr: [{ apiKey: "k1" }, { harmless: 2 }],
+  });
+
+  // Every secret-keyed string is scrubbed, at any depth.
+  assert.equal(out.licenseKey, "[REDACTED]");
+  assert.equal(out.serverUrl, "[REDACTED]");
+  assert.equal(out.nested.providerApiKey, "[REDACTED]");
+  assert.equal(out.nested.bearerToken, "[REDACTED]");
+  assert.equal(out.arr[0].apiKey, "[REDACTED]");
+
+  // Non-secret fields (incl. a boolean named with a secret-ish key) survive.
+  assert.equal(out.licenseValid, true);
+  assert.equal(out.settingsMode, "advanced");
+  assert.equal(out.vaultInstanceId, "id-1");
+  assert.equal(out.nested.note, "keep-me");
+  assert.equal(out.arr[1].harmless, 2);
+});
+
+test("redactDiagnosticsDir scrubs every JSON under the diagnostics tree", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "redact-diag-"));
+  try {
+    fs.mkdirSync(path.join(dir, "plugin-dir"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "bridge-discovery"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "plugin-dir", "data.json"),
+      JSON.stringify({ licenseKey: "live", serverUrl: "https://s", settingsMode: "advanced" }),
+    );
+    fs.writeFileSync(
+      path.join(dir, "bridge-discovery", "abc.json"),
+      JSON.stringify({ pluginId: "systemsculpt-ai", port: 1234, token: "bearer-secret" }),
+    );
+    // A non-JSON file must be left untouched (not a credential carrier).
+    fs.writeFileSync(path.join(dir, "obsidian.log"), "licenseKey not really here");
+
+    const redacted = redactDiagnosticsDir(dir);
+    assert.equal(redacted.length, 2);
+
+    const data = JSON.parse(fs.readFileSync(path.join(dir, "plugin-dir", "data.json"), "utf8"));
+    assert.equal(data.licenseKey, "[REDACTED]");
+    assert.equal(data.serverUrl, "[REDACTED]");
+    assert.equal(data.settingsMode, "advanced");
+
+    const disc = JSON.parse(fs.readFileSync(path.join(dir, "bridge-discovery", "abc.json"), "utf8"));
+    assert.equal(disc.token, "[REDACTED]");
+    assert.equal(disc.pluginId, "systemsculpt-ai");
+    assert.equal(disc.port, 1234);
+
+    assert.equal(fs.readFileSync(path.join(dir, "obsidian.log"), "utf8"), "licenseKey not really here");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("redactDiagnosticsDir is a no-op for a missing directory", () => {
+  assert.deepEqual(redactDiagnosticsDir(path.join(os.tmpdir(), "redact-missing-xyz-404")), []);
+});

--- a/testing/native/shared/redact-diagnostics.test.mjs
+++ b/testing/native/shared/redact-diagnostics.test.mjs
@@ -66,6 +66,25 @@ test("redactDiagnosticsDir scrubs every JSON under the diagnostics tree", () => 
   }
 });
 
+test("redactDiagnosticsDir fails closed on an unparseable .json (never ships raw)", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "redact-failclosed-"));
+  try {
+    // A *.json that fails to parse (e.g. a crash truncated data.json mid-write)
+    // could still contain a secret. It must NOT survive into the artifact.
+    const broken = path.join(dir, "data.json");
+    fs.writeFileSync(broken, '{"licenseKey":"live-secret-uuid", TRUNCATED');
+
+    const redacted = redactDiagnosticsDir(dir);
+    assert.deepEqual(redacted, [broken]);
+
+    const after = fs.readFileSync(broken, "utf8");
+    assert.ok(!after.includes("live-secret-uuid"), "raw secret must be gone");
+    assert.match(after, /_redacted/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("redactDiagnosticsDir is a no-op for a missing directory", () => {
   assert.deepEqual(redactDiagnosticsDir(path.join(os.tmpdir(), "redact-missing-xyz-404")), []);
 });


### PR DESCRIPTION
The desktop E2E lanes uploaded the seeded license key inside `data.json` on failure (the Windows lane had been doing this on real runs). GitHub log masking doesn't cover artifact file contents, so on this public repo the key was downloadable from every failed run's artifacts. (The exposed artifacts have been deleted; the key should be rotated separately.)

- Shared, unit-tested redactor (`testing/native/shared/redact-diagnostics.mjs`) that recursively scrubs secret-keyed values from every JSON under a diagnostics dir — called by all three desktop lanes before upload, so the redaction can't drift.
- Linux/macОS: smoke secrets scoped to a dedicated seed step (off the job env); Obsidian launched secret-free.
- Windows: secrets kept at job scope (device scripts consume them indirectly) but the artifact is redacted — the actual leak vector.
- All lanes: `permissions: contents: read` + `persist-credentials: false`.
- `test:native:shared` now globs `*.test.mjs`, so the new redactor test (and the previously-orphaned `json.test.mjs`) run in CI.

Follow-up to #244 (Linux lane), which introduced the redaction inline; this supersedes it with the shared helper.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Secrets and credentials are now automatically redacted from diagnostic artifacts before upload, preventing accidental exposure of sensitive information
  * Applied least-privilege permissions and improved credential isolation in CI/CD workflows across Linux, macOS, and Windows E2E test lanes

* **Tests**
  * Added tests for the new diagnostic redaction utility to ensure secrets are properly scrubbed from diagnostic files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->