### PR TITLE
License-expiry / invalid-key UX: clear, actionable renewal flow (#249)

### DIFF
--- a/src/css/components/notices.css
+++ b/src/css/components/notices.css
@@ -61,6 +61,73 @@
   flex: 1;
 }
 
+/* License / subscription banner (#249) — persistent, dismissible, actionable. */
+.systemsculpt-license-banner {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  margin: 0 8px 8px 8px;
+  background-color: var(--background-modifier-error);
+  border: 1px solid var(--background-modifier-error-hover);
+  border-radius: var(--radius-m);
+  color: var(--text-error);
+  font-size: var(--font-ui-small);
+}
+
+.systemsculpt-license-banner-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.systemsculpt-license-banner-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke: var(--text-error);
+}
+
+.systemsculpt-license-banner-text {
+  flex: 1;
+}
+
+.systemsculpt-license-banner-renew {
+  flex-shrink: 0;
+  cursor: pointer;
+  padding: 2px 10px;
+  border-radius: var(--radius-s);
+  background-color: var(--interactive-accent);
+  color: var(--text-on-accent);
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-medium);
+  border: none;
+}
+
+.systemsculpt-license-banner-renew:hover {
+  background-color: var(--interactive-accent-hover);
+}
+
+.systemsculpt-license-banner-dismiss {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 2px;
+  background: transparent;
+  border: none;
+  color: var(--text-error);
+  opacity: 0.7;
+}
+
+.systemsculpt-license-banner-dismiss:hover {
+  opacity: 1;
+}
+
+.systemsculpt-license-banner-dismiss svg {
+  width: 14px;
+  height: 14px;
+}
+
 /* Agent Status Modal styles */
 .systemsculpt-agent-status-section {
   margin-bottom: 16px;

--- a/src/services/StreamingErrorHandler.ts
+++ b/src/services/StreamingErrorHandler.ts
@@ -247,7 +247,43 @@ export class StreamingErrorHandler {
             return 0;
           };
 
-          if (normalizedUpstreamCode === 'insufficient_credits') {
+          // License / subscription failure (#249). The managed SystemSculpt API
+          // authenticates with the license key, so any 401/403 here is a license
+          // problem — never a transient stream error. A newer server sends a
+          // discriminated code (`license_expired` | `license_invalid` | ...) and a
+          // `renew_url`; older servers send only a 401 with a human string, so we
+          // fall back to status + message text. Without this, the key bug (#249)
+          // surfaced as the generic "Error in streaming response. Please try again."
+          const topLevelCode = typeof data.code === 'string' ? data.code.trim().toLowerCase() : '';
+          const licenseCode = normalizedUpstreamCode.startsWith('license_') ? normalizedUpstreamCode : topLevelCode;
+          const serverErrorMessage = (isStringError ? String(data.error) : upstreamMessage).trim();
+          const isLicenseCode =
+            licenseCode.startsWith('license_') || licenseCode === 'invalid_license' || licenseCode === 'missing_license';
+          const isAuthStatus = status === 401 || status === 403;
+          const mentionsLicense = /licen[sc]e/i.test(serverErrorMessage);
+
+          if (isLicenseCode || (isAuthStatus && (mentionsLicense || isAuthFailureMessage(serverErrorMessage)))) {
+            const expired = licenseCode === 'license_expired' || /\bexpired\b/i.test(serverErrorMessage);
+            errorCode = expired ? ERROR_CODES.LICENSE_EXPIRED : ERROR_CODES.INVALID_LICENSE;
+            errorMessage = getErrorMessage(errorCode);
+            const renewUrlRaw =
+              typeof data.renew_url === 'string' && data.renew_url.trim()
+                ? data.renew_url.trim()
+                : typeof (data.error as any)?.renew_url === 'string' && (data.error as any).renew_url.trim()
+                  ? (data.error as any).renew_url.trim()
+                  : null;
+            metadata = {
+              model: data.model,
+              statusCode: status,
+              rawError: data.error,
+              licenseFailure: true,
+              ...(serverErrorMessage ? { serverMessage: serverErrorMessage } : {}),
+              ...(licenseCode ? { licenseCode } : {}),
+              ...(renewUrlRaw ? { renewUrl: renewUrlRaw } : {}),
+              ...(requestId ? { requestId } : {}),
+              ...(context?.endpoint ? { endpoint: context.endpoint } : {}),
+            };
+          } else if (normalizedUpstreamCode === 'insufficient_credits') {
             errorCode = ERROR_CODES.INSUFFICIENT_CREDITS;
             errorMessage = upstreamMessage || getErrorMessage(errorCode);
             metadata = {

--- a/src/services/StreamingErrorHandler.ts
+++ b/src/services/StreamingErrorHandler.ts
@@ -255,10 +255,18 @@ export class StreamingErrorHandler {
           // fall back to status + message text. Without this, the key bug (#249)
           // surfaced as the generic "Error in streaming response. Please try again."
           const topLevelCode = typeof data.code === 'string' ? data.code.trim().toLowerCase() : '';
-          const licenseCode = normalizedUpstreamCode.startsWith('license_') ? normalizedUpstreamCode : topLevelCode;
+          // Honor a discriminated license code from either the object form
+          // (`error.code`, captured in normalizedUpstreamCode) or the top-level
+          // `code` — never silently drop `invalid_license`/`missing_license`.
+          const isKnownLicenseCode = (code: string): boolean =>
+            code.startsWith('license_') || code === 'invalid_license' || code === 'missing_license';
+          const licenseCode = isKnownLicenseCode(normalizedUpstreamCode)
+            ? normalizedUpstreamCode
+            : isKnownLicenseCode(topLevelCode)
+              ? topLevelCode
+              : '';
           const serverErrorMessage = (isStringError ? String(data.error) : upstreamMessage).trim();
-          const isLicenseCode =
-            licenseCode.startsWith('license_') || licenseCode === 'invalid_license' || licenseCode === 'missing_license';
+          const isLicenseCode = isKnownLicenseCode(licenseCode);
           const isAuthStatus = status === 401 || status === 403;
           const mentionsLicense = /licen[sc]e/i.test(serverErrorMessage);
 

--- a/src/services/__tests__/StreamingErrorHandler.test.ts
+++ b/src/services/__tests__/StreamingErrorHandler.test.ts
@@ -49,6 +49,54 @@ describe("StreamingErrorHandler", () => {
     }).rejects.toThrow(upstreamMessage);
   });
 
+  describe("SystemSculpt API license failures (#249)", () => {
+    it("classifies a 401 'Invalid or expired license key' string as LICENSE_EXPIRED (not a generic stream error)", async () => {
+      const response = createMockResponse(401, { error: "Invalid or expired license key" });
+      await expect(
+        StreamingErrorHandler.handleStreamError(response, false)
+      ).rejects.toMatchObject({
+        code: ERROR_CODES.LICENSE_EXPIRED,
+        message: "Your license has expired. Please renew your subscription.",
+      });
+    });
+
+    it("classifies an invalid (non-expired) key as INVALID_LICENSE", async () => {
+      const response = createMockResponse(401, { error: "Invalid license key", code: "license_invalid" });
+      await expect(
+        StreamingErrorHandler.handleStreamError(response, false)
+      ).rejects.toMatchObject({ code: ERROR_CODES.INVALID_LICENSE });
+    });
+
+    it("honors a discriminated server code + renew_url in metadata", async () => {
+      const response = createMockResponse(401, {
+        error: "Invalid or expired license key",
+        code: "license_expired",
+        renew_url: "https://systemsculpt.com/renew",
+      });
+      try {
+        await StreamingErrorHandler.handleStreamError(response, false);
+        throw new Error("expected handleStreamError to throw");
+      } catch (err) {
+        const systemError = err as SystemSculptError;
+        expect(systemError.code).toBe(ERROR_CODES.LICENSE_EXPIRED);
+        expect(systemError.metadata).toEqual(
+          expect.objectContaining({
+            licenseFailure: true,
+            renewUrl: "https://systemsculpt.com/renew",
+            statusCode: 401,
+          })
+        );
+      }
+    });
+
+    it("does NOT misclassify a generic 500 stream error as a license problem", async () => {
+      const response = createMockResponse(500, { error: "INTERNAL_ERROR", message: "boom" });
+      await expect(
+        StreamingErrorHandler.handleStreamError(response, false)
+      ).rejects.toMatchObject({ code: ERROR_CODES.STREAM_ERROR });
+    });
+  });
+
   describe("non-JSON response handling", () => {
     it("handles plain text error response", async () => {
       const response = createMockResponse(500, "Internal Server Error");

--- a/src/services/__tests__/StreamingErrorHandler.test.ts
+++ b/src/services/__tests__/StreamingErrorHandler.test.ts
@@ -89,6 +89,24 @@ describe("StreamingErrorHandler", () => {
       }
     });
 
+    it("classifies the object-shaped error form ({ error: { code } }) as a license failure", async () => {
+      const response = createMockResponse(401, {
+        error: { code: "invalid_license", message: "Invalid license key" },
+      });
+      await expect(
+        StreamingErrorHandler.handleStreamError(response, false)
+      ).rejects.toMatchObject({ code: ERROR_CODES.INVALID_LICENSE });
+    });
+
+    it("classifies an object-shaped missing_license code as a license failure", async () => {
+      const response = createMockResponse(401, {
+        error: { code: "missing_license", message: "Missing license key" },
+      });
+      await expect(
+        StreamingErrorHandler.handleStreamError(response, false)
+      ).rejects.toMatchObject({ code: ERROR_CODES.INVALID_LICENSE });
+    });
+
     it("does NOT misclassify a generic 500 stream error as a license problem", async () => {
       const response = createMockResponse(500, { error: "INTERNAL_ERROR", message: "boom" });
       await expect(

--- a/src/utils/externalUrl.ts
+++ b/src/utils/externalUrl.ts
@@ -1,0 +1,40 @@
+/**
+ * Open an external URL safely.
+ *
+ * - Only `http:`/`https:` schemes are honored — a `javascript:`/`data:` URL
+ *   (e.g. an untrusted value that reached us via server metadata) is rejected.
+ * - Prefers the system browser via Electron `shell.openExternal` on desktop.
+ * - Falls back to `window.open(..., "_blank", "noopener,noreferrer")` to avoid
+ *   reverse-tabnabbing / opener abuse.
+ *
+ * Returns `true` if the URL was safe and an open was attempted, `false` otherwise.
+ */
+export async function openExternalUrl(url: string): Promise<boolean> {
+  const trimmed = String(url || "").trim();
+  if (!trimmed) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return false;
+  const href = parsed.toString();
+
+  const runtimeRequire = typeof window !== "undefined" ? (window as any)?.require : null;
+  const electron = typeof runtimeRequire === "function" ? runtimeRequire("electron") : null;
+  const shell = electron?.shell;
+  try {
+    if (typeof shell?.openExternal === "function") {
+      await shell.openExternal(href);
+      return true;
+    }
+  } catch {
+    // Fall back to window.open below.
+  }
+  if (typeof window !== "undefined" && typeof window.open === "function") {
+    window.open(href, "_blank", "noopener,noreferrer");
+  }
+  return true;
+}

--- a/src/utils/oauthUiHelpers.ts
+++ b/src/utils/oauthUiHelpers.ts
@@ -1,3 +1,5 @@
+import { openExternalUrl } from "./externalUrl";
+
 export type OAuthPromptLike = {
   message?: unknown;
   placeholder?: unknown;
@@ -15,22 +17,5 @@ export function isOAuthCodePrompt(prompt: OAuthPromptLike): boolean {
 }
 
 export async function openExternalUrlForOAuth(url: string): Promise<void> {
-  const trimmed = String(url || "").trim();
-  if (!trimmed) {
-    return;
-  }
-  const runtimeRequire = typeof window !== "undefined" ? (window as any)?.require : null;
-  const electron = typeof runtimeRequire === "function" ? runtimeRequire("electron") : null;
-  const shell = electron?.shell;
-  try {
-    if (typeof shell?.openExternal === "function") {
-      await shell.openExternal(trimmed);
-      return;
-    }
-  } catch {
-    // Fall back to window.open below.
-  }
-  if (typeof window !== "undefined" && typeof window.open === "function") {
-    window.open(trimmed, "_blank", "noopener,noreferrer");
-  }
+  await openExternalUrl(url);
 }

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -8,6 +8,7 @@ import type SystemSculptPlugin from "../../main";
 import { showPopup, showAlert } from "../../core/ui/";
 import { SystemSculptError, isContextOverflowErrorMessage, ERROR_CODES } from "../../utils/errors";
 import { SYSTEMSCULPT_WEBSITE } from "../../constants/externalServices";
+import { openExternalUrl } from "../../utils/externalUrl";
 import { MessageRenderer } from "./MessageRenderer";
 import { InputHandler, type AutomationApprovalMode } from "./InputHandler";
 import { FileContextManager } from "./FileContextManager";
@@ -746,7 +747,7 @@ export class ChatView extends ItemView {
       );
 
       if (result?.action === "primary" || result?.confirmed) {
-        window.open(renewUrl, "_blank");
+        void openExternalUrl(renewUrl);
       } else if (result?.action === "secondary") {
         this.openSetupTab("account");
       }
@@ -928,7 +929,14 @@ export class ChatView extends ItemView {
     this.creditsBalanceRefreshPromise = (async () => {
       try {
         this.creditsBalance = await this.aiService.getCreditsBalance();
-        // A successful balance fetch means the license is healthy again.
+        // A successful balance fetch means the license is healthy again — heal
+        // any stale invalid state so gating/account UI agree (#249). Guarded so
+        // a routine poll doesn't rewrite settings on every refresh.
+        if (this.plugin.settings.licenseValid === false) {
+          try {
+            await this.plugin.getSettingsManager().updateSettings({ licenseValid: true });
+          } catch {}
+        }
         try { uiSetup.hideLicenseBanner(this); } catch {}
       } catch (creditsError) {
         // Proactively surface an expired/invalid license on chat open — before

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -7,6 +7,7 @@ import { ScrollManagerService } from "./ScrollManagerService";
 import type SystemSculptPlugin from "../../main";
 import { showPopup, showAlert } from "../../core/ui/";
 import { SystemSculptError, isContextOverflowErrorMessage, ERROR_CODES } from "../../utils/errors";
+import { SYSTEMSCULPT_WEBSITE } from "../../constants/externalServices";
 import { MessageRenderer } from "./MessageRenderer";
 import { InputHandler, type AutomationApprovalMode } from "./InputHandler";
 import { FileContextManager } from "./FileContextManager";
@@ -705,6 +706,53 @@ export class ChatView extends ItemView {
       return;
     }
 
+    if (
+      error instanceof SystemSculptError &&
+      (error.code === ERROR_CODES.LICENSE_EXPIRED || error.code === ERROR_CODES.INVALID_LICENSE)
+    ) {
+      await this.resetFailedAssistantTurn();
+
+      // A rejected license is no longer valid — reflect that across the UI so
+      // gating, the account panel, and the banner all agree (#249).
+      try {
+        await this.plugin.getSettingsManager().updateSettings({ licenseValid: false });
+      } catch {}
+
+      const expired = error.code === ERROR_CODES.LICENSE_EXPIRED;
+      const renewUrl =
+        typeof error.metadata?.renewUrl === "string" && error.metadata.renewUrl
+          ? String(error.metadata.renewUrl)
+          : SYSTEMSCULPT_WEBSITE.LICENSE;
+
+      try {
+        uiSetup.showLicenseBanner(this, { expired, renewUrl });
+      } catch {}
+
+      if (automationRequestActive) {
+        return;
+      }
+
+      const result = await showPopup(
+        this.app,
+        expired
+          ? "Your SystemSculpt subscription has expired, so the managed AI can't run.\n\nRenew to continue, or switch to your own API key in Settings."
+          : "Your SystemSculpt license key is invalid or was changed, so the managed AI can't run.\n\nRenew or re-enter your key, or switch to your own API key in Settings.",
+        {
+          title: expired ? "Subscription expired" : "License problem",
+          icon: "key-round",
+          primaryButton: "Renew subscription",
+          secondaryButton: "Open settings",
+        }
+      );
+
+      if (result?.action === "primary" || result?.confirmed) {
+        window.open(renewUrl, "_blank");
+      } else if (result?.action === "secondary") {
+        this.openSetupTab("account");
+      }
+      return;
+    }
+
     if (error instanceof SystemSculptError && error.code === ERROR_CODES.TURN_IN_FLIGHT) {
       await this.resetFailedAssistantTurn();
       const lockUntil = typeof error.metadata?.lockUntil === 'string' ? error.metadata.lockUntil : '';
@@ -880,8 +928,30 @@ export class ChatView extends ItemView {
     this.creditsBalanceRefreshPromise = (async () => {
       try {
         this.creditsBalance = await this.aiService.getCreditsBalance();
-      } catch {
-        // Avoid noisy toasts; the balance UI is a convenience panel.
+        // A successful balance fetch means the license is healthy again.
+        try { uiSetup.hideLicenseBanner(this); } catch {}
+      } catch (creditsError) {
+        // Proactively surface an expired/invalid license on chat open — before
+        // the user sends a doomed message (#249). Other errors stay silent
+        // (the balance UI is a convenience panel).
+        if (
+          creditsError instanceof SystemSculptError &&
+          (creditsError.code === ERROR_CODES.LICENSE_EXPIRED || creditsError.code === ERROR_CODES.INVALID_LICENSE)
+        ) {
+          try {
+            await this.plugin.getSettingsManager().updateSettings({ licenseValid: false });
+          } catch {}
+          const renewUrl =
+            typeof creditsError.metadata?.renewUrl === "string" && creditsError.metadata.renewUrl
+              ? String(creditsError.metadata.renewUrl)
+              : SYSTEMSCULPT_WEBSITE.LICENSE;
+          try {
+            uiSetup.showLicenseBanner(this, {
+              expired: creditsError.code === ERROR_CODES.LICENSE_EXPIRED,
+              renewUrl,
+            });
+          } catch {}
+        }
       } finally {
         try {
           await this.updateCreditsIndicator();

--- a/src/views/chatview/__tests__/chatview-license-error-handling.test.ts
+++ b/src/views/chatview/__tests__/chatview-license-error-handling.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { ChatView } from "../ChatView";
+import { ERROR_CODES, SystemSculptError } from "../../../utils/errors";
+import { showPopup } from "../../../core/ui/";
+import { openExternalUrl } from "../../../utils/externalUrl";
+import { uiSetup } from "../uiSetup";
+import { SYSTEMSCULPT_WEBSITE } from "../../../constants/externalServices";
+
+jest.mock("../../../core/ui/", () => ({ showPopup: jest.fn() }));
+jest.mock("../../../utils/externalUrl", () => ({ openExternalUrl: jest.fn() }));
+jest.mock("../uiSetup", () => ({
+  uiSetup: {
+    showLicenseBanner: jest.fn(),
+    hideLicenseBanner: jest.fn(),
+    updateToolCompatibilityWarning: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const showPopupMock = showPopup as jest.Mock;
+const openExternalUrlMock = openExternalUrl as jest.Mock;
+const showBannerMock = uiSetup.showLicenseBanner as jest.Mock;
+const hideBannerMock = uiSetup.hideLicenseBanner as jest.Mock;
+
+const makeHandleErrorView = (opts: { automation?: boolean; updateSettings: jest.Mock }) => ({
+  inputHandler: { isAutomationRequestActive: jest.fn(() => opts.automation === true) },
+  getEffectiveSelectedModelId: jest.fn(() => "systemsculpt@@systemsculpt/ai-agent"),
+  resetFailedAssistantTurn: jest.fn().mockResolvedValue(undefined),
+  openSetupTab: jest.fn(),
+  messages: [],
+  chatId: "chat-license",
+  isGenerating: false,
+  app: {},
+  plugin: {
+    getSettingsManager: () => ({ updateSettings: opts.updateSettings }),
+    settings: { licenseValid: true },
+  },
+});
+
+const makeRefreshView = (opts: {
+  licenseValid: boolean;
+  getCreditsBalance: jest.Mock;
+  updateSettings: jest.Mock;
+}) => ({
+  plugin: {
+    getEntitlementService: () => ({ hasSystemSculptLicense: () => true }),
+    getSettingsManager: () => ({ updateSettings: opts.updateSettings }),
+    settings: { licenseValid: opts.licenseValid },
+  },
+  aiService: { getCreditsBalance: opts.getCreditsBalance },
+  updateCreditsIndicator: jest.fn().mockResolvedValue(undefined),
+  creditsBalanceRefreshPromise: null as Promise<void> | null,
+  creditsBalance: null,
+});
+
+describe("ChatView license error handling (#249)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("expired license: flips licenseValid, shows an expired banner, and renews on the primary action", async () => {
+    showPopupMock.mockResolvedValue({ action: "primary" });
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    const view = makeHandleErrorView({ updateSettings });
+
+    await ChatView.prototype.handleError.call(
+      view as any,
+      new SystemSculptError("expired", ERROR_CODES.LICENSE_EXPIRED, 401, {
+        renewUrl: "https://systemsculpt.com/renew",
+      })
+    );
+
+    expect(view.resetFailedAssistantTurn).toHaveBeenCalledTimes(1);
+    expect(updateSettings).toHaveBeenCalledWith({ licenseValid: false });
+    expect(showBannerMock).toHaveBeenCalledWith(view, {
+      expired: true,
+      renewUrl: "https://systemsculpt.com/renew",
+    });
+    expect(showPopupMock).toHaveBeenCalledTimes(1);
+    expect(openExternalUrlMock).toHaveBeenCalledWith("https://systemsculpt.com/renew");
+    expect(view.openSetupTab).not.toHaveBeenCalled();
+  });
+
+  it("invalid license: shows an invalid banner, opens settings on the secondary action, and falls back to the license URL", async () => {
+    showPopupMock.mockResolvedValue({ action: "secondary" });
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    const view = makeHandleErrorView({ updateSettings });
+
+    await ChatView.prototype.handleError.call(
+      view as any,
+      new SystemSculptError("invalid", ERROR_CODES.INVALID_LICENSE, 401, {})
+    );
+
+    expect(showBannerMock).toHaveBeenCalledWith(view, {
+      expired: false,
+      renewUrl: SYSTEMSCULPT_WEBSITE.LICENSE,
+    });
+    expect(view.openSetupTab).toHaveBeenCalledWith("account");
+    expect(openExternalUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("during automation: heals state and banners but skips the blocking popup", async () => {
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    const view = makeHandleErrorView({ automation: true, updateSettings });
+
+    await ChatView.prototype.handleError.call(
+      view as any,
+      new SystemSculptError("expired", ERROR_CODES.LICENSE_EXPIRED, 401, {})
+    );
+
+    expect(view.resetFailedAssistantTurn).toHaveBeenCalledTimes(1);
+    expect(updateSettings).toHaveBeenCalledWith({ licenseValid: false });
+    expect(showBannerMock).toHaveBeenCalledTimes(1);
+    expect(showPopupMock).not.toHaveBeenCalled();
+    expect(openExternalUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshCreditsBalance: proactively flags an expired license from a credits 401", async () => {
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    const getCreditsBalance = jest.fn().mockRejectedValue(
+      new SystemSculptError("expired", ERROR_CODES.LICENSE_EXPIRED, 401, { renewUrl: "https://x/renew" })
+    );
+    const view = makeRefreshView({ licenseValid: true, getCreditsBalance, updateSettings });
+
+    await ChatView.prototype.refreshCreditsBalance.call(view as any);
+
+    expect(updateSettings).toHaveBeenCalledWith({ licenseValid: false });
+    expect(showBannerMock).toHaveBeenCalledWith(view, { expired: true, renewUrl: "https://x/renew" });
+    expect(hideBannerMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshCreditsBalance: heals stale invalid state and hides the banner on a successful fetch", async () => {
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    const getCreditsBalance = jest.fn().mockResolvedValue({ remaining: 100 });
+    const view = makeRefreshView({ licenseValid: false, getCreditsBalance, updateSettings });
+
+    await ChatView.prototype.refreshCreditsBalance.call(view as any);
+
+    expect(updateSettings).toHaveBeenCalledWith({ licenseValid: true });
+    expect(hideBannerMock).toHaveBeenCalledWith(view);
+  });
+
+  it("refreshCreditsBalance: does not rewrite settings when the license is already valid", async () => {
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    const getCreditsBalance = jest.fn().mockResolvedValue({ remaining: 100 });
+    const view = makeRefreshView({ licenseValid: true, getCreditsBalance, updateSettings });
+
+    await ChatView.prototype.refreshCreditsBalance.call(view as any);
+
+    expect(updateSettings).not.toHaveBeenCalled();
+    expect(hideBannerMock).toHaveBeenCalledWith(view);
+  });
+
+  it("refreshCreditsBalance: stays silent for a non-license credits error", async () => {
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    const getCreditsBalance = jest.fn().mockRejectedValue(
+      new SystemSculptError("boom", ERROR_CODES.STREAM_ERROR, 500, {})
+    );
+    const view = makeRefreshView({ licenseValid: true, getCreditsBalance, updateSettings });
+
+    await ChatView.prototype.refreshCreditsBalance.call(view as any);
+
+    expect(updateSettings).not.toHaveBeenCalled();
+    expect(showBannerMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/chatview/__tests__/license-banner.test.ts
+++ b/src/views/chatview/__tests__/license-banner.test.ts
@@ -1,0 +1,87 @@
+jest.mock("../../../utils/modelUtils", () => ({
+  createCanonicalId: jest.fn((p: string, m: string) => `${p}@@${m}`),
+  ensureCanonicalId: jest.fn((id: string) => id || ""),
+  getModelLabelWithProvider: jest.fn((id: string) => id || ""),
+  getDisplayName: jest.fn((id: string) => id || ""),
+  getImageCompatibilityInfo: jest.fn(),
+}));
+
+import { JSDOM } from "jsdom";
+import { uiSetup } from "../uiSetup";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>");
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+
+// Minimal Obsidian HTMLElement extensions used by the banner code.
+const proto = (global as any).window.HTMLElement.prototype;
+if (!proto.empty) {
+  proto.empty = function () {
+    while (this.firstChild) this.removeChild(this.firstChild);
+    return this;
+  };
+}
+
+const createChatView = () => {
+  const root = document.createElement("div");
+  root.appendChild(document.createElement("div")); // children[0]
+  const content = document.createElement("div"); // children[1]
+  root.appendChild(content);
+  const composer = document.createElement("div");
+  composer.className = "systemsculpt-chat-composer";
+  content.appendChild(composer);
+  return { chatView: { containerEl: root } as any, content };
+};
+
+const bannerOf = (content: HTMLElement) =>
+  content.querySelector(".systemsculpt-license-banner") as HTMLElement | null;
+
+describe("uiSetup license banner (#249)", () => {
+  it("renders a dismissible, actionable banner above the composer for an expired subscription", () => {
+    const { chatView, content } = createChatView();
+
+    uiSetup.showLicenseBanner(chatView, { expired: true, renewUrl: "https://systemsculpt.com/renew" });
+
+    const banner = bannerOf(content);
+    expect(banner).not.toBeNull();
+    expect(banner!.style.display).toBe("flex");
+    expect(banner!.querySelector(".systemsculpt-license-banner-text")?.textContent).toMatch(/expired/i);
+    // Inserted before the composer (so it sits at the bottom of the message area).
+    expect(banner!.nextElementSibling?.className).toBe("systemsculpt-chat-composer");
+
+    const renewBtn = banner!.querySelector(".systemsculpt-license-banner-renew") as HTMLElement;
+    expect(renewBtn).not.toBeNull();
+    const openSpy = jest.spyOn(dom.window as any, "open").mockImplementation(() => null);
+    renewBtn.dispatchEvent(new dom.window.Event("click"));
+    expect(openSpy).toHaveBeenCalledWith("https://systemsculpt.com/renew", "_blank");
+    openSpy.mockRestore();
+  });
+
+  it("uses invalid-key copy when the license is invalid (not expired)", () => {
+    const { chatView, content } = createChatView();
+    uiSetup.showLicenseBanner(chatView, { expired: false, renewUrl: "https://x" });
+    expect(bannerOf(content)!.querySelector(".systemsculpt-license-banner-text")?.textContent).toMatch(/invalid/i);
+  });
+
+  it("is idempotent — repeated shows reuse one banner element", () => {
+    const { chatView, content } = createChatView();
+    uiSetup.showLicenseBanner(chatView, { expired: true, renewUrl: "https://x" });
+    uiSetup.showLicenseBanner(chatView, { expired: true, renewUrl: "https://x" });
+    expect(content.querySelectorAll(".systemsculpt-license-banner")).toHaveLength(1);
+  });
+
+  it("hideLicenseBanner hides an existing banner", () => {
+    const { chatView, content } = createChatView();
+    uiSetup.showLicenseBanner(chatView, { expired: true, renewUrl: "https://x" });
+    uiSetup.hideLicenseBanner(chatView);
+    expect(bannerOf(content)!.style.display).toBe("none");
+  });
+
+  it("the dismiss button hides the banner", () => {
+    const { chatView, content } = createChatView();
+    uiSetup.showLicenseBanner(chatView, { expired: true, renewUrl: "https://x" });
+    const dismiss = bannerOf(content)!.querySelector(".systemsculpt-license-banner-dismiss") as HTMLElement;
+    dismiss.dispatchEvent(new dom.window.Event("click"));
+    expect(bannerOf(content)!.style.display).toBe("none");
+  });
+});

--- a/src/views/chatview/__tests__/license-banner.test.ts
+++ b/src/views/chatview/__tests__/license-banner.test.ts
@@ -53,7 +53,8 @@ describe("uiSetup license banner (#249)", () => {
     expect(renewBtn).not.toBeNull();
     const openSpy = jest.spyOn(dom.window as any, "open").mockImplementation(() => null);
     renewBtn.dispatchEvent(new dom.window.Event("click"));
-    expect(openSpy).toHaveBeenCalledWith("https://systemsculpt.com/renew", "_blank");
+    // Opened safely: scheme-validated, in a new tab, with opener/referrer stripped.
+    expect(openSpy).toHaveBeenCalledWith("https://systemsculpt.com/renew", "_blank", "noopener,noreferrer");
     openSpy.mockRestore();
   });
 

--- a/src/views/chatview/uiSetup.ts
+++ b/src/views/chatview/uiSetup.ts
@@ -7,6 +7,7 @@ import { InputHandler } from "./InputHandler";
 import { ensureCanonicalId, getDisplayName, getImageCompatibilityInfo } from '../../utils/modelUtils';
 import { attachOverlapInsetManager } from "../../core/ui/services/OverlapInsetService";
 import { renderChatCreditsIndicator } from "./ui/ChatComposerIndicators";
+import { openExternalUrl } from "../../utils/externalUrl";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Utility helpers for desktop Pi chat UI
@@ -520,7 +521,7 @@ export const uiSetup = {
     renewBtn.className = "systemsculpt-license-banner-renew";
     renewBtn.textContent = "Renew";
     renewBtn.addEventListener("click", () => {
-      window.open(options.renewUrl, "_blank");
+      void openExternalUrl(options.renewUrl);
     });
     banner.appendChild(renewBtn);
 

--- a/src/views/chatview/uiSetup.ts
+++ b/src/views/chatview/uiSetup.ts
@@ -12,6 +12,7 @@ import { renderChatCreditsIndicator } from "./ui/ChatComposerIndicators";
 // Utility helpers for desktop Pi chat UI
 // ────────────────────────────────────────────────────────────────────────────
 const TOOL_WARNING_BANNER_CLASS = "systemsculpt-tool-warning-banner";
+const LICENSE_BANNER_CLASS = "systemsculpt-license-banner";
 const IMAGE_CONTEXT_EXTENSIONS = new Set(["jpg", "jpeg", "png", "webp", "svg"]);
 
 const isImageExtension = (extension?: string | null): boolean => {
@@ -100,6 +101,18 @@ const ensureToolWarningBanner = (container: HTMLElement): HTMLElement | null => 
     banner.appendChild(textSpan);
   }
 
+  return banner;
+};
+
+const ensureLicenseBanner = (container: HTMLElement): HTMLElement | null => {
+  let banner = container.querySelector(`.${LICENSE_BANNER_CLASS}`) as HTMLElement | null;
+  if (!banner) {
+    const composer = container.querySelector(".systemsculpt-chat-composer");
+    if (!composer) return null;
+    banner = document.createElement("div");
+    banner.className = LICENSE_BANNER_CLASS;
+    composer.parentNode?.insertBefore(banner, composer);
+  }
   return banner;
 };
 
@@ -477,5 +490,56 @@ export const uiSetup = {
       // On error, hide warning
       if (banner) banner.style.display = "none";
     }
+  },
+
+  /**
+   * Show a persistent, dismissible license/subscription banner above the
+   * composer with a Renew action (#249). Idempotent — reuses an existing banner.
+   */
+  showLicenseBanner: function(chatView: ChatView, options: { expired: boolean; renewUrl: string }): void {
+    const container = chatView.containerEl.children[1] as HTMLElement | undefined;
+    if (!container) return;
+    const banner = ensureLicenseBanner(container);
+    if (!banner) return;
+
+    banner.empty();
+
+    const iconSpan = document.createElement("span");
+    iconSpan.className = "systemsculpt-license-banner-icon";
+    setIcon(iconSpan, "key-round");
+    banner.appendChild(iconSpan);
+
+    const textSpan = document.createElement("span");
+    textSpan.className = "systemsculpt-license-banner-text";
+    textSpan.textContent = options.expired
+      ? "Your SystemSculpt subscription has expired. Renew to keep using the managed AI, or switch to your own API key in Settings."
+      : "Your SystemSculpt license is invalid. Renew or update your key to keep using the managed AI, or switch to your own API key in Settings.";
+    banner.appendChild(textSpan);
+
+    const renewBtn = document.createElement("button");
+    renewBtn.className = "systemsculpt-license-banner-renew";
+    renewBtn.textContent = "Renew";
+    renewBtn.addEventListener("click", () => {
+      window.open(options.renewUrl, "_blank");
+    });
+    banner.appendChild(renewBtn);
+
+    const dismissBtn = document.createElement("button");
+    dismissBtn.className = "systemsculpt-license-banner-dismiss";
+    dismissBtn.setAttribute("aria-label", "Dismiss");
+    setIcon(dismissBtn, "x");
+    dismissBtn.addEventListener("click", () => {
+      banner.style.display = "none";
+    });
+    banner.appendChild(dismissBtn);
+
+    banner.style.display = "flex";
+  },
+
+  /** Hide the license banner (e.g. once a credits refresh succeeds). */
+  hideLicenseBanner: function(chatView: ChatView): void {
+    const container = chatView.containerEl.children[1] as HTMLElement | undefined;
+    const banner = container?.querySelector(`.${LICENSE_BANNER_CLASS}`) as HTMLElement | null;
+    if (banner) banner.style.display = "none";
   },
 };


### PR DESCRIPTION
Part 1 of #249 (plugin side; a companion API PR adds the discriminated error code + renew_url).

A license/subscription 401 from the managed API used to surface as the generic **"Error in streaming response. Please try again."** Now:

- **Classified correctly:** `StreamingErrorHandler` maps managed-API 401/403 to `LICENSE_EXPIRED` / `INVALID_LICENSE` (the codes already existed but were never produced on this path). It honors a server-provided `code` + `renew_url` when present, and falls back to HTTP status + message text so it works against today's server too.
- **Actionable on send:** chat shows a "Renew subscription" CTA (and "Open settings") instead of a dead-end retry, and flips `licenseValid` so gating/account UI agree.
- **Proactive on open:** the previously-silent `credits/balance` 401 now raises a persistent, dismissible banner above the composer with a Renew action — before the user sends a doomed message.

Permanent guards: handler classification unit tests (expired vs invalid vs discriminated code+renew_url vs a 500 that must stay generic) and a uiSetup banner test (render/dismiss/idempotent/renew action).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a dismissible license/subscription banner to inform users of expired or invalid license status, with a “Renew” action and easy access to account settings.
- Improved license-related error handling to classify expired vs invalid/missing licenses and surface the correct renewal URL/message.

## Bug Fixes
- Updated credits-balance refresh to proactively sync license validity state and automatically show/hide the banner based on results.

## Tests
- Added coverage for license failure classification, banner rendering/dismissal, and end-to-end ChatView license error handling (including automation mode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->