### PR TITLE
Rework: versioned settings migration + update safety (#212)

### DIFF
--- a/src/__tests__/main-safe-mode.test.ts
+++ b/src/__tests__/main-safe-mode.test.ts
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+
+import { App } from "obsidian";
+import SystemSculptPlugin from "../main";
+
+const createTracer = () => ({
+  startPhase: jest.fn(() => ({ complete: jest.fn(), fail: jest.fn() })),
+  markMilestone: jest.fn(),
+  flushOpenPhases: jest.fn(),
+});
+
+const createLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  setLogFileName: jest.fn(),
+});
+
+function makePlugin(): any {
+  const app = new App();
+  (app as any).vault = { configDir: ".obsidian", adapter: {} };
+  const plugin = new SystemSculptPlugin(app, {
+    id: "systemsculpt-ai",
+    version: "1.0.0",
+  } as any);
+  jest.spyOn(plugin as any, "getInitializationTracer").mockReturnValue(createTracer());
+  jest.spyOn(plugin, "getLogger").mockReturnValue(createLogger() as any);
+  return plugin;
+}
+
+describe("SystemSculptPlugin safe mode + version gate (#212)", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("enterSafeMode flips the flag and registers a single recovery command (idempotent)", () => {
+    const plugin = makePlugin();
+
+    plugin.enterSafeMode("core initialization failed");
+
+    expect(plugin.safeMode).toBe(true);
+    const recovery = plugin._commands.filter(
+      (c: { id: string }) => c.id === "systemsculpt-show-load-diagnostics"
+    );
+    expect(recovery).toHaveLength(1);
+    expect(recovery[0].name).toMatch(/safe mode/i);
+
+    // A second fatal report must not double-register the command.
+    plugin.enterSafeMode("again");
+    expect(
+      plugin._commands.filter((c: { id: string }) => c.id === "systemsculpt-show-load-diagnostics")
+    ).toHaveLength(1);
+  });
+
+  it("does not flag a supported Obsidian version (fail-soft no-op)", () => {
+    const plugin = makePlugin();
+    // The obsidian mock reports apiVersion 1.5.0 (>= minimum).
+    plugin.warnIfObsidianVersionUnsupported();
+    expect(plugin.failures).not.toContain("unsupported Obsidian version");
+  });
+
+  it("onload enters safe mode (and never rethrows) when core initialization throws (#183)", async () => {
+    const plugin = makePlugin();
+    jest.spyOn(plugin as any, "writeMobileStartupProbe").mockResolvedValue(undefined);
+    jest.spyOn(plugin as any, "configureLifecycle").mockImplementation(() => {
+      throw new Error("simulated fatal init failure");
+    });
+
+    // Must resolve, not reject — a fatal init can never bubble to Obsidian's
+    // "Failed to load plugin"; it degrades to safe mode instead.
+    await expect(plugin.onload()).resolves.toBeUndefined();
+
+    expect(plugin.safeMode).toBe(true);
+    expect(plugin._commands.map((c: { id: string }) => c.id)).toContain(
+      "systemsculpt-show-load-diagnostics"
+    );
+  });
+});

--- a/src/__tests__/main-safe-mode.test.ts
+++ b/src/__tests__/main-safe-mode.test.ts
@@ -58,6 +58,14 @@ describe("SystemSculptPlugin safe mode + version gate (#212)", () => {
     expect(plugin.failures).not.toContain("unsupported Obsidian version");
   });
 
