### PR TITLE
test(integration): guard mobile graceful degradation — recorder withheld on mobile (#207)

### DIFF
--- a/testing/integration/bundle-load.mobile.test.ts
+++ b/testing/integration/bundle-load.mobile.test.ts
@@ -79,6 +79,15 @@ describe("built bundle (main.js) on mobile emulation", () => {
     const commandIds = plugin._commands.map((command: { id: string }) => command.id);
     expect(new Set(commandIds).size).toBe(commandIds.length);
 
+    // #207 graceful degradation: the desktop-only recorder service is WITHHELD
+    // on mobile. Its construction is gated behind !PlatformContext.isMobileRuntime()
+    // (src/main.ts:1689) because recording needs desktop audio APIs. A regression
+    // that ungates it — re-introducing desktop-only code on phones, the #181/#207
+    // failure class — flips this to non-null. The desktop guard
+    // (bundle-load.test.ts) asserts the same service IS initialized off-mobile, so
+    // this is a real gate, not a vacuous default (the field defaulting to null).
+    expect(plugin.recorderService).toBeNull();
+
     plugin.unload();
   });
 });

--- a/testing/integration/bundle-load.test.ts
+++ b/testing/integration/bundle-load.test.ts
@@ -61,6 +61,13 @@ describe("built bundle (main.js)", () => {
     const commandIds = plugin._commands.map((command: { id: string }) => command.id);
     expect(new Set(commandIds).size).toBe(commandIds.length);
 
+    // Contrast with the mobile guard (bundle-load.mobile.test.ts): the
+    // desktop-only recorder service that mobile withholds DOES initialize
+    // off-mobile. This is what makes "withheld on mobile" a real gate
+    // (src/main.ts:1689) rather than a vacuous default — a regression in either
+    // direction (recorder on mobile, or recorder missing on desktop) red-builds.
+    expect(plugin.recorderService).not.toBeNull();
+
     plugin.unload();
   });
 });


### PR DESCRIPTION
Adds the graceful-degradation half of #207's mobile CI guard: a desktop-only subsystem (the recorder — needs desktop audio APIs) must stay **withheld** on mobile, not crash startup.

- `bundle-load.mobile.test.ts`: `recorderService` is null under mobile flags; `bundle-load.test.ts`: non-null off-mobile — so it's a real gate (present on desktop / withheld on mobile), not a vacuous default. A regression in either direction red-builds.
- Runs in the required `ci.yml` integration job — no device, no secrets. Completes #207's mobile-emulation facet (Linux lane: #244).

Closes #207

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reinforced integration test coverage with regression testing for platform-specific functionality. Tests now verify that the recorder service correctly initializes on desktop platforms while remaining properly disabled on mobile devices, enhancing quality assurance and preventing future compatibility regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->