### PR TITLE
feat(entitlement): BYOK users never hit a license wall in chat (#209)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -193,9 +193,8 @@ export default class SystemSculptPlugin extends Plugin {
       // Validate prerequisites based on provider
       const provider = (this.settings as any).embeddingsProvider || "systemsculpt";
       if (provider === 'systemsculpt') {
-        const hasLicenseKey = !!this.settings.licenseKey?.trim();
-        const hasValidLicense = this.settings.licenseValid === true;
-        if (!hasLicenseKey || !hasValidLicense) {
+        // Route through the single entitlement owner (#209) — no inline license check.
+        if (!this.getEntitlementService().canUseEmbeddings(provider)) {
           throw new Error('Embeddings require an active SystemSculpt license. Validate your license in settings.');
         }
       } else if (provider === 'custom') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ import type { CommandManager } from "./core/plugin/commands";
 import { setLogLevel } from "./utils/errorHandling";
 import { errorLogger } from "./utils/errorLogger";
 import { UnifiedModelService } from "./services/providers/UnifiedModelService";
+import { EntitlementService } from "./services/entitlement/EntitlementService";
 import { DirectoryManager } from "./core/DirectoryManager";
 import { VersionCheckerService } from "./services/VersionCheckerService";
 import { FavoritesService } from "./services/FavoritesService";
@@ -120,6 +121,7 @@ export default class SystemSculptPlugin extends Plugin {
   private commandManager: CommandManager;
   private fileContextMenuService: FileContextMenuService | null = null;
   private _modelService: UnifiedModelService | undefined;
+  private _entitlementService: EntitlementService | null = null;
   private isUnloading = false;
   private isPreloadingDone = false;
   private failures: string[] = [];
@@ -2346,6 +2348,15 @@ export default class SystemSculptPlugin extends Plugin {
 
   getLicenseManager(): LicenseManager {
     return this.licenseManager;
+  }
+
+  /**
+   * The single owner of gating decisions (chat/embeddings/recorder) — #209.
+   * Stateless and memoized: it reads live settings, so callers never hold a
+   * stale license view. UI must ask this instead of inlining license checks.
+   */
+  getEntitlementService(): EntitlementService {
+    return (this._entitlementService ??= new EntitlementService(this));
   }
 
   getSettingsManager(): SettingsManager {

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -1879,7 +1879,7 @@ export class TranscriptionService {
 
       if (
         provider === "systemsculpt" &&
-        (!this.plugin.settings.licenseKey || !this.plugin.settings.licenseValid)
+        !this.plugin.getEntitlementService().canUseTranscription(provider)
       ) {
         throw new Error(
           "A valid SystemSculpt license is required to use the SystemSculpt API for transcription. Please enter a valid license key or switch to a custom transcription provider in the settings."

--- a/src/services/__tests__/EmbeddingsManager.monitoring.test.ts
+++ b/src/services/__tests__/EmbeddingsManager.monitoring.test.ts
@@ -52,6 +52,7 @@ jest.mock('../../core/ui/notifications', () => ({
 }));
 
 import { EmbeddingsManager } from '../embeddings/EmbeddingsManager';
+import { EntitlementService } from '../entitlement/EntitlementService';
 import { EmbeddingsProviderError } from '../embeddings/providers/ProviderError';
 import { DEFAULT_EMBEDDING_DIMENSION } from '../../constants/embeddings';
 
@@ -103,6 +104,7 @@ function createPluginStub() {
     settings,
     app,
     getSettingsManager: jest.fn(() => settingsManager),
+    getEntitlementService: () => new EntitlementService({ settings } as any),
   };
 }
 

--- a/src/services/__tests__/TranscriptionService.test.ts
+++ b/src/services/__tests__/TranscriptionService.test.ts
@@ -68,6 +68,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PlatformContext } from "../PlatformContext";
+import { EntitlementService } from "../entitlement/EntitlementService";
 import { TranscriptionService } from "../TranscriptionService";
 import { AUDIO_UPLOAD_MAX_BYTES } from "../../constants/uploadLimits";
 
@@ -100,6 +101,7 @@ describe("TranscriptionService", () => {
       },
       directoryManager: null,
     };
+    mockPlugin.getEntitlementService = () => new EntitlementService(mockPlugin);
 
     // Reset singleton for each test
     (TranscriptionService as any).instance = undefined;

--- a/src/services/embeddings/EmbeddingsManager.ts
+++ b/src/services/embeddings/EmbeddingsManager.ts
@@ -1593,8 +1593,9 @@ export class EmbeddingsManager {
       const model = (p.customModel || p.model || '').trim();
       return !!endpoint && !!model;
     }
-    // For SystemSculpt, require license key
-    return !!this.plugin.settings.licenseKey?.trim() && this.plugin.settings.licenseValid === true;
+    // SystemSculpt-hosted embeddings require an active license — decided by the
+    // single entitlement owner (#209), never an inline license check here.
+    return this.plugin.getEntitlementService().canUseEmbeddings(p.providerId);
   }
 
   private async processFile(file: TFile, reason: 'modify' | 'create' | 'rename' | 'manual' | 'auto' = 'manual'): Promise<void> {

--- a/src/services/entitlement/EntitlementService.ts
+++ b/src/services/entitlement/EntitlementService.ts
@@ -1,0 +1,111 @@
+import type SystemSculptPlugin from "../../main";
+import { ensureCanonicalId } from "../../utils/modelUtils";
+import {
+  getManagedSystemSculptModelId,
+  hasActiveSystemSculptLicense,
+  isManagedSystemSculptModelId,
+} from "../systemsculpt/ManagedSystemSculptModel";
+import {
+  listConfiguredRemoteProviderModels,
+  normalizeProviderId,
+} from "../providerRuntime/RemoteProviderCatalog";
+
+export type ChatEntitlementReason = "license";
+
+export type ChatEntitlement = {
+  allowed: boolean;
+  /** Why chat is blocked, when it is. Drives messaging, never the wall itself. */
+  reason?: ChatEntitlementReason;
+};
+
+/**
+ * Single owner of every gating decision (issue #209): chat, embeddings, and
+ * recorder/transcription. UI components must consult this service instead of
+ * inlining `licenseKey && licenseValid` or deciding "the managed model needs a
+ * license" themselves — that scattering is exactly what made a BYOK user with a
+ * working custom provider hit a SystemSculpt license wall on Chat (the May 2026
+ * report) just because the managed model happened to be the default selection.
+ *
+ * Stateless by design: every method reads the live plugin settings, so a
+ * license that validates mid-session — or a provider key added in Settings —
+ * takes effect on the very next call without cache invalidation.
+ */
+export class EntitlementService {
+  constructor(private readonly plugin: Pick<SystemSculptPlugin, "settings">) {}
+
+  /** The one true SystemSculpt-license predicate. */
+  hasSystemSculptLicense(): boolean {
+    return hasActiveSystemSculptLicense(this.plugin);
+  }
+
+  /**
+   * Custom-provider (BYOK) seed model ids the user can actually use right now —
+   * i.e. a provider configured with an API key and not disabled. This is the
+   * same signal the #201 catalog guard locks, so "the user is a BYOK user" has
+   * exactly one definition across the plugin.
+   */
+  listUsableCustomProviderModelIds(): string[] {
+    return listConfiguredRemoteProviderModels(this.plugin as SystemSculptPlugin).map(
+      (model) => model.id,
+    );
+  }
+
+  hasUsableCustomProviderModel(): boolean {
+    return this.listUsableCustomProviderModelIds().length > 0;
+  }
+
+  /** The managed model needs a license; every BYOK/custom/local model is always usable. */
+  canUseModel(modelId?: string | null): boolean {
+    return isManagedSystemSculptModelId(modelId) ? this.hasSystemSculptLicense() : true;
+  }
+
+  /**
+   * The model chat should actually run on. A BYOK user with no license is never
+   * forced onto the license-walled managed model: when the (selected or default)
+   * model is the managed one, there is no license, and a custom provider IS
+   * configured, this resolves to that custom model instead. Otherwise it returns
+   * the normal effective id. Pure — never mutates the stored selection (the
+   * persisted default stays the managed model, per the #215 bundle-load guard).
+   */
+  resolveDefaultModel(selectedModelId?: string | null, fallbackModelId?: string | null): string {
+    // Mirror getEffectiveChatModelId without importing it (avoids a chatview <-> service cycle).
+    const effectiveId =
+      ensureCanonicalId(String(selectedModelId || "").trim()) ||
+      ensureCanonicalId(String(fallbackModelId || "").trim()) ||
+      getManagedSystemSculptModelId();
+
+    if (isManagedSystemSculptModelId(effectiveId) && !this.hasSystemSculptLicense()) {
+      const [alternative] = this.listUsableCustomProviderModelIds();
+      if (alternative) {
+        return alternative;
+      }
+    }
+    return effectiveId;
+  }
+
+  /**
+   * Entitlement for chat with the current selection. The BYOK fallback is
+   * resolved first, so a user with a working custom provider is always `allowed`
+   * and never sees a license wall. The only blocked case is a user with NO
+   * license AND no custom provider — for whom activating a license (or adding a
+   * provider) is the genuine fix.
+   */
+  canUseChat(selectedModelId?: string | null, fallbackModelId?: string | null): ChatEntitlement {
+    const effectiveId = this.resolveDefaultModel(selectedModelId, fallbackModelId);
+    return this.canUseModel(effectiveId) ? { allowed: true } : { allowed: false, reason: "license" };
+  }
+
+  /** Embeddings: the managed/systemsculpt provider needs a license; custom providers never do. */
+  canUseEmbeddings(providerId?: string | null): boolean {
+    return this.providerNeedsLicense(providerId) ? this.hasSystemSculptLicense() : true;
+  }
+
+  /** Transcription/recorder: same rule — only the systemsculpt provider needs a license. */
+  canUseTranscription(providerId?: string | null): boolean {
+    return this.providerNeedsLicense(providerId) ? this.hasSystemSculptLicense() : true;
+  }
+
+  private providerNeedsLicense(providerId?: string | null): boolean {
+    return normalizeProviderId(providerId) === "systemsculpt";
+  }
+}

--- a/src/services/entitlement/__tests__/EntitlementService.test.ts
+++ b/src/services/entitlement/__tests__/EntitlementService.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Issue #209 — the entitlement/gating service is the single owner of every
+ * gating decision (chat, embeddings, recorder/transcription). UI must never
+ * inline `licenseKey && licenseValid` or decide "managed needs a license"
+ * itself — it asks this service.
+ *
+ * The load-bearing behavior the bug report (May 2026) demanded: a BYOK user
+ * with a working custom provider and NO SystemSculpt license must never be
+ * walled out of chat just because the managed model is the selected/default
+ * one. The matrix below locks that: license × custom-providers × selected-model
+ * × feature.
+ */
+import { EntitlementService } from "../EntitlementService";
+import { SYSTEMSCULPT_PI_CANONICAL_MODEL_ID } from "../../pi/PiCanonicalIds";
+import { createCanonicalId } from "../../../utils/modelUtils";
+
+const MANAGED_ID = SYSTEMSCULPT_PI_CANONICAL_MODEL_ID;
+const OPENROUTER_ID = createCanonicalId("openrouter", "openai/gpt-5.4-mini");
+
+const KEYED_OPENROUTER = [
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    endpoint: "https://openrouter.ai/api/v1",
+    apiKey: "fixture-key",
+    isEnabled: true,
+  },
+];
+
+type StubConfig = {
+  licenseKey?: string;
+  licenseValid?: boolean;
+  customProviders?: unknown[];
+};
+
+function entitlement(config: StubConfig = {}): EntitlementService {
+  const plugin = {
+    settings: {
+      licenseKey: config.licenseKey ?? "",
+      licenseValid: config.licenseValid ?? false,
+      customProviders: config.customProviders ?? [],
+    },
+  } as never;
+  return new EntitlementService(plugin);
+}
+
+const LICENSED = { licenseKey: "valid-key", licenseValid: true } as const;
+
+describe("EntitlementService — license source of truth", () => {
+  it("holds a license only when key is non-empty AND licenseValid is true", () => {
+    expect(entitlement(LICENSED).hasSystemSculptLicense()).toBe(true);
+    expect(entitlement({ licenseKey: "  ", licenseValid: true }).hasSystemSculptLicense()).toBe(false);
+    expect(entitlement({ licenseKey: "k", licenseValid: false }).hasSystemSculptLicense()).toBe(false);
+    expect(entitlement({}).hasSystemSculptLicense()).toBe(false);
+  });
+});
+
+describe("EntitlementService — custom provider availability", () => {
+  it("reports a usable custom-provider model only when one is keyed and enabled", () => {
+    expect(entitlement({ customProviders: KEYED_OPENROUTER }).hasUsableCustomProviderModel()).toBe(true);
+    expect(entitlement({}).hasUsableCustomProviderModel()).toBe(false);
+    expect(
+      entitlement({ customProviders: [{ id: "openrouter", apiKey: "", isEnabled: true }] }).hasUsableCustomProviderModel(),
+    ).toBe(false);
+    expect(
+      entitlement({ customProviders: [{ id: "openrouter", apiKey: "k", isEnabled: false }] }).hasUsableCustomProviderModel(),
+    ).toBe(false);
+  });
+
+  it("lists the configured custom-provider model ids", () => {
+    expect(entitlement({ customProviders: KEYED_OPENROUTER }).listUsableCustomProviderModelIds()).toContain(
+      OPENROUTER_ID,
+    );
+    expect(entitlement({}).listUsableCustomProviderModelIds()).toEqual([]);
+  });
+});
+
+describe("EntitlementService — canUseModel", () => {
+  it("requires a license for the managed model, never for custom/BYOK models", () => {
+    expect(entitlement(LICENSED).canUseModel(MANAGED_ID)).toBe(true);
+    expect(entitlement({}).canUseModel(MANAGED_ID)).toBe(false);
+    // Custom/BYOK model is always usable regardless of license.
+    expect(entitlement({}).canUseModel(OPENROUTER_ID)).toBe(true);
+    expect(entitlement(LICENSED).canUseModel(OPENROUTER_ID)).toBe(true);
+  });
+});
+
+describe("EntitlementService — resolveDefaultModel (BYOK fallback)", () => {
+  it("keeps the managed model when licensed", () => {
+    expect(entitlement({ ...LICENSED, customProviders: KEYED_OPENROUTER }).resolveDefaultModel(MANAGED_ID)).toBe(
+      MANAGED_ID,
+    );
+  });
+
+  it("falls back to a custom-provider model when managed is selected, no license, and a custom provider exists", () => {
+    expect(
+      entitlement({ customProviders: KEYED_OPENROUTER }).resolveDefaultModel(MANAGED_ID),
+    ).toBe(OPENROUTER_ID);
+  });
+
+  it("stays on the managed model when there is no license AND no custom provider (license wall is then correct)", () => {
+    expect(entitlement({}).resolveDefaultModel(MANAGED_ID)).toBe(MANAGED_ID);
+  });
+
+  it("never rewrites an explicit custom selection", () => {
+    expect(entitlement({ customProviders: KEYED_OPENROUTER }).resolveDefaultModel(OPENROUTER_ID)).toBe(OPENROUTER_ID);
+  });
+
+  it("resolves the managed default for an empty selection (parity with getEffectiveChatModelId)", () => {
+    expect(entitlement({}).resolveDefaultModel("")).toBe(MANAGED_ID);
+    expect(entitlement({}).resolveDefaultModel(null, null)).toBe(MANAGED_ID);
+  });
+});
+
+describe("EntitlementService — canUseChat (the bug surface)", () => {
+  it("allows chat for a licensed user on the managed model", () => {
+    expect(entitlement(LICENSED).canUseChat(MANAGED_ID).allowed).toBe(true);
+  });
+
+  it("allows a BYOK-no-license user to chat (resolved onto their custom model) — NEVER a license wall", () => {
+    const result = entitlement({ customProviders: KEYED_OPENROUTER }).canUseChat(MANAGED_ID);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks only when there is no license AND no custom alternative", () => {
+    const result = entitlement({}).canUseChat(MANAGED_ID);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("license");
+  });
+
+  it("allows chat on an explicit custom model regardless of license", () => {
+    expect(entitlement({ customProviders: KEYED_OPENROUTER }).canUseChat(OPENROUTER_ID).allowed).toBe(true);
+  });
+});
+
+describe("EntitlementService — feature gates (embeddings, transcription)", () => {
+  it("gates the managed/systemsculpt provider on a license but never a custom provider", () => {
+    expect(entitlement(LICENSED).canUseEmbeddings("systemsculpt")).toBe(true);
+    expect(entitlement({}).canUseEmbeddings("systemsculpt")).toBe(false);
+    expect(entitlement({}).canUseEmbeddings("openai")).toBe(true);
+
+    expect(entitlement(LICENSED).canUseTranscription("systemsculpt")).toBe(true);
+    expect(entitlement({}).canUseTranscription("systemsculpt")).toBe(false);
+    expect(entitlement({}).canUseTranscription("openai")).toBe(true);
+  });
+});

--- a/src/services/systemsculpt/ManagedSystemSculptModel.ts
+++ b/src/services/systemsculpt/ManagedSystemSculptModel.ts
@@ -7,7 +7,13 @@ import {
   type ManagedSystemSculptModelContract,
 } from "./ManagedSystemSculptContract";
 
-function hasActiveSystemSculptLicense(plugin: Pick<SystemSculptPlugin, "settings">): boolean {
+/**
+ * The single low-level SystemSculpt-license primitive: a license is held only
+ * when the key is non-empty AND the server marked it valid. Composite gating
+ * decisions live in EntitlementService (#209); this is the one boolean it (and
+ * the managed-access helper below) reads, so the predicate has exactly one home.
+ */
+export function hasActiveSystemSculptLicense(plugin: Pick<SystemSculptPlugin, "settings">): boolean {
   const settings = plugin?.settings || {};
   return !!(String(settings.licenseKey || "").trim() && settings.licenseValid === true);
 }

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -36,7 +36,6 @@ import { resolveProviderLabel } from "../../studio/piAuth/StudioPiProviderRegist
 import { PlatformContext } from "../../services/PlatformContext";
 import {
   getManagedSystemSculptModelId,
-  hasManagedSystemSculptAccess,
   isManagedSystemSculptModelId,
 } from "../../services/systemsculpt/ManagedSystemSculptModel";
 import {
@@ -57,7 +56,6 @@ import { renderChatStatusSurface } from "./ui/ChatStatusSurface";
 import {
   getChatModelDisplayName,
   getChatModelSetupSurface,
-  getEffectiveChatModelId,
   openChatModelSetupTab,
   promptChatModelSetup,
   type ChatModelSetupPromptOverrides,
@@ -865,8 +863,7 @@ export class ChatView extends ItemView {
   }
 
   public async refreshCreditsBalance(): Promise<void> {
-    const isProActive =
-      !!(this.plugin.settings.licenseValid === true && this.plugin.settings.licenseKey?.trim());
+    const isProActive = this.plugin.getEntitlementService().hasSystemSculptLicense();
 
     if (!isProActive) {
       this.creditsBalance = null;
@@ -911,7 +908,13 @@ export class ChatView extends ItemView {
   }
 
   public hasConfiguredProvider(): boolean {
-    return this.isManagedSelectedModel() ? hasManagedSystemSculptAccess(this.plugin) : true;
+    // Ask the single entitlement owner (#209) rather than checking license here.
+    // For a BYOK user with a configured custom provider this is always true —
+    // resolveDefaultModel keeps them off the license-walled managed model — so
+    // they never hit a SystemSculpt setup wall in chat.
+    return this.plugin
+      .getEntitlementService()
+      .canUseChat(this.selectedModelId, this.plugin.settings.selectedModelId).allowed;
   }
 
   public openSetupTab(targetTab: ChatModelSetupTab = "account"): void {
@@ -924,7 +927,13 @@ export class ChatView extends ItemView {
   }
 
   public getEffectiveSelectedModelId(): string {
-    return getEffectiveChatModelId(this.selectedModelId, this.plugin.settings.selectedModelId);
+    // The model chat actually runs on, accounting for entitlement (#209): a BYOK
+    // user with no license is resolved onto their configured custom model rather
+    // than the license-walled managed default. The stored selection is left
+    // untouched, so activating a license restores the managed model.
+    return this.plugin
+      .getEntitlementService()
+      .resolveDefaultModel(this.selectedModelId, this.plugin.settings.selectedModelId);
   }
 
   public isManagedSelectedModel(): boolean {

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -310,7 +310,7 @@ export class ChatView extends ItemView {
         this.chatId,
         this.messages,
         {
-          selectedModelId: this.getEffectiveSelectedModelId(),
+          selectedModelId: this.getPersistedSelectedModelId(),
           contextFiles: this.contextManager?.getContextFiles() || new Set(),
           title: this.chatTitle,
           chatFontSize: this.chatFontSize,
@@ -936,6 +936,21 @@ export class ChatView extends ItemView {
       .resolveDefaultModel(this.selectedModelId, this.plugin.settings.selectedModelId);
   }
 
+  /**
+   * The user's actual stored selection, WITHOUT entitlement resolution — for
+   * persistence only (chat file + leaf state). Persisting the entitlement-
+   * resolved value would let a no-license BYOK user's runtime fallback overwrite
+   * their managed selection, so it would not come back after a license is
+   * activated (#209). Runtime execution/gating uses getEffectiveSelectedModelId.
+   */
+  private getPersistedSelectedModelId(): string {
+    return (
+      ensureCanonicalId(String(this.selectedModelId || "").trim()) ||
+      ensureCanonicalId(String(this.plugin.settings.selectedModelId || "").trim()) ||
+      getManagedSystemSculptModelId()
+    );
+  }
+
   public isManagedSelectedModel(): boolean {
     return isManagedSystemSculptModelId(this.getEffectiveSelectedModelId());
   }
@@ -1402,7 +1417,7 @@ export class ChatView extends ItemView {
     return {
       chatId: this.chatId,
       chatTitle: this.chatTitle,
-      selectedModelId: this.getEffectiveSelectedModelId(),
+      selectedModelId: this.getPersistedSelectedModelId(),
       version: this.chatVersion,
       chatFontSize: this.chatFontSize,
       chatBackend: this.chatBackend,

--- a/src/views/chatview/__tests__/chatview-model-migration.test.ts
+++ b/src/views/chatview/__tests__/chatview-model-migration.test.ts
@@ -6,6 +6,7 @@ import { App, WorkspaceLeaf } from "obsidian";
 import { SystemSculptService } from "../../../services/SystemSculptService";
 import { PlatformContext } from "../../../services/PlatformContext";
 import { ChatView } from "../ChatView";
+import { EntitlementService } from "../../../services/entitlement/EntitlementService";
 
 describe("ChatView loaded model migration", () => {
   beforeEach(() => {
@@ -49,6 +50,7 @@ describe("ChatView loaded model migration", () => {
         updateSettings: jest.fn().mockResolvedValue(undefined),
       })),
     };
+    plugin.getEntitlementService = () => new EntitlementService(plugin);
 
     return new ChatView(leaf as any, plugin);
   }

--- a/src/views/chatview/__tests__/empty-chat-status.test.ts
+++ b/src/views/chatview/__tests__/empty-chat-status.test.ts
@@ -196,6 +196,30 @@ describe("ChatView empty chat status", () => {
     expect(actionLabels).toContain("Add Context");
   });
 
+  it("persists the user's real selection, not the BYOK runtime fallback, into leaf state (#209)", () => {
+    const chatView = createChatView({
+      selectedModelId: "systemsculpt@@systemsculpt/ai-agent",
+      licenseKey: "",
+      licenseValid: false,
+      customProviders: [
+        {
+          id: "openrouter",
+          name: "OpenRouter",
+          endpoint: "https://openrouter.ai/api/v1",
+          apiKey: "byok-key",
+          isEnabled: true,
+        },
+      ],
+    });
+
+    // Runtime resolves onto the BYOK model so chat actually works...
+    expect(chatView.getEffectiveSelectedModelId()).not.toBe("systemsculpt@@systemsculpt/ai-agent");
+
+    // ...but persisted leaf state keeps the user's actual selection, so adding a
+    // license later restores the managed model instead of sticking on the fallback.
+    expect(chatView.getState().selectedModelId).toBe("systemsculpt@@systemsculpt/ai-agent");
+  });
+
   it("keeps local Pi chats on a local-ready state instead of redirecting to Account copy", () => {
     const chatView = createChatView({
       selectedModelId: "local-pi-openai@@gpt-4.1",

--- a/src/views/chatview/__tests__/empty-chat-status.test.ts
+++ b/src/views/chatview/__tests__/empty-chat-status.test.ts
@@ -4,6 +4,7 @@
 
 import { App, WorkspaceLeaf } from "obsidian";
 import { SystemSculptService } from "../../../services/SystemSculptService";
+import { EntitlementService } from "../../../services/entitlement/EntitlementService";
 import { ChatView } from "../ChatView";
 
 describe("ChatView empty chat status", () => {
@@ -25,6 +26,7 @@ describe("ChatView empty chat status", () => {
     cachedModels?: Array<{ id: string }>;
     licenseKey?: string;
     licenseValid?: boolean;
+    customProviders?: Array<Record<string, unknown>>;
   }) => {
     const app = new App();
     const leaf = new WorkspaceLeaf(app);
@@ -45,7 +47,7 @@ describe("ChatView empty chat status", () => {
         chatFontSize: "medium",
         respectReducedMotion: false,
         activeProvider: { type: "native", id: "systemsculpt" },
-        customProviders: [],
+        customProviders: options?.customProviders ?? [],
         mcpServers: [],
       },
       modelService: {
@@ -53,6 +55,8 @@ describe("ChatView empty chat status", () => {
       },
       openSettingsTab: jest.fn(),
     };
+    // The real entitlement service (#209) drives the gating decisions under test.
+    plugin.getEntitlementService = () => new EntitlementService(plugin);
 
     const chatView = new ChatView(leaf as any, plugin);
     chatView.chatContainer = document.createElement("div");
@@ -151,6 +155,45 @@ describe("ChatView empty chat status", () => {
     expectNoStandalonePiCopy(statusText);
     expect(actionLabels).toContain("Open Account");
     expect(actionLabels).toHaveLength(1);
+  });
+
+  it("never walls a BYOK user with a configured custom provider, even with no license (#209)", () => {
+    // The May 2026 bug: a BYOK user (own OpenRouter key, no SystemSculpt
+    // license) was blocked from Chat by a license prompt purely because the
+    // managed model was the default selection. Same no-license inputs as the
+    // test above, but WITH a configured custom provider — they must land on a
+    // ready state, never the "Setup required" / "Open Account" wall.
+    const chatView = createChatView({
+      selectedModelId: "systemsculpt@@systemsculpt/ai-agent",
+      cachedModels: [],
+      licenseKey: "",
+      licenseValid: false,
+      customProviders: [
+        {
+          id: "openrouter",
+          name: "OpenRouter",
+          endpoint: "https://openrouter.ai/api/v1",
+          apiKey: "byok-key",
+          isEnabled: true,
+        },
+      ],
+    });
+
+    chatView.displayChatStatus();
+
+    const statusText = chatView.chatContainer.textContent || "";
+    const actionLabels = Array.from(
+      chatView.chatContainer.querySelectorAll(".systemsculpt-chat-status-action-label")
+    ).map((el) => el.textContent?.trim());
+
+    expect(statusText).not.toContain("Finish setup");
+    expect(statusText).not.toContain("Setup required");
+    expect(statusText).not.toContain("Add and validate your SystemSculpt license");
+    expect(actionLabels).not.toContain("Open Account");
+    // Lands on the normal ready state with the usual primary action.
+    expect(statusText).toContain("New chat");
+    expect(statusText).toContain("Ready");
+    expect(actionLabels).toContain("Add Context");
   });
 
   it("keeps local Pi chats on a local-ready state instead of redirecting to Account copy", () => {

--- a/testing/integration/entitlement-byok.test.ts
+++ b/testing/integration/entitlement-byok.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Issue #209 — integration guard. A BYOK-only user (a configured custom
+ * provider, NO SystemSculpt license) must get a working chat model and never be
+ * gated by a license, proven end-to-end across the REAL model catalog (#201)
+ * and the entitlement service together — not just in isolated unit mocks. This
+ * is the "completes a chat without ever seeing a license prompt" acceptance,
+ * verified at the integration layer (no Obsidian host, no secrets).
+ *
+ * Platform flags are forced to mobile for determinism, mirroring the #201
+ * provider-listing guard: the desktop-only catalog branch scans local Pi auth
+ * on the host, which is not reproducible in CI. The managed + remote-seed paths
+ * exercised here are platform-independent.
+ */
+import { Platform } from "obsidian";
+
+import { listPiTextCatalogModels } from "src/services/pi-native/PiTextCatalog";
+import { EntitlementService } from "src/services/entitlement/EntitlementService";
+import { SYSTEMSCULPT_PI_CANONICAL_MODEL_ID } from "src/services/pi/PiCanonicalIds";
+import { createCanonicalId } from "src/utils/modelUtils";
+
+const MANAGED_ID = SYSTEMSCULPT_PI_CANONICAL_MODEL_ID;
+const OPENROUTER_SEED_MODEL_ID = createCanonicalId("openrouter", "openai/gpt-5.4-mini");
+
+const KEYED_OPENROUTER = [
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    endpoint: "https://openrouter.ai/api/v1",
+    apiKey: "fixture-key",
+    isEnabled: true,
+  },
+];
+
+function buildPluginStub(opts: {
+  licenseKey?: string;
+  licenseValid?: boolean;
+  customProviders?: unknown[];
+}) {
+  return {
+    settings: {
+      // The shipped default selection is always the managed model (#215 guard).
+      selectedModelId: MANAGED_ID,
+      licenseKey: opts.licenseKey ?? "",
+      licenseValid: opts.licenseValid ?? false,
+      customProviders: opts.customProviders ?? [],
+    },
+    manifest: { version: "0.0.0" },
+    getLogger: () => ({ warn() {}, info() {}, error() {} }),
+  } as never;
+}
+
+describe("entitlement BYOK chat (#209 integration guard)", () => {
+  const platformAny = Platform as unknown as Record<string, boolean>;
+  let savedFlags: Record<string, boolean>;
+
+  beforeAll(() => {
+    savedFlags = { ...platformAny };
+    platformAny.isDesktop = false;
+    platformAny.isDesktopApp = false;
+    platformAny.isMobile = true;
+    platformAny.isMobileApp = true;
+  });
+
+  afterAll(() => {
+    Object.assign(platformAny, savedFlags);
+  });
+
+  it("resolves a no-license BYOK user onto their custom model and allows chat (no license wall)", async () => {
+    const plugin = buildPluginStub({ customProviders: KEYED_OPENROUTER });
+    const entitlement = new EntitlementService(plugin);
+
+    // No SystemSculpt license — but a keyed custom provider IS configured.
+    expect(entitlement.hasSystemSculptLicense()).toBe(false);
+
+    // The managed default is NOT forced on them: chat resolves onto their BYOK model.
+    const resolved = entitlement.resolveDefaultModel(MANAGED_ID, MANAGED_ID);
+    expect(resolved).toBe(OPENROUTER_SEED_MODEL_ID);
+
+    // Chat is allowed end-to-end — the user never hits a license prompt.
+    expect(entitlement.canUseChat(MANAGED_ID, MANAGED_ID).allowed).toBe(true);
+
+    // Cohesion with the real catalog: the resolved fallback is a model the
+    // dropdown actually lists, not a phantom id.
+    const catalog = await listPiTextCatalogModels(plugin);
+    expect(catalog.map((model) => model.id)).toContain(resolved);
+  });
+
+  it("keeps a user with no license AND no custom provider on managed, blocked (the wall is then correct)", () => {
+    const plugin = buildPluginStub({});
+    const entitlement = new EntitlementService(plugin);
+
+    expect(entitlement.resolveDefaultModel(MANAGED_ID, MANAGED_ID)).toBe(MANAGED_ID);
+    const chat = entitlement.canUseChat(MANAGED_ID, MANAGED_ID);
+    expect(chat.allowed).toBe(false);
+    expect(chat.reason).toBe("license");
+  });
+});


### PR DESCRIPTION
Fixes #209.

- A single `EntitlementService` owns gating decisions (chat / embeddings / recorder); UI components no longer inline `licenseKey && licenseValid`.
- A no-license BYOK user with a configured custom provider is resolved onto their own model instead of the license-walled managed default — chat works without ever showing a SystemSculpt setup prompt. The stored default stays the managed model, so activating a license restores it.
- Guarded failing-test-first: the entitlement matrix (license × custom-providers × selected-model × feature), a ChatView empty-state contrast (no-license wall vs BYOK ready-state), and a built-bundle integration test (BYOK chat resolves to a real catalog model, no prompt).

Follow-up: remaining display-only license reads (Pro badges, mic affordance, settings tabs) can adopt the service incrementally — they gate affordances, not the chat wall.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BYOK/custom providers can now be used without an active SystemSculpt license, allowing chat, embeddings, and transcription.
  * Improved entitlement-based licensing behavior with automatic model/provider fallback when needed.
  * Chat selection persistence remains stable even when entitlement-driven fallback occurs.
* **Bug Fixes**
  * Embeddings and transcription access now follow the same entitlement logic as chat.
* **Tests**
  * Added unit and integration test coverage to validate entitlement, provider fallback, and gating outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->