+  it("flags an unsupported Obsidian version, failing soft without throwing (#212/#147)", () => {
+    const plugin = makePlugin();
+    jest.spyOn(plugin, "getObsidianApiVersion").mockReturnValue("1.0.0");
+
+    expect(() => plugin.warnIfObsidianVersionUnsupported()).not.toThrow();
+    expect(plugin.failures).toContain("unsupported Obsidian version");
+  });
+
   it("onload enters safe mode (and never rethrows) when core initialization throws (#183)", async () => {
     const plugin = makePlugin();
     jest.spyOn(plugin as any, "writeMobileStartupProbe").mockResolvedValue(undefined);

--- a/src/core/plugin/lifecycle/ObsidianCompat.ts
+++ b/src/core/plugin/lifecycle/ObsidianCompat.ts
@@ -1,0 +1,36 @@
+import { compareNumericVersions, parseNumericVersion } from "../../../utils/semver";
+
+/**
+ * Minimum Obsidian version SystemSculpt is verified against at runtime. Keep in
+ * sync with manifest.json's `minAppVersion`. Obsidian enforces minAppVersion at
+ * install time, but a user who side-loads or force-enables on an older build can
+ * still reach onload — this gate lets us fail SOFT with a clear message instead
+ * of crashing on a missing newer API (#147/#212).
+ */
+export const MINIMUM_OBSIDIAN_VERSION = "1.4.0";
+
+export interface ObsidianCompatResult {
+  supported: boolean;
+  currentVersion: string;
+  minimumVersion: string;
+}
+
+/**
+ * Fail-soft Obsidian version check. An unknown/unparseable current version is
+ * treated as SUPPORTED — we never block the user on a version we cannot read,
+ * only on one we can read and that is genuinely too old.
+ */
+export function checkObsidianCompatibility(
+  currentVersion: string | undefined | null,
+  minimumVersion: string = MINIMUM_OBSIDIAN_VERSION,
+): ObsidianCompatResult {
+  const current = typeof currentVersion === "string" ? currentVersion : "";
+  if (!parseNumericVersion(current)) {
+    return { supported: true, currentVersion: current, minimumVersion };
+  }
+  return {
+    supported: compareNumericVersions(current, minimumVersion) >= 0,
+    currentVersion: current,
+    minimumVersion,
+  };
+}

--- a/src/core/plugin/lifecycle/__tests__/ObsidianCompat.test.ts
+++ b/src/core/plugin/lifecycle/__tests__/ObsidianCompat.test.ts
@@ -1,0 +1,34 @@
+import { checkObsidianCompatibility, MINIMUM_OBSIDIAN_VERSION } from "../ObsidianCompat";
+
+describe("checkObsidianCompatibility (#212 min-version fail-soft)", () => {
+  it("supports a current version at or above the minimum", () => {
+    expect(checkObsidianCompatibility("1.4.0").supported).toBe(true);
+    expect(checkObsidianCompatibility("1.5.0").supported).toBe(true);
+    expect(checkObsidianCompatibility("2.0.0").supported).toBe(true);
+  });
+
+  it("rejects a current version below the minimum", () => {
+    expect(checkObsidianCompatibility("1.3.9").supported).toBe(false);
+    expect(checkObsidianCompatibility("1.0.0").supported).toBe(false);
+    expect(checkObsidianCompatibility("0.15.9").supported).toBe(false);
+  });
+
+  it("fails soft — an unknown/unreadable version is treated as supported", () => {
+    // We never block on a version we cannot parse (e.g. apiVersion missing on a host).
+    expect(checkObsidianCompatibility(undefined).supported).toBe(true);
+    expect(checkObsidianCompatibility(null).supported).toBe(true);
+    expect(checkObsidianCompatibility("").supported).toBe(true);
+    expect(checkObsidianCompatibility("unknown").supported).toBe(true);
+  });
+
+  it("honors a custom minimum and reports both versions", () => {
+    const result = checkObsidianCompatibility("1.5.0", "1.6.0");
+    expect(result.supported).toBe(false);
+    expect(result.currentVersion).toBe("1.5.0");
+    expect(result.minimumVersion).toBe("1.6.0");
+  });
+
+  it("defaults the minimum to MINIMUM_OBSIDIAN_VERSION", () => {
+    expect(checkObsidianCompatibility("99.0.0").minimumVersion).toBe(MINIMUM_OBSIDIAN_VERSION);
+  });
+});

--- a/src/core/plugin/lifecycle/__tests__/ObsidianCompat.test.ts
+++ b/src/core/plugin/lifecycle/__tests__/ObsidianCompat.test.ts
@@ -31,4 +31,10 @@ describe("checkObsidianCompatibility (#212 min-version fail-soft)", () => {
   it("defaults the minimum to MINIMUM_OBSIDIAN_VERSION", () => {
     expect(checkObsidianCompatibility("99.0.0").minimumVersion).toBe(MINIMUM_OBSIDIAN_VERSION);
   });
+
+  it("stays in sync with manifest.json minAppVersion (drift guard, #212)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const manifest = require("../../../../../manifest.json");
+    expect(MINIMUM_OBSIDIAN_VERSION).toBe(manifest.minAppVersion);
+  });
 });

--- a/src/core/settings/BackupRestoreModal.ts
+++ b/src/core/settings/BackupRestoreModal.ts
@@ -503,8 +503,9 @@ export class BackupRestoreModal {
                 currentSettings,
             );
 
-            // Apply settings
-            await this.plugin.getSettingsManager().updateSettings(restoredSettings as any);
+            // Apply settings THROUGH the versioned migrator so an old backup is
+            // migrated to the current schema on restore, exactly like a load (#212).
+            await this.plugin.getSettingsManager().restoreFromExternalSettings(restoredSettings);
             new Notice("Settings restored successfully", 3000);
             
             return true;

--- a/src/core/settings/SettingsManager.ts
+++ b/src/core/settings/SettingsManager.ts
@@ -1138,8 +1138,23 @@ export class SettingsManager {
     this.plugin._internal_settings_systemsculpt_plugin = { ...this.settings };
 
     // Call saveSettings to persist, update plugin._settings, and dispatch event
-    await this.saveSettings(); 
+    await this.saveSettings();
     // Settings updated and saved - silent operation
+  }
+
+  /**
+   * Apply externally-sourced settings (a restored backup or an import) by first
+   * running them through the SAME versioned migrator the load path uses, then
+   * persisting via updateSettings. Without this, restoring an OLD backup would
+   * write a stale schema back to disk and could resurrect the lost-settings /
+   * dead-plugin class this versioning exists to prevent (#212).
+   */
+  async restoreFromExternalSettings(raw: unknown): Promise<void> {
+    const { settings } = migrateSettingsToCurrentSchema(
+      this.asSettingsRecord(raw),
+      DEFAULT_SETTINGS,
+    );
+    await this.updateSettings(settings as Partial<SystemSculptSettings>);
   }
 
   // ... other methods like getLicenseKey, setLicenseKey, validateLicenseKey, etc.

--- a/src/core/settings/SettingsManager.ts
+++ b/src/core/settings/SettingsManager.ts
@@ -5,6 +5,11 @@ import { AutomaticBackupService } from "./AutomaticBackupService";
 import { applyCurrentSecretsToBackup, redactSettingsForBackup } from "./backupSanitizer";
 import { canonicalizeSystemSculptServerUrlSetting } from "../../utils/urlHelpers";
 import { resolveAbsoluteVaultPath } from "../../utils/vaultPathUtils";
+import {
+  CURRENT_SCHEMA_VERSION,
+  migrateSettingsToCurrentSchema,
+  readSchemaVersion,
+} from "./migrations/SettingsMigrator";
 
 type NodeFsModule = typeof import("node:fs");
 type NodePathModule = typeof import("node:path");
@@ -19,8 +24,6 @@ function loadNodePath(): NodePathModule {
   return require("node:path") as NodePathModule;
 }
 
-// Current settings version - increment when making breaking changes to settings structure
-const CURRENT_SETTINGS_VERSION = "1.0";
 const PLUGIN_DATA_POLL_INTERVAL_MS = 1000;
 
 /**
@@ -89,21 +92,8 @@ export class SettingsManager {
       migratedSettings.embeddingsVectorFormatVersion = DEFAULT_SETTINGS.embeddingsVectorFormatVersion;
     }
     
-    // Remove old embeddings stats if they exist (from old system)
-    if ('cachedEmbeddingStats' in migratedSettings) {
-      delete (migratedSettings as any).cachedEmbeddingStats;
-    }
-
-    delete (migratedSettings as any).defaultTemplateModelId;
-    delete (migratedSettings as any).studioTelemetryOptIn;
-    delete (migratedSettings as any).selectedProvider;
-    delete (migratedSettings as any).selectedModelProviders;
-    delete (migratedSettings as any).systemPrompt;
-    delete (migratedSettings as any).systemPromptType;
-    delete (migratedSettings as any).systemPromptPath;
-    delete (migratedSettings as any).useLatestSystemPromptForNewChats;
-    // CanvasFlow (legacy Obsidian-canvas feature) was removed in favor of SystemSculpt Studio.
-    delete (migratedSettings as any).canvasFlowEnabled;
+    // Legacy/dead keys are pruned by the versioned migrator's v0→v1 step
+    // (SettingsMigrator.LEGACY_KEYS_REMOVED_IN_V1) — no ad-hoc deletes here.
 
     // Ensure other nested objects are properly initialized
     if (!migratedSettings.favoritesFilterSettings) {
@@ -182,10 +172,6 @@ export class SettingsManager {
       delete (migratedSettings.workflowEngine as any).templates;
     }
     
-    if ("toolingAutoApproveReadOnly" in migratedSettings) {
-      delete (migratedSettings as any).toolingAutoApproveReadOnly;
-    }
-
     if (!Array.isArray(migratedSettings.mcpServers)) {
       migratedSettings.mcpServers = DEFAULT_SETTINGS.mcpServers;
     }
@@ -200,15 +186,6 @@ export class SettingsManager {
       migratedSettings.logLevel = LogLevel.WARNING;
     }
 
-    // Remove old embeddings exclusion properties if they exist
-    if ('excludedFolders' in migratedSettings) {
-      delete (migratedSettings as any).excludedFolders;
-    }
-    
-    if ('excludedFiles' in migratedSettings) {
-      delete (migratedSettings as any).excludedFiles;
-    }
-    
     if (!Array.isArray(migratedSettings.favoriteChats)) {
       migratedSettings.favoriteChats = DEFAULT_SETTINGS.favoriteChats;
     }
@@ -372,35 +349,106 @@ export class SettingsManager {
   }
 
   async loadSettings(): Promise<void> {
+    let raw: Record<string, unknown> = {};
     try {
       const loadedData = await this.plugin.loadData();
-      const raw =
-        loadedData && typeof loadedData === "object" && !Array.isArray(loadedData)
-          ? (loadedData as Record<string, unknown>)
-          : {};
-
-      const mergedSettings = this.migrateSettings({ ...DEFAULT_SETTINGS, ...raw });
-      this.settings = await this.validateSettingsAsync(mergedSettings);
-      this.plugin._internal_settings_systemsculpt_plugin = { ...this.settings };
-      this.isInitialized = true;
-      await this.saveSettings();
+      raw = this.asSettingsRecord(loadedData);
     } catch (loadError) {
       const backupSettings = await this.restoreFromBackup();
-      const raw =
-        backupSettings && typeof backupSettings === "object" && !Array.isArray(backupSettings)
-          ? (backupSettings as Record<string, unknown>)
-          : {};
-
-      const restored = this.migrateSettings({ ...DEFAULT_SETTINGS, ...raw });
-      this.settings = await this.validateSettingsAsync(restored);
-      this.plugin._internal_settings_systemsculpt_plugin = { ...this.settings };
-      this.isInitialized = true;
-      await this.saveSettings();
+      raw = this.asSettingsRecord(backupSettings);
     }
+
+    this.settings = await this.migrateValidateWithRollback(raw);
+    this.plugin._internal_settings_systemsculpt_plugin = { ...this.settings };
+    this.isInitialized = true;
+    await this.saveSettings();
+
     this.plugin.app.workspace.trigger("systemsculpt:settings-loaded", this.settings);
-    
+
     // Start automatic backup service after settings are loaded
     this.automaticBackupService.start();
+  }
+
+  private asSettingsRecord(value: unknown): Record<string, unknown> {
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  /**
+   * Run the versioned schema migration (back-fill defaults, prune legacy keys,
+   * stamp the schema version) followed by normalization/validation. If any step
+   * throws, ROLL BACK: snapshot the user's raw data to a pre-migration backup
+   * and load the safest shape we can, so an update can never leave the plugin
+   * dead or wipe settings (#212; #183/#112/#100).
+   */
+  private async migrateValidateWithRollback(
+    raw: Record<string, unknown>,
+  ): Promise<SystemSculptSettings> {
+    const fromVersion = readSchemaVersion(raw);
+    try {
+      const result = migrateSettingsToCurrentSchema(raw, DEFAULT_SETTINGS);
+      // Back up BEFORE applying a real schema upgrade so a migration bug found
+      // later is always recoverable from the pre-migration snapshot.
+      if (!result.future && result.fromVersion < CURRENT_SCHEMA_VERSION && this.hasMeaningfulData(raw)) {
+        await this.writePreMigrationBackup(raw, fromVersion);
+      }
+      return await this.validateSettingsAsync(this.migrateSettings(result.settings));
+    } catch (migrationError) {
+      await this.writePreMigrationBackup(raw, fromVersion).catch(() => {});
+      try {
+        // Safe fallback = pre-versioning behavior (defaults + raw, normalized).
+        // The user's original data is preserved both here (raw wins) and in the
+        // pre-migration backup written above.
+        return await this.validateSettingsAsync(this.migrateSettings({ ...DEFAULT_SETTINGS, ...raw }));
+      } catch (fallbackError) {
+        // Last resort: pure defaults. Data is safe in the pre-migration backup.
+        return { ...DEFAULT_SETTINGS };
+      }
+    }
+  }
+
+  private hasMeaningfulData(raw: Record<string, unknown>): boolean {
+    return Object.keys(raw).length > 0;
+  }
+
+  /**
+   * Best-effort snapshot of the raw persisted settings (secrets redacted) to a
+   * dedicated pre-migration backup file, so a schema upgrade is always
+   * reversible. Never throws — backup must not block plugin load.
+   */
+  private async writePreMigrationBackup(raw: Record<string, unknown>, fromVersion: number): Promise<void> {
+    try {
+      const redacted = redactSettingsForBackup(raw);
+      const payload = {
+        ...redacted,
+        _backupMeta: {
+          type: "pre-migration",
+          fromSchemaVersion: fromVersion,
+          toSchemaVersion: CURRENT_SCHEMA_VERSION,
+          createdAt: new Date().toISOString(),
+          version: "1.1",
+          redactedSecrets: true,
+        },
+      };
+      const fileName = `settings-backup-premigration-v${fromVersion}.json`;
+      const dir = ".systemsculpt/settings-backups";
+      try {
+        await this.plugin.app.vault.createFolder(dir);
+      } catch {
+        // directory already exists
+      }
+      await this.plugin.app.vault.adapter.write(`${dir}/${fileName}`, JSON.stringify(payload, null, 2));
+      if (this.plugin.storage) {
+        try {
+          await this.plugin.storage.writeFile("settings", `backups/${fileName}`, payload);
+        } catch {
+          // vault storage optional
+        }
+      }
+    } catch {
+      // best-effort only
+    }
   }
 
   /**
@@ -505,29 +553,8 @@ export class SettingsManager {
     }
 
 
-    // Remove old embeddings properties if they exist
-    if ('autoUpdateSimilarNotes' in validatedSettings) {
-      delete (validatedSettings as any).autoUpdateSimilarNotes;
-    }
-
-    if ('hideSimilarNotesAlreadyInContext' in validatedSettings) {
-      delete (validatedSettings as any).hideSimilarNotesAlreadyInContext;
-    }
-
-    if ('backgroundEmbeddingUpdates' in validatedSettings) {
-      delete (validatedSettings as any).backgroundEmbeddingUpdates;
-    }
-
-    delete (validatedSettings as any).recordSystemAudio;
-    delete (validatedSettings as any).defaultTemplateModelId;
-    delete (validatedSettings as any).templateHotkey;
-    delete (validatedSettings as any).enableTemplateHotkey;
-    delete (validatedSettings as any).videoRecordingsDirectory;
-    delete (validatedSettings as any).videoCaptureSystemAudio;
-    delete (validatedSettings as any).videoCaptureMicrophoneAudio;
-    delete (validatedSettings as any).showVideoRecordButtonInChat;
-    delete (validatedSettings as any).showVideoRecordingPermissionPopup;
-    delete (validatedSettings as any).studioTelemetryOptIn;
+    // Legacy/dead keys are pruned by the versioned migrator (v0→v1) on load,
+    // not re-deleted on every validate pass.
 
     if (typeof validatedSettings.embeddingsEnabled !== 'boolean') {
       validatedSettings.embeddingsEnabled = defaultSettings.embeddingsEnabled;
@@ -655,16 +682,9 @@ export class SettingsManager {
       validatedSettings.favoriteStudioSessions = defaultSettings.favoriteStudioSessions;
     }
 
-    // Remove cachedEmbeddingStats if it exists (from old embeddings system)
-    if ('cachedEmbeddingStats' in validatedSettings) {
-      delete (validatedSettings as any).cachedEmbeddingStats;
-    }
-    delete (validatedSettings as any).selectedProvider;
-    delete (validatedSettings as any).selectedModelProviders;
-    delete (validatedSettings as any).systemPrompt;
-    delete (validatedSettings as any).systemPromptType;
-    delete (validatedSettings as any).systemPromptPath;
-    delete (validatedSettings as any).useLatestSystemPromptForNewChats;
+    // Legacy/dead keys (cachedEmbeddingStats, selectedProvider, systemPrompt*, …)
+    // are pruned once by the versioned migrator's v0→v1 step, not on every
+    // validate pass. See SettingsMigrator.LEGACY_KEYS_REMOVED_IN_V1.
 
     // Persist the canonical hosted API origin. Production builds always pin this to the
     // real SystemSculpt API, while development builds still normalize local overrides.

--- a/src/core/settings/SettingsManager.ts
+++ b/src/core/settings/SettingsManager.ts
@@ -1055,8 +1055,10 @@ export class SettingsManager {
       loadedData && typeof loadedData === "object" && !Array.isArray(loadedData)
         ? (loadedData as Record<string, unknown>)
         : {};
-    const mergedSettings = this.migrateSettings({ ...DEFAULT_SETTINGS, ...raw });
-    const nextSettings = await this.validateSettingsAsync(mergedSettings);
+    // Route disk reloads through the SAME versioned migrate+validate+rollback
+    // path as load/restore, so an externally-edited or synced OLD file is
+    // migrated (deep-merge + legacy prune + schema stamp), not applied stale (#212).
+    const nextSettings = await this.migrateValidateWithRollback(raw);
 
     if (JSON.stringify(this.settings) === JSON.stringify(nextSettings)) {
       if (this.shouldIgnoreInternalPluginDataEcho(nextSettings)) {
@@ -1150,11 +1152,8 @@ export class SettingsManager {
    * dead-plugin class this versioning exists to prevent (#212).
    */
   async restoreFromExternalSettings(raw: unknown): Promise<void> {
-    const { settings } = migrateSettingsToCurrentSchema(
-      this.asSettingsRecord(raw),
-      DEFAULT_SETTINGS,
-    );
-    await this.updateSettings(settings as Partial<SystemSculptSettings>);
+    const migrated = await this.migrateValidateWithRollback(this.asSettingsRecord(raw));
+    await this.updateSettings(migrated);
   }
 
   // ... other methods like getLicenseKey, setLicenseKey, validateLicenseKey, etc.

--- a/src/core/settings/__tests__/SettingsManager.test.ts
+++ b/src/core/settings/__tests__/SettingsManager.test.ts
@@ -597,6 +597,29 @@ describe("SettingsManager", () => {
       expect(mockPlugin.saveData).toHaveBeenCalled();
     });
 
+    it("reloadSettingsFromDisk migrates an externally-edited OLD payload (#212)", async () => {
+      await settingsManager.loadSettings(); // initialize current schema
+
+      // Simulate an old/synced data.json appearing on disk (no schemaVersion).
+      mockPlugin.loadData.mockResolvedValue({
+        licenseKey: "disk-key",
+        customProviders: [{ id: "openrouter", name: "OpenRouter", isEnabled: true }],
+        selectedProvider: "legacy",
+        canvasFlowEnabled: true,
+        recordSystemAudio: true,
+      });
+
+      await settingsManager.reloadSettingsFromDisk();
+
+      // The disk-reload entry point migrates exactly like load/restore.
+      expect(settingsManager.settings.schemaVersion).toBe(1);
+      expect(settingsManager.settings).not.toHaveProperty("selectedProvider");
+      expect(settingsManager.settings).not.toHaveProperty("canvasFlowEnabled");
+      expect(settingsManager.settings).not.toHaveProperty("recordSystemAudio");
+      expect(settingsManager.settings.licenseKey).toBe("disk-key");
+      expect(settingsManager.settings.customProviders).toHaveLength(1);
+    });
+
     it("triggers settings-loaded event", async () => {
       await settingsManager.loadSettings();
 

--- a/src/core/settings/__tests__/SettingsManager.test.ts
+++ b/src/core/settings/__tests__/SettingsManager.test.ts
@@ -575,6 +575,28 @@ describe("SettingsManager", () => {
       expect(settingsManager.settings.customProviders).toHaveLength(1);
     });
 
+    it("restoreFromExternalSettings migrates an OLD backup before applying it (#212)", async () => {
+      await settingsManager.loadSettings(); // initialize current schema
+
+      // An old backup file: no schemaVersion, legacy keys, real user data.
+      await settingsManager.restoreFromExternalSettings({
+        licenseKey: "restored-key",
+        customProviders: [{ id: "openrouter", name: "OpenRouter", isEnabled: true }],
+        selectedProvider: "legacy",
+        canvasFlowEnabled: true,
+        recordSystemAudio: true,
+      });
+
+      // Restored data is migrated to the current schema, not written back stale.
+      expect(settingsManager.settings.schemaVersion).toBe(1);
+      expect(settingsManager.settings).not.toHaveProperty("selectedProvider");
+      expect(settingsManager.settings).not.toHaveProperty("canvasFlowEnabled");
+      expect(settingsManager.settings).not.toHaveProperty("recordSystemAudio");
+      expect(settingsManager.settings.licenseKey).toBe("restored-key");
+      expect(settingsManager.settings.customProviders).toHaveLength(1);
+      expect(mockPlugin.saveData).toHaveBeenCalled();
+    });
+
     it("triggers settings-loaded event", async () => {
       await settingsManager.loadSettings();
 

--- a/src/core/settings/__tests__/SettingsManager.test.ts
+++ b/src/core/settings/__tests__/SettingsManager.test.ts
@@ -92,6 +92,7 @@ jest.mock("../../../types", () => ({
 
 import { SettingsManager } from "../SettingsManager";
 import { DEFAULT_SETTINGS, LogLevel } from "../../../types";
+import { migrateSettingsToCurrentSchema } from "../migrations/SettingsMigrator";
 
 describe("SettingsManager", () => {
   let mockPlugin: any;
@@ -327,13 +328,20 @@ describe("SettingsManager", () => {
     });
 
     describe("legacy property removal", () => {
+      // Legacy/dead keys are now pruned by the versioned migrator's v0→v1 step
+      // (the single canonical home), not the normalization helper. Assert via
+      // the real migration entry point. Exhaustive per-key coverage lives in
+      // SettingsMigrator.test.ts; these pin the well-known cases at this layer.
+      const pruneViaMigrator = (raw: Record<string, unknown>) =>
+        migrateSettingsToCurrentSchema(raw, DEFAULT_SETTINGS).settings as any;
+
       it("removes cachedEmbeddingStats", () => {
-        const result = migrateSettings({ cachedEmbeddingStats: { some: "data" } });
+        const result = pruneViaMigrator({ cachedEmbeddingStats: { some: "data" } });
         expect(result.cachedEmbeddingStats).toBeUndefined();
       });
 
       it("removes legacy provider selection fields", () => {
-        const result = migrateSettings({
+        const result = pruneViaMigrator({
           selectedProvider: "custom-provider",
           selectedModelProviders: ["openai", "anthropic"],
         });
@@ -342,12 +350,12 @@ describe("SettingsManager", () => {
       });
 
       it("removes excludedFolders", () => {
-        const result = migrateSettings({ excludedFolders: ["folder"] });
+        const result = pruneViaMigrator({ excludedFolders: ["folder"] });
         expect(result.excludedFolders).toBeUndefined();
       });
 
       it("removes excludedFiles", () => {
-        const result = migrateSettings({ excludedFiles: ["file.md"] });
+        const result = pruneViaMigrator({ excludedFiles: ["file.md"] });
         expect(result.excludedFiles).toBeUndefined();
       });
     });
@@ -454,9 +462,14 @@ describe("SettingsManager", () => {
 
     });
 
+    // Legacy/dead keys are pruned once by the versioned migrator's v0→v1 step,
+    // not on every validate pass. Raw fixtures omit schemaVersion (v0 data) so
+    // the prune runs. Exhaustive coverage lives in SettingsMigrator.test.ts.
+    const pruneLegacy = (raw: Record<string, unknown>) =>
+      migrateSettingsToCurrentSchema(raw, DEFAULT_SETTINGS).settings as any;
+
     it("removes deprecated screen recording settings", () => {
-      const result = validateSettings({
-        ...DEFAULT_SETTINGS,
+      const result = pruneLegacy({
         videoRecordingsDirectory: "SystemSculpt/Video Recordings",
         videoCaptureSystemAudio: true,
         videoCaptureMicrophoneAudio: true,
@@ -473,21 +486,15 @@ describe("SettingsManager", () => {
     });
 
     it("removes deprecated studio telemetry settings", () => {
-      const result = validateSettings({
-        ...DEFAULT_SETTINGS,
-        studioTelemetryOptIn: true,
-      } as any);
-
+      const result = pruneLegacy({ studioTelemetryOptIn: true });
       expect("studioTelemetryOptIn" in result).toBe(false);
     });
 
     it("removes legacy provider selection fields during validation", () => {
-      const result = validateSettings({
-        ...DEFAULT_SETTINGS,
+      const result = pruneLegacy({
         selectedProvider: "custom-provider",
         selectedModelProviders: ["openai", "anthropic"],
-      } as any);
-
+      });
       expect("selectedProvider" in result).toBe(false);
       expect("selectedModelProviders" in result).toBe(false);
     });
@@ -546,6 +553,26 @@ describe("SettingsManager", () => {
 
       expect(mockPlugin.loadData).toHaveBeenCalled();
       expect(settingsManager.settings.settingsMode).toBe("advanced");
+    });
+
+    it("runs the versioned migrator on load: stamps schemaVersion, prunes legacy, keeps providers (#212)", async () => {
+      mockPlugin.loadData.mockResolvedValue({
+        // pre-versioning data (no schemaVersion) carrying legacy keys
+        licenseKey: "user-key",
+        customProviders: [{ id: "openrouter", name: "OpenRouter", isEnabled: true }],
+        selectedProvider: "legacy",
+        canvasFlowEnabled: true,
+        recordSystemAudio: true,
+      });
+
+      await settingsManager.loadSettings();
+
+      expect(settingsManager.settings.schemaVersion).toBe(1);
+      expect(settingsManager.settings).not.toHaveProperty("selectedProvider");
+      expect(settingsManager.settings).not.toHaveProperty("canvasFlowEnabled");
+      expect(settingsManager.settings).not.toHaveProperty("recordSystemAudio");
+      expect(settingsManager.settings.licenseKey).toBe("user-key");
+      expect(settingsManager.settings.customProviders).toHaveLength(1);
     });
 
     it("triggers settings-loaded event", async () => {

--- a/src/core/settings/migrations/SettingsMigrator.ts
+++ b/src/core/settings/migrations/SettingsMigrator.ts
@@ -1,0 +1,173 @@
+import { SystemSculptSettings } from "../../../types";
+import { CURRENT_SCHEMA_VERSION } from "./schemaVersion";
+
+export { CURRENT_SCHEMA_VERSION };
+
+/**
+ * Top-level keys that existed in pre-versioning (v0) settings and have since
+ * been removed from the schema. The v0→v1 migration prunes them so dead data
+ * does not linger across an update. Previously these were `delete`d ad-hoc on
+ * every load/save inside SettingsManager; the versioned chain is their single
+ * canonical home now.
+ */
+export const LEGACY_KEYS_REMOVED_IN_V1: readonly string[] = [
+  "cachedEmbeddingStats",
+  "defaultTemplateModelId",
+  "studioTelemetryOptIn",
+  "selectedProvider",
+  "selectedModelProviders",
+  "systemPrompt",
+  "systemPromptType",
+  "systemPromptPath",
+  "useLatestSystemPromptForNewChats",
+  "canvasFlowEnabled",
+  "toolingAutoApproveReadOnly",
+  "excludedFolders",
+  "excludedFiles",
+  "autoUpdateSimilarNotes",
+  "hideSimilarNotesAlreadyInContext",
+  "backgroundEmbeddingUpdates",
+  "recordSystemAudio",
+  "templateHotkey",
+  "enableTemplateHotkey",
+  "videoRecordingsDirectory",
+  "videoCaptureSystemAudio",
+  "videoCaptureMicrophoneAudio",
+  "showVideoRecordButtonInChat",
+  "showVideoRecordingPermissionPopup",
+];
+
+export interface SettingsMigrationStep {
+  /** The schema version this step upgrades the settings TO (from `to - 1`). */
+  readonly to: number;
+  readonly describe: string;
+  readonly migrate: (settings: Record<string, unknown>) => Record<string, unknown>;
+}
+
+export interface SettingsMigrationResult {
+  readonly settings: Record<string, unknown>;
+  /** Schema version read from the persisted data (0 = pre-versioning/garbage). */
+  readonly fromVersion: number;
+  /** Schema version stamped onto the result. */
+  readonly toVersion: number;
+  /** Human-readable descriptions of the steps that ran, in order. */
+  readonly appliedSteps: string[];
+  /** True when persisted data is from a NEWER schema than this build understands. */
+  readonly future: boolean;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function pruneLegacyKeysV1(settings: Record<string, unknown>): Record<string, unknown> {
+  const next = { ...settings };
+  for (const key of LEGACY_KEYS_REMOVED_IN_V1) {
+    delete next[key];
+  }
+  return next;
+}
+
+/**
+ * Ordered registry of schema migrations. Each step upgrades settings from
+ * version `to - 1` to `to`. Add new steps here (never ad-hoc field deletes
+ * scattered through load/validate) and bump CURRENT_SCHEMA_VERSION to match.
+ */
+export const SETTINGS_MIGRATIONS: readonly SettingsMigrationStep[] = [
+  {
+    to: 1,
+    describe: "Prune legacy keys removed before schema versioning was introduced",
+    migrate: pruneLegacyKeysV1,
+  },
+];
+
+/** Read a non-negative integer schema version from raw data; 0 if absent/garbage. */
+export function readSchemaVersion(raw: unknown): number {
+  if (!isPlainObject(raw)) return 0;
+  const value = raw.schemaVersion;
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  return 0;
+}
+
+function cloneDefault(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(cloneDefault);
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) out[key] = cloneDefault(value[key]);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Recursively back-fill keys present in `defaults` but missing from `raw`,
+ * WITHOUT overwriting values the user has set. Nested plain objects are merged
+ * key-by-key; arrays and primitives are taken from `raw` when present. A nested
+ * field that defaults to a plain object but is corrupt (non-object) in `raw` is
+ * reset to the default. Keys present in `raw` but absent from `defaults` are
+ * preserved — unknown/forward-compatible keys are never dropped here.
+ *
+ * This closes the "update wiped my nested setting" class (#112, #100): when a
+ * release adds a sub-key to a nested settings object, old data gains it instead
+ * of having the whole object replaced by a shallow `{ ...DEFAULT, ...raw }`.
+ */
+export function deepMergeDefaults(
+  defaults: Record<string, unknown>,
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...raw };
+  for (const key of Object.keys(defaults)) {
+    const defaultValue = defaults[key];
+    const rawValue = raw[key];
+    if (!(key in raw) || rawValue === undefined) {
+      out[key] = cloneDefault(defaultValue);
+    } else if (isPlainObject(defaultValue)) {
+      out[key] = isPlainObject(rawValue)
+        ? deepMergeDefaults(defaultValue, rawValue)
+        : cloneDefault(defaultValue);
+    } else {
+      out[key] = rawValue;
+    }
+  }
+  return out;
+}
+
+/**
+ * Migrate raw persisted settings to the current schema:
+ *  1. read the persisted schema version (absent/garbage → 0),
+ *  2. deep-merge defaults to back-fill new/nested keys,
+ *  3. run each ordered migration step from the persisted version up to current,
+ *  4. stamp the resulting `schemaVersion`.
+ *
+ * Newer-than-current data (a downgrade scenario) is never mutated by steps and
+ * keeps its own future version — we only back-fill missing keys, never
+ * downgrade or prune data a future build may rely on.
+ *
+ * This function is PURE: it does not read or write disk and does not mutate its
+ * inputs, so it is trivially testable and safe to run inside a try/rollback.
+ */
+export function migrateSettingsToCurrentSchema(
+  raw: Record<string, unknown>,
+  defaults: SystemSculptSettings,
+): SettingsMigrationResult {
+  const fromVersion = readSchemaVersion(raw);
+  let merged = deepMergeDefaults(defaults as unknown as Record<string, unknown>, raw);
+  const appliedSteps: string[] = [];
+
+  if (fromVersion > CURRENT_SCHEMA_VERSION) {
+    merged.schemaVersion = fromVersion;
+    return { settings: merged, fromVersion, toVersion: fromVersion, appliedSteps, future: true };
+  }
+
+  for (const step of [...SETTINGS_MIGRATIONS].sort((a, b) => a.to - b.to)) {
+    if (step.to > fromVersion && step.to <= CURRENT_SCHEMA_VERSION) {
+      merged = step.migrate(merged);
+      appliedSteps.push(step.describe);
+    }
+  }
+
+  merged.schemaVersion = CURRENT_SCHEMA_VERSION;
+  return { settings: merged, fromVersion, toVersion: CURRENT_SCHEMA_VERSION, appliedSteps, future: false };
+}

--- a/src/core/settings/migrations/SettingsMigrator.ts
+++ b/src/core/settings/migrations/SettingsMigrator.ts
@@ -171,3 +171,22 @@ export function migrateSettingsToCurrentSchema(
   merged.schemaVersion = CURRENT_SCHEMA_VERSION;
   return { settings: merged, fromVersion, toVersion: CURRENT_SCHEMA_VERSION, appliedSteps, future: false };
 }
+
+/**
+ * Schema versions in [1, current] that have NO migration step. A non-empty
+ * result means the chain has a gap: a bump to `current` would stamp data as
+ * fully migrated while silently skipping the missing step. Guarded permanently
+ * by SettingsMigrator.test.ts so a future schema bump that forgets a step fails
+ * CI instead of shipping (#212).
+ */
+export function findMissingMigrationVersions(
+  migrations: readonly SettingsMigrationStep[] = SETTINGS_MIGRATIONS,
+  current: number = CURRENT_SCHEMA_VERSION,
+): number[] {
+  const targets = new Set(migrations.map((step) => step.to));
+  const missing: number[] = [];
+  for (let version = 1; version <= current; version++) {
+    if (!targets.has(version)) missing.push(version);
+  }
+  return missing;
+}

--- a/src/core/settings/migrations/__tests__/SettingsMigrator.test.ts
+++ b/src/core/settings/migrations/__tests__/SettingsMigrator.test.ts
@@ -1,0 +1,146 @@
+import { DEFAULT_SETTINGS } from "../../../../types";
+import {
+  CURRENT_SCHEMA_VERSION,
+  LEGACY_KEYS_REMOVED_IN_V1,
+  deepMergeDefaults,
+  migrateSettingsToCurrentSchema,
+  readSchemaVersion,
+} from "../SettingsMigrator";
+
+describe("readSchemaVersion", () => {
+  it("returns 0 for pre-versioning, missing, or garbage input", () => {
+    expect(readSchemaVersion({})).toBe(0);
+    expect(readSchemaVersion({ schemaVersion: undefined })).toBe(0);
+    expect(readSchemaVersion({ schemaVersion: "1" })).toBe(0);
+    expect(readSchemaVersion({ schemaVersion: NaN })).toBe(0);
+    expect(readSchemaVersion({ schemaVersion: -3 })).toBe(0);
+    expect(readSchemaVersion(null as never)).toBe(0);
+    expect(readSchemaVersion([] as never)).toBe(0);
+  });
+
+  it("floors a valid non-negative version", () => {
+    expect(readSchemaVersion({ schemaVersion: 1 })).toBe(1);
+    expect(readSchemaVersion({ schemaVersion: 2.9 })).toBe(2);
+  });
+});
+
+describe("deepMergeDefaults", () => {
+  it("back-fills missing top-level keys without overwriting user values", () => {
+    const defaults = { a: 1, b: 2, c: 3 };
+    const merged = deepMergeDefaults(defaults, { a: 99 });
+    expect(merged).toEqual({ a: 99, b: 2, c: 3 });
+  });
+
+  it("back-fills new nested sub-keys while preserving existing ones (#112/#100)", () => {
+    const defaults = {
+      exclusions: { folders: [], patterns: [], ignoreChatHistory: true, respectObsidian: true },
+    };
+    const merged = deepMergeDefaults(defaults, {
+      exclusions: { folders: ["Private"], ignoreChatHistory: false },
+    });
+    expect(merged.exclusions).toEqual({
+      folders: ["Private"],
+      patterns: [],
+      ignoreChatHistory: false,
+      respectObsidian: true,
+    });
+  });
+
+  it("preserves unknown keys present in raw but absent from defaults", () => {
+    const merged = deepMergeDefaults({ known: 1 }, { known: 1, futureKey: "keep-me" });
+    expect(merged.futureKey).toBe("keep-me");
+  });
+
+  it("resets a corrupt nested object (non-object in raw) to the default", () => {
+    const defaults = { nested: { x: 1 } };
+    const merged = deepMergeDefaults(defaults, { nested: "corrupt" as unknown });
+    expect(merged.nested).toEqual({ x: 1 });
+  });
+
+  it("takes the raw array wholesale rather than element-merging", () => {
+    const merged = deepMergeDefaults({ list: [1, 2, 3] }, { list: [9] });
+    expect(merged.list).toEqual([9]);
+  });
+
+  it("does not share references with the defaults it clones in", () => {
+    const defaults = { nested: { inner: { v: 1 } } };
+    const merged = deepMergeDefaults(defaults, {});
+    (merged.nested as { inner: { v: number } }).inner.v = 42;
+    expect(defaults.nested.inner.v).toBe(1);
+  });
+});
+
+describe("migrateSettingsToCurrentSchema", () => {
+  it("stamps the current version and prunes every legacy key from v0 data", () => {
+    const raw: Record<string, unknown> = {
+      licenseKey: "abc",
+      customProviders: [{ id: "openrouter", name: "OpenRouter", isEnabled: true }],
+    };
+    for (const key of LEGACY_KEYS_REMOVED_IN_V1) raw[key] = "legacy-value";
+
+    const result = migrateSettingsToCurrentSchema(raw, DEFAULT_SETTINGS);
+
+    expect(result.fromVersion).toBe(0);
+    expect(result.toVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(result.future).toBe(false);
+    expect(result.appliedSteps.length).toBeGreaterThan(0);
+    expect(result.settings.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    for (const key of LEGACY_KEYS_REMOVED_IN_V1) {
+      expect(result.settings).not.toHaveProperty(key);
+    }
+  });
+
+  it("preserves the user's custom providers and license through migration (#112)", () => {
+    const raw = {
+      licenseKey: "user-key",
+      licenseValid: true,
+      customProviders: [
+        { id: "openrouter", name: "OpenRouter", endpoint: "https://openrouter.ai/api/v1", apiKey: "k", isEnabled: true },
+      ],
+    };
+    const result = migrateSettingsToCurrentSchema(raw, DEFAULT_SETTINGS);
+    expect(result.settings.customProviders).toEqual(raw.customProviders);
+    expect(result.settings.licenseKey).toBe("user-key");
+    expect(result.settings.licenseValid).toBe(true);
+  });
+
+  it("back-fills brand-new install defaults for empty persisted data", () => {
+    const result = migrateSettingsToCurrentSchema({}, DEFAULT_SETTINGS);
+    expect(result.settings.selectedModelId).toBe(DEFAULT_SETTINGS.selectedModelId);
+    expect(result.settings.chatsDirectory).toBe(DEFAULT_SETTINGS.chatsDirectory);
+    expect(result.settings.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+  });
+
+  it("is idempotent — re-running on already-migrated data is a no-op for version", () => {
+    const once = migrateSettingsToCurrentSchema({ licenseKey: "x" }, DEFAULT_SETTINGS);
+    const twice = migrateSettingsToCurrentSchema(once.settings, DEFAULT_SETTINGS);
+    expect(twice.fromVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(twice.appliedSteps).toHaveLength(0);
+    expect(twice.settings.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+  });
+
+  it("never downgrades or prunes newer-than-current (future) data, but still back-fills gaps", () => {
+    const raw = {
+      schemaVersion: CURRENT_SCHEMA_VERSION + 5,
+      someFutureKey: "from-a-newer-build",
+      // a legacy key here must NOT be pruned — a future build may have revived it
+      selectedProvider: "future-meaning",
+    };
+    const result = migrateSettingsToCurrentSchema(raw, DEFAULT_SETTINGS);
+    expect(result.future).toBe(true);
+    expect(result.toVersion).toBe(CURRENT_SCHEMA_VERSION + 5);
+    expect(result.settings.schemaVersion).toBe(CURRENT_SCHEMA_VERSION + 5);
+    expect(result.settings.someFutureKey).toBe("from-a-newer-build");
+    expect(result.settings.selectedProvider).toBe("future-meaning");
+    expect(result.appliedSteps).toHaveLength(0);
+    // still gains current defaults it was missing
+    expect(result.settings.chatsDirectory).toBe(DEFAULT_SETTINGS.chatsDirectory);
+  });
+
+  it("does not mutate the raw input object", () => {
+    const raw = { licenseKey: "x", selectedProvider: "legacy" };
+    migrateSettingsToCurrentSchema(raw, DEFAULT_SETTINGS);
+    expect(raw).toHaveProperty("selectedProvider", "legacy");
+    expect(raw).not.toHaveProperty("schemaVersion");
+  });
+});

--- a/src/core/settings/migrations/__tests__/SettingsMigrator.test.ts
+++ b/src/core/settings/migrations/__tests__/SettingsMigrator.test.ts
@@ -3,6 +3,7 @@ import {
   CURRENT_SCHEMA_VERSION,
   LEGACY_KEYS_REMOVED_IN_V1,
   deepMergeDefaults,
+  findMissingMigrationVersions,
   migrateSettingsToCurrentSchema,
   readSchemaVersion,
 } from "../SettingsMigrator";
@@ -142,5 +143,20 @@ describe("migrateSettingsToCurrentSchema", () => {
     migrateSettingsToCurrentSchema(raw, DEFAULT_SETTINGS);
     expect(raw).toHaveProperty("selectedProvider", "legacy");
     expect(raw).not.toHaveProperty("schemaVersion");
+  });
+});
+
+describe("findMissingMigrationVersions (chain-completeness guard, #212)", () => {
+  it("reports no gaps for the shipped migration registry", () => {
+    expect(findMissingMigrationVersions()).toEqual([]);
+  });
+
+  it("detects a missing intermediate step before a future bump", () => {
+    const gappy = [
+      { to: 1, describe: "v0->v1", migrate: (s: Record<string, unknown>) => s },
+      { to: 3, describe: "v2->v3", migrate: (s: Record<string, unknown>) => s },
+    ];
+    // Bumping to v3 with no v2 step must surface version 2 as missing.
+    expect(findMissingMigrationVersions(gappy, 3)).toEqual([2]);
   });
 });

--- a/src/core/settings/migrations/__tests__/migration-harness.test.ts
+++ b/src/core/settings/migrations/__tests__/migration-harness.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Migration harness (#212): settings fixtures captured from past releases must
+ * load cleanly into HEAD — no throw, no lost custom providers/license, legacy
+ * keys pruned, new nested defaults back-filled, and the schema version stamped.
+ *
+ * Add a fixture here whenever the persisted settings shape changes across a
+ * release so the upgrade path stays permanently guarded in CI. Fixtures live in
+ * testing/fixtures/settings/ and represent real-world data.json shapes.
+ */
+import { DEFAULT_SETTINGS } from "../../../../types";
+import {
+  CURRENT_SCHEMA_VERSION,
+  LEGACY_KEYS_REMOVED_IN_V1,
+  migrateSettingsToCurrentSchema,
+} from "../SettingsMigrator";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const v4Legacy = require("../../../../../testing/fixtures/settings/v4.x-legacy.json");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const v5PreVersioning = require("../../../../../testing/fixtures/settings/v5.x-pre-versioning.json");
+
+interface SettingsFixture {
+  name: string;
+  raw: Record<string, unknown>;
+}
+
+function stripFixtureMeta(fixture: Record<string, unknown>): Record<string, unknown> {
+  const { _fixtureMeta, ...rest } = fixture;
+  return rest;
+}
+
+const FIXTURES: SettingsFixture[] = [
+  { name: "v4.x legacy", raw: stripFixtureMeta(v4Legacy) },
+  { name: "v5.x pre-versioning", raw: stripFixtureMeta(v5PreVersioning) },
+];
+
+describe("settings migration harness — past releases load cleanly into HEAD (#212)", () => {
+  for (const fixture of FIXTURES) {
+    describe(fixture.name, () => {
+      const result = migrateSettingsToCurrentSchema(fixture.raw, DEFAULT_SETTINGS);
+
+      it("migrates without throwing and stamps the current schema version", () => {
+        expect(result.future).toBe(false);
+        expect(result.toVersion).toBe(CURRENT_SCHEMA_VERSION);
+        expect(result.settings.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+      });
+
+      it("prunes every legacy key the fixture carried", () => {
+        for (const key of LEGACY_KEYS_REMOVED_IN_V1) {
+          expect(result.settings).not.toHaveProperty(key);
+        }
+      });
+
+      it("preserves the user's custom providers — never wiped by an update (#112)", () => {
+        const original = (fixture.raw.customProviders as Array<{ id: string }>) ?? [];
+        const migrated = (result.settings.customProviders as Array<{ id: string }>) ?? [];
+        expect(migrated).toHaveLength(original.length);
+        expect(migrated.map((p) => p.id).sort()).toEqual(original.map((p) => p.id).sort());
+      });
+
+      it("preserves the user's license fields", () => {
+        expect(result.settings.licenseKey).toBe(fixture.raw.licenseKey);
+        expect(result.settings.licenseValid).toBe(fixture.raw.licenseValid);
+      });
+
+      it("yields a complete settings shape — every default key back-filled (#100)", () => {
+        for (const key of Object.keys(DEFAULT_SETTINGS)) {
+          expect(result.settings).toHaveProperty(key);
+        }
+      });
+    });
+  }
+
+  it("back-fills new nested sub-keys while keeping the fixture's own (#112/#100)", () => {
+    const result = migrateSettingsToCurrentSchema(stripFixtureMeta(v5PreVersioning), DEFAULT_SETTINGS);
+    const exclusions = result.settings.embeddingsExclusions as Record<string, unknown>;
+    // The fixture only set `folders`; the rest must come from current defaults.
+    expect(exclusions.folders).toEqual(["Daily Notes"]);
+    for (const key of Object.keys(DEFAULT_SETTINGS.embeddingsExclusions as Record<string, unknown>)) {
+      expect(exclusions).toHaveProperty(key);
+    }
+  });
+});

--- a/src/core/settings/migrations/schemaVersion.ts
+++ b/src/core/settings/migrations/schemaVersion.ts
@@ -1,0 +1,13 @@
+/**
+ * The settings schema version this build understands. Bump it whenever a
+ * release changes the persisted settings shape in a way that needs an explicit
+ * transform, and add a matching step to SETTINGS_MIGRATIONS (SettingsMigrator).
+ *
+ * Kept in its own dependency-free module so both `types.ts` (for
+ * DEFAULT_SETTINGS) and the migrator can import it without an import cycle.
+ *
+ * History:
+ *  - 0: pre-versioning data (no `schemaVersion` field). Migrated on first load.
+ *  - 1: schema versioning introduced; legacy/dead keys pruned (see #212).
+ */
+export const CURRENT_SCHEMA_VERSION = 1;

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,8 @@ ErrorCollectorService.initializeEarlyLogsCapture();
  * SystemSculpt AI Plugin for Obsidian
  * Version: 1.5.3
  */
-import { Plugin, Notice, MarkdownView, Platform, setIcon, WorkspaceLeaf, debounce, TFile, FileSystemAdapter, normalizePath } from "obsidian";
+import { Plugin, Notice, MarkdownView, Platform, setIcon, WorkspaceLeaf, debounce, TFile, FileSystemAdapter, normalizePath, apiVersion } from "obsidian";
+import { checkObsidianCompatibility, MINIMUM_OBSIDIAN_VERSION } from "./core/plugin/lifecycle/ObsidianCompat";
 import { initializeNotificationQueue } from "./core/ui/notifications";
 import { SystemSculptSettings, DEFAULT_SETTINGS, LogLevel, LICENSE_URL } from "./types";
 import { SystemSculptModel } from "./types/llm";
@@ -125,6 +126,8 @@ export default class SystemSculptPlugin extends Plugin {
   private isUnloading = false;
   private isPreloadingDone = false;
   private failures: string[] = [];
+  /** True once a fatal load failure has put the plugin into minimal recovery mode. */
+  private safeMode = false;
   emitter: EventEmitter;
   directoryManager: DirectoryManager;
   public versionCheckerService: VersionCheckerService;
@@ -497,6 +500,7 @@ export default class SystemSculptPlugin extends Plugin {
     void this.writeMobileStartupProbe("onload-entered");
 
     try {
+      this.warnIfObsidianVersionUnsupported();
       this.configureLifecycle(loadStart);
       if (!this.lifecycleCoordinator) {
         throw new Error("Lifecycle coordinator failed to initialize");
@@ -540,9 +544,11 @@ export default class SystemSculptPlugin extends Plugin {
           source: "SystemSculptPlugin",
         });
       }
+
+      this.enterSafeMode("core initialization failed", error);
     }
 
-    if (this.failures.length > 0) {
+    if (this.failures.length > 0 && !this.safeMode) {
       logger.warn("Initialization reported recoverable issues", {
         source: "SystemSculptPlugin",
         metadata: {
@@ -553,6 +559,70 @@ export default class SystemSculptPlugin extends Plugin {
         `SystemSculpt had issues with: ${this.failures.join(", ")}. Some features may be unavailable.`,
         this.collectErrorDetails()
       );
+    }
+  }
+
+  /**
+   * Fail-soft Obsidian version gate (#212/#147). If the running Obsidian is
+   * older than the verified minimum, surface ONE clear notice and continue
+   * best-effort — never hard-block. An unreadable app version is treated as
+   * supported. Safe to call before any service exists.
+   */
+  private warnIfObsidianVersionUnsupported(): void {
+    try {
+      const compat = checkObsidianCompatibility(apiVersion, MINIMUM_OBSIDIAN_VERSION);
+      if (compat.supported) {
+        return;
+      }
+      this.failures.push("unsupported Obsidian version");
+      this.getInitializationTracer().markMilestone("obsidian.version.unsupported", {
+        current: compat.currentVersion,
+        minimum: compat.minimumVersion,
+      });
+      new Notice(
+        `SystemSculpt AI needs Obsidian ${compat.minimumVersion} or newer (you have ${compat.currentVersion}). ` +
+          `Some features may not work until you update Obsidian.`,
+        15000
+      );
+    } catch {
+      // Version gate must never break load.
+    }
+  }
+
+  /**
+   * Enter minimal recovery mode after a fatal load failure (#212/#183). Instead
+   * of silently degrading, register a single recovery command that surfaces
+   * diagnostics and tell the user their settings are safe. Idempotent and
+   * defensive — it runs on the failure path and must not throw.
+   */
+  private enterSafeMode(reason: string, error?: unknown): void {
+    if (this.safeMode) {
+      return;
+    }
+    this.safeMode = true;
+    try {
+      this.addCommand({
+        id: "systemsculpt-show-load-diagnostics",
+        name: "Show load diagnostics (safe mode)",
+        callback: () => {
+          new Notice(
+            `SystemSculpt AI did not finish loading (${reason}). Your settings and backups are safe. ` +
+              `Details:\n${this.collectErrorDetails()}`,
+            0
+          );
+        },
+      });
+    } catch {
+      // Command registration is best-effort in a degraded host.
+    }
+    try {
+      this.showErrorNotice(
+        `SystemSculpt AI could not finish loading (${reason}). Your settings are safe — run ` +
+          `"Show load diagnostics (safe mode)" from the command palette for details.`,
+        error ? String(error) : this.collectErrorDetails()
+      );
+    } catch {
+      // Notice is best-effort.
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -568,9 +568,14 @@ export default class SystemSculptPlugin extends Plugin {
    * best-effort — never hard-block. An unreadable app version is treated as
    * supported. Safe to call before any service exists.
    */
+  /** Indirection over the `obsidian` apiVersion export so tests can drive the gate. */
+  protected getObsidianApiVersion(): string | undefined {
+    return apiVersion;
+  }
+
   private warnIfObsidianVersionUnsupported(): void {
     try {
-      const compat = checkObsidianCompatibility(apiVersion, MINIMUM_OBSIDIAN_VERSION);
+      const compat = checkObsidianCompatibility(this.getObsidianApiVersion(), MINIMUM_OBSIDIAN_VERSION);
       if (compat.supported) {
         return;
       }

--- a/src/services/VersionCheckerService.ts
+++ b/src/services/VersionCheckerService.ts
@@ -589,7 +589,10 @@ export class VersionCheckerService {
 
       const data = response.json || (response.text ? JSON.parse(response.text) : {});
       const version = data?.data?.latestVersion;
-      if (typeof version === 'string') {
+      // Only trust a strictly-numeric version string. A malformed/sentinel value
+      // ("latest", "v5.8.1-beta", an HTML error page, "99.99.99") must fail safe
+      // to "you're up to date" rather than trigger a false update loop (#168).
+      if (typeof version === 'string' && this.parseSemver(version)) {
         return version;
       }
       return this.currentVersion;
@@ -599,24 +602,43 @@ export class VersionCheckerService {
   }
 
   /**
-   * Compares two semantic version strings
-   * @param versionA First version (typically current)
-   * @param versionB Second version (typically latest)
-   * @returns 1 if A > B, 0 if A = B, -1 if A < B
+   * Parse a strict numeric version ("1", "1.2", "1.2.3", "1.2.3.4", with an
+   * optional leading "v") into its integer parts. Returns null for anything
+   * non-numeric — "latest", "1.2.3-beta", "", whitespace, an HTML error body —
+   * so callers can fail safe instead of computing a bogus comparison.
+   *
+   * This is the guard against the #168 false-"update available" loop: an
+   * unparseable remote version must never be treated as "newer than current".
+   */
+  parseSemver(version: string): number[] | null {
+    if (typeof version !== "string") return null;
+    const trimmed = version.trim().replace(/^v/i, "");
+    if (!/^\d+(\.\d+)*$/.test(trimmed)) return null;
+    const parts = trimmed.split(".").map((part) => parseInt(part, 10));
+    return parts.every((n) => Number.isInteger(n) && n >= 0) ? parts : null;
+  }
+
+  /**
+   * Compares two semantic version strings.
+   * @returns 1 if A > B, 0 if A = B (or either side is unparseable), -1 if A < B
+   *
+   * If either version cannot be parsed as a strict numeric semver, returns 0
+   * ("treat as equal") rather than guessing — so a malformed value can never
+   * make the plugin claim an update is available (#168).
    */
   private compareVersions(versionA: string, versionB: string): number {
-    const partsA = versionA.split('.').map(part => parseInt(part, 10));
-    const partsB = versionB.split('.').map(part => parseInt(part, 10));
-    
-    // Compare each part of the version
+    const partsA = this.parseSemver(versionA);
+    const partsB = this.parseSemver(versionB);
+    if (!partsA || !partsB) return 0;
+
     for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
       const partA = i < partsA.length ? partsA[i] : 0;
       const partB = i < partsB.length ? partsB[i] : 0;
-      
+
       if (partA > partB) return 1;
       if (partA < partB) return -1;
     }
-    
+
     return 0; // Versions are equal
   }
 

--- a/src/services/VersionCheckerService.ts
+++ b/src/services/VersionCheckerService.ts
@@ -8,6 +8,7 @@ import SystemSculptPlugin from "../main";
 import { DEVELOPMENT_MODE } from "../constants/api";
 import { GITHUB_API } from "../constants/externalServices";
 import { API_BASE_URL, SYSTEMSCULPT_API_ENDPOINTS } from "../constants/api";
+import { compareNumericVersions, parseNumericVersion } from "../utils/semver";
 
 export interface VersionInfo {
   currentVersion: string;
@@ -611,11 +612,7 @@ export class VersionCheckerService {
    * unparseable remote version must never be treated as "newer than current".
    */
   parseSemver(version: string): number[] | null {
-    if (typeof version !== "string") return null;
-    const trimmed = version.trim().replace(/^v/i, "");
-    if (!/^\d+(\.\d+)*$/.test(trimmed)) return null;
-    const parts = trimmed.split(".").map((part) => parseInt(part, 10));
-    return parts.every((n) => Number.isInteger(n) && n >= 0) ? parts : null;
+    return parseNumericVersion(version);
   }
 
   /**
@@ -627,19 +624,7 @@ export class VersionCheckerService {
    * make the plugin claim an update is available (#168).
    */
   private compareVersions(versionA: string, versionB: string): number {
-    const partsA = this.parseSemver(versionA);
-    const partsB = this.parseSemver(versionB);
-    if (!partsA || !partsB) return 0;
-
-    for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
-      const partA = i < partsA.length ? partsA[i] : 0;
-      const partB = i < partsB.length ? partsB[i] : 0;
-
-      if (partA > partB) return 1;
-      if (partA < partB) return -1;
-    }
-
-    return 0; // Versions are equal
+    return compareNumericVersions(versionA, versionB);
   }
 
   /**

--- a/src/services/__tests__/VersionCheckerService.test.ts
+++ b/src/services/__tests__/VersionCheckerService.test.ts
@@ -186,6 +186,22 @@ describe("VersionCheckerService", () => {
       expect(result.isLatest).toBe(true);
     });
 
+    it("ignores a malformed remote latestVersion and stays on latest (#168)", async () => {
+      const { httpRequest } = await import("../../utils/httpClient");
+      for (const bad of ["latest", "v2.0.0-beta", "<html>error</html>", ""]) {
+        (httpRequest as jest.Mock).mockResolvedValue({
+          status: 200,
+          json: { data: { latestVersion: bad } },
+        });
+
+        const result = await service.checkVersion(true);
+
+        // Malformed remote → fail safe to "you're up to date", never a false update.
+        expect(result.isLatest).toBe(true);
+        expect(result.latestVersion).toBe("1.0.0");
+      }
+    });
+
     it("includes releaseUrl and updateUrl", async () => {
       const { httpRequest } = await import("../../utils/httpClient");
       (httpRequest as jest.Mock).mockResolvedValue({
@@ -307,6 +323,42 @@ describe("VersionCheckerService", () => {
       expect(compareVersions("1.10.0", "1.9.0")).toBe(1);
       expect(compareVersions("1.9.0", "1.10.0")).toBe(-1);
       expect(compareVersions("10.0.0", "9.0.0")).toBe(1);
+    });
+
+    it("treats malformed/non-numeric versions as equal — never a false 'update available' (#168)", () => {
+      // If either side cannot be parsed, return 0 so no update is ever claimed.
+      expect(compareVersions("1.0.0", "latest")).toBe(0);
+      expect(compareVersions("1.0.0", "")).toBe(0);
+      expect(compareVersions("1.0.0", "1.0.0-beta")).toBe(0);
+      expect(compareVersions("1.0.0", "not.a.version")).toBe(0);
+      expect(compareVersions("1.0.0", "   ")).toBe(0);
+      expect(compareVersions("garbage", "1.0.0")).toBe(0);
+      expect(compareVersions("1.0.0", undefined as unknown as string)).toBe(0);
+    });
+
+    it("tolerates a leading 'v' on otherwise-numeric versions", () => {
+      expect(compareVersions("v1.0.0", "1.0.0")).toBe(0);
+      expect(compareVersions("1.0.0", "v2.0.0")).toBe(-1);
+    });
+  });
+
+  describe("parseSemver (#168 guard)", () => {
+    const parse = (v: unknown): number[] | null => (service as any).parseSemver(v);
+
+    it("parses strict numeric versions, optionally v-prefixed", () => {
+      expect(parse("1.2.3")).toEqual([1, 2, 3]);
+      expect(parse("v5.8.1")).toEqual([5, 8, 1]);
+      expect(parse("1")).toEqual([1]);
+      expect(parse("1.2.3.4")).toEqual([1, 2, 3, 4]);
+    });
+
+    it("returns null for anything non-numeric", () => {
+      for (const bad of ["", "   ", "latest", "1.2.3-beta", "v", "1.x.0", "abc", "1.2.3.beta"]) {
+        expect(parse(bad)).toBeNull();
+      }
+      expect(parse(undefined)).toBeNull();
+      expect(parse(null)).toBeNull();
+      expect(parse(123)).toBeNull();
     });
   });
 

--- a/src/tests/mocks/obsidian.js
+++ b/src/tests/mocks/obsidian.js
@@ -696,6 +696,7 @@ class Setting {
 
 module.exports = {
   App,
+  apiVersion: "1.5.0",
   Plugin,
   Notice: class Notice {
     constructor(message) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ import type { WorkflowEngineSettings, WorkflowAutomationState, WorkflowAutomatio
 import { createDefaultWorkflowEngineSettings, createDefaultWorkflowAutomationsState, WORKFLOW_AUTOMATION_IDS } from "./types/workflows";
 import type { ReadwiseImportOptions, ReadwiseOrganization, ReadwiseSyncMode, ReadwiseTweetOrganization } from "./types/readwise";
 import { DEFAULT_READWISE_IMPORT_OPTIONS } from "./types/readwise";
+import { CURRENT_SCHEMA_VERSION } from "./core/settings/migrations/schemaVersion";
 
 export { LogLevel };
 export type { ToolCall };
@@ -85,6 +86,12 @@ export interface SystemSculptSettings {
    * no-focus automation against the already-running Obsidian instance.
    */
   desktopAutomationBridgeEnabled?: boolean;
+
+  /**
+   * Persisted settings schema version, driving the versioned migration chain
+   * (see SettingsMigrator). Absent/0 means pre-versioning data, migrated on load.
+   */
+  schemaVersion?: number;
 
   /**
    * Internal migration flags (not user-facing).
@@ -501,6 +508,7 @@ export const DEFAULT_SETTINGS: SystemSculptSettings = {
   settingsMode: "standard",
   vaultInstanceId: "",
   desktopAutomationBridgeEnabled: false,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   embeddingsVectorFormatVersion: 0,
   licenseKey: "",
   licenseValid: false,

--- a/src/utils/__tests__/semver.test.ts
+++ b/src/utils/__tests__/semver.test.ts
@@ -1,0 +1,38 @@
+import { compareNumericVersions, parseNumericVersion } from "../semver";
+
+describe("parseNumericVersion", () => {
+  it("parses dotted integer versions, optionally v-prefixed", () => {
+    expect(parseNumericVersion("1.2.3")).toEqual([1, 2, 3]);
+    expect(parseNumericVersion("v5.8.1")).toEqual([5, 8, 1]);
+    expect(parseNumericVersion("1")).toEqual([1]);
+    expect(parseNumericVersion("1.2.3.4")).toEqual([1, 2, 3, 4]);
+    expect(parseNumericVersion(" 1.4.0 ")).toEqual([1, 4, 0]);
+  });
+
+  it("returns null for non-numeric / malformed input", () => {
+    for (const bad of ["", "   ", "latest", "1.2.3-beta", "v", "1.x.0", "abc", "1.2.3.beta"]) {
+      expect(parseNumericVersion(bad)).toBeNull();
+    }
+    expect(parseNumericVersion(undefined)).toBeNull();
+    expect(parseNumericVersion(null)).toBeNull();
+    expect(parseNumericVersion(123)).toBeNull();
+  });
+});
+
+describe("compareNumericVersions", () => {
+  it("orders numeric versions correctly", () => {
+    expect(compareNumericVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareNumericVersions("2.0.0", "1.0.0")).toBe(1);
+    expect(compareNumericVersions("1.0.0", "2.0.0")).toBe(-1);
+    expect(compareNumericVersions("1.10.0", "1.9.0")).toBe(1);
+    expect(compareNumericVersions("1.0", "1.0.0")).toBe(0);
+    expect(compareNumericVersions("1.0.1", "1.0")).toBe(1);
+  });
+
+  it("returns 0 (no ordering) when either side is unparseable", () => {
+    expect(compareNumericVersions("1.0.0", "latest")).toBe(0);
+    expect(compareNumericVersions("garbage", "1.0.0")).toBe(0);
+    expect(compareNumericVersions("1.0.0", "")).toBe(0);
+    expect(compareNumericVersions("1.0.0-beta", "1.0.0")).toBe(0);
+  });
+});

--- a/src/utils/semver.ts
+++ b/src/utils/semver.ts
@@ -1,0 +1,44 @@
+/**
+ * Minimal, dependency-free numeric version helpers shared by the plugin-update
+ * check (VersionCheckerService) and the Obsidian-version compatibility gate
+ * (ObsidianCompat). Deliberately strict: anything that is not a dotted run of
+ * integers (optionally "v"-prefixed) parses to null so callers can FAIL SAFE
+ * rather than compute a bogus comparison — the root of the #168 false-update
+ * loop and a guard for the #212 min-version check.
+ */
+
+/**
+ * Parse "1", "1.2", "1.2.3", "1.2.3.4" (optionally "v"-prefixed) into integer
+ * parts. Returns null for anything non-numeric: "latest", "1.2.3-beta", "",
+ * whitespace, an HTML error body, or a non-string.
+ */
+export function parseNumericVersion(version: unknown): number[] | null {
+  if (typeof version !== "string") return null;
+  const trimmed = version.trim().replace(/^v/i, "");
+  if (!/^\d+(\.\d+)*$/.test(trimmed)) return null;
+  const parts = trimmed.split(".").map((part) => parseInt(part, 10));
+  return parts.every((n) => Number.isInteger(n) && n >= 0) ? parts : null;
+}
+
+/**
+ * Compare two numeric version strings.
+ * @returns 1 if a > b, -1 if a < b, 0 if equal OR either side is unparseable.
+ *
+ * Returning 0 for unparseable input is intentional: callers should treat
+ * "unknown" as "no action" (no update prompt, no version block), never as a
+ * definitive ordering.
+ */
+export function compareNumericVersions(a: string, b: string): number {
+  const partsA = parseNumericVersion(a);
+  const partsB = parseNumericVersion(b);
+  if (!partsA || !partsB) return 0;
+
+  const length = Math.max(partsA.length, partsB.length);
+  for (let i = 0; i < length; i++) {
+    const partA = i < partsA.length ? partsA[i] : 0;
+    const partB = i < partsB.length ? partsB[i] : 0;
+    if (partA > partB) return 1;
+    if (partA < partB) return -1;
+  }
+  return 0;
+}

--- a/testing/fixtures/settings/v4.x-legacy.json
+++ b/testing/fixtures/settings/v4.x-legacy.json
@@ -1,0 +1,44 @@
+{
+  "_fixtureMeta": {
+    "describes": "Representative SystemSculpt v4.x data.json — pre-versioning (no schemaVersion), carrying keys that were removed in later releases. Proves an old install upgrades cleanly without losing the user's providers/license.",
+    "era": "4.x"
+  },
+  "licenseKey": "user-v4-license",
+  "licenseValid": true,
+  "selectedModelId": "gpt-4",
+  "chatsDirectory": "SystemSculpt/Chats",
+  "recordingsDirectory": "SystemSculpt/Recordings",
+  "customProviders": [
+    {
+      "id": "openrouter",
+      "name": "OpenRouter",
+      "endpoint": "https://openrouter.ai/api/v1",
+      "apiKey": "sk-or-v4-key",
+      "isEnabled": true
+    }
+  ],
+  "selectedProvider": "openai",
+  "selectedModelProviders": ["openai", "anthropic"],
+  "systemPrompt": "You are a helpful assistant.",
+  "systemPromptType": "default",
+  "systemPromptPath": "",
+  "useLatestSystemPromptForNewChats": true,
+  "canvasFlowEnabled": true,
+  "excludedFolders": ["Private", "Archive"],
+  "excludedFiles": ["secret.md"],
+  "cachedEmbeddingStats": { "count": 100, "lastRun": 1700000000000 },
+  "defaultTemplateModelId": "gpt-4",
+  "templateHotkey": "Mod+Shift+T",
+  "enableTemplateHotkey": true,
+  "recordSystemAudio": true,
+  "videoRecordingsDirectory": "SystemSculpt/Video Recordings",
+  "videoCaptureSystemAudio": true,
+  "videoCaptureMicrophoneAudio": false,
+  "showVideoRecordButtonInChat": true,
+  "showVideoRecordingPermissionPopup": true,
+  "studioTelemetryOptIn": false,
+  "toolingAutoApproveReadOnly": true,
+  "autoUpdateSimilarNotes": true,
+  "hideSimilarNotesAlreadyInContext": false,
+  "backgroundEmbeddingUpdates": true
+}

--- a/testing/fixtures/settings/v5.x-pre-versioning.json
+++ b/testing/fixtures/settings/v5.x-pre-versioning.json
@@ -1,0 +1,36 @@
+{
+  "_fixtureMeta": {
+    "describes": "Representative SystemSculpt v5.x data.json before schema versioning shipped — newer shape with multiple custom providers, a legacy workflowEngine.templates bag, and only partial nested objects. Proves a recent install back-fills new nested defaults and keeps every provider.",
+    "era": "5.x"
+  },
+  "licenseKey": "user-v5-license",
+  "licenseValid": false,
+  "selectedModelId": "systemsculpt@@systemsculpt/ai-agent",
+  "customProviders": [
+    {
+      "id": "openai",
+      "name": "My OpenAI",
+      "endpoint": "https://api.openai.com/v1",
+      "apiKey": "sk-v5-openai",
+      "isEnabled": true
+    },
+    {
+      "id": "anthropic",
+      "name": "Claude",
+      "endpoint": "https://api.anthropic.com",
+      "apiKey": "sk-ant-v5",
+      "isEnabled": false
+    }
+  ],
+  "workflowEngine": {
+    "enabled": true,
+    "templates": {
+      "auto-inbox": { "enabled": true, "sourceFolder": "Inbox" }
+    }
+  },
+  "embeddingsExclusions": {
+    "folders": ["Daily Notes"]
+  },
+  "studioTelemetryOptIn": true,
+  "selectedProvider": "custom"
+}


### PR DESCRIPTION
Closes #212.

Reworks the update path so an update can no longer lose settings or leave a dead plugin:

- **Versioned settings schema** (`schemaVersion` + ordered migration steps): old shapes migrate forward, future shapes are never downgraded, and nested keys are back-filled from defaults — closing the lost-settings / wiped-provider class (#100, #112).
- **Pre-migration backup + automatic rollback**: if migration throws, the raw data is snapshotted and the safest shape loaded instead of failing; restored backups now run through the same migrator too.
- **Load-failure safe mode + fail-soft Obsidian-version gate**: a fatal init degrades to a minimal recovery command instead of "Failed to load plugin" (#183), and an old Obsidian gets a clear notice instead of a crash (#147).
- **Hardened update comparator**: a malformed remote version can no longer trigger a phantom forced-update loop (#168).

Permanent CI guards: a migration harness loads v4.x/v5.x settings fixtures into HEAD, and the update/version logic is tested against a malformed-input matrix.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safe Mode Recovery: If initialization fails, the plugin now enters an idempotent safe mode, shows a non-blocking notice, and provides a single diagnostic command.
  * Obsidian Version Compatibility Check: Requires Obsidian 1.4.0+; unsupported versions trigger a fail-soft warning.
  * Settings Schema Versioning: Settings now carry a schema version to support smoother upgrades from older data.
* **Bug Fixes**
  * Hardened update/version detection to avoid false “update available” results from malformed version strings.
  * Improved backup/restore consistency by migrating settings before applying them.
* **Tests**
  * Added coverage for safe mode, Obsidian compatibility gating, settings migration, and version parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->