### PR TITLE
fix(lifecycle): make a disabled plugin fully inert (#214)

### DIFF
--- a/src/core/plugin/__tests__/ribbons.test.ts
+++ b/src/core/plugin/__tests__/ribbons.test.ts
@@ -167,4 +167,19 @@ describe("RibbonManager", () => {
       expect(ribbon.isConnected).toBe(false);
     });
   });
+
+  // #134/#214: ribbon init is deferred (a setTimeout in ViewManager), so the
+  // queued callback can fire after onunload flips the unloading flag. The guard
+  // must keep that late init from re-adding icons to a disabled plugin.
+  it("does not register ribbons when the plugin is already unloading (#134)", async () => {
+    const { app, plugin } = createPlugin();
+    plugin.isPluginUnloading = jest.fn(() => true);
+    const manager = new RibbonManager(plugin, app);
+
+    manager.initialize();
+    await flushAsyncWork();
+
+    expect(plugin.isPluginUnloading).toHaveBeenCalled();
+    expect(getRibbonElements(plugin)).toHaveLength(0);
+  });
 });

--- a/src/core/plugin/ribbons.ts
+++ b/src/core/plugin/ribbons.ts
@@ -27,7 +27,10 @@ export class RibbonManager {
    * Initialize the ribbon manager and register all ribbon icons
    */
   initialize() {
-    if (this.isDisposed || this.isInitialized) {
+    // Disabled means inert (#134/#214): ribbon init is deferred (a setTimeout in
+    // ViewManager), so this can fire after onunload flips the unloading flag.
+    // Don't re-add icons to a plugin that is already tearing down.
+    if (this.isDisposed || this.isInitialized || this.plugin?.isPluginUnloading?.()) {
       return;
     }
     this.isInitialized = true;
@@ -106,7 +109,7 @@ export class RibbonManager {
     title: string,
     callback: () => void
   ) {
-    if (this.isDisposed) {
+    if (this.isDisposed || this.plugin?.isPluginUnloading?.()) {
       return;
     }
     const ribbon = this.plugin.addRibbonIcon(icon, title, callback) as RibbonHandle;

--- a/src/core/storage/StorageManager.ts
+++ b/src/core/storage/StorageManager.ts
@@ -206,14 +206,21 @@ export class StorageManager {
       const folderExists = this.app.vault.getAbstractFileByPath(normalizedPath) instanceof TFolder;
       
       if (!exists || !folderExists) {
+        // Re-check after the await: unload may have begun mid-flight (#214).
+        if (this.isUnloading()) {
+          return;
+        }
         await this.app.vault.createFolder(normalizedPath);
       }
-      
+
       // Create marker file if requested
       if (createMarker) {
         const markerPath = `${normalizedPath}/.folder`;
         const markerExists = await this.app.vault.adapter.exists(markerPath);
         if (!markerExists) {
+          if (this.isUnloading()) {
+            return;
+          }
           await this.app.vault.adapter.write(
             markerPath,
             "This file helps Obsidian recognize the directory."
@@ -259,7 +266,12 @@ export class StorageManager {
       
       // Convert object to JSON if needed
       const content = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
-      
+
+      // Re-check after the await: unload may have begun mid-flight (#214).
+      if (this.isUnloading()) {
+        return { success: false, error: "plugin-unloading" };
+      }
+
       // Write the file
       await this.app.vault.adapter.write(path, content);
       
@@ -291,6 +303,11 @@ export class StorageManager {
       const adapter: any = this.app.vault.adapter as any;
 
       const exists = await this.app.vault.adapter.exists(path);
+
+      // Re-check after the await: unload may have begun mid-flight (#214).
+      if (this.isUnloading()) {
+        return { success: false, error: "plugin-unloading" };
+      }
 
       if (!exists) {
         await this.app.vault.adapter.write(path, payload);

--- a/src/core/storage/StorageManager.ts
+++ b/src/core/storage/StorageManager.ts
@@ -46,7 +46,18 @@ export class StorageManager {
     this.app = app;
     this.plugin = plugin;
   }
-  
+
+  /**
+   * Once the plugin is unloading every write path becomes a no-op, so a disabled
+   * plugin leaves no further trace on disk (#214/#158). StorageManager is the
+   * single chokepoint that diagnostics, logs, metrics, and backups all funnel
+   * through, so this one guard makes "disabled means no disk writes" hold even
+   * when a timer or flush closure is still mid-flight.
+   */
+  private isUnloading(): boolean {
+    return this.plugin?.isPluginUnloading?.() === true;
+  }
+
   /**
    * Initialize the storage system
    * Creates necessary directories and ensures everything is ready
@@ -167,6 +178,10 @@ export class StorageManager {
    * @returns Promise resolving when directory is created
    */
   async ensureDirectory(path: string, createMarker: boolean = false): Promise<void> {
+    if (this.isUnloading()) {
+      return;
+    }
+
     // Normalize path to use forward slashes
     const normalizedPath = path.replace(/\\/g, '/');
     
@@ -231,6 +246,10 @@ export class StorageManager {
     fileName: string, 
     data: string | object
   ): Promise<StorageOperationResult> {
+    if (this.isUnloading()) {
+      return { success: false, error: "plugin-unloading" };
+    }
+
     try {
       // Ensure storage is initialized
       await this.initialize();
@@ -260,6 +279,10 @@ export class StorageManager {
     fileName: string,
     data: string
   ): Promise<StorageOperationResult> {
+    if (this.isUnloading()) {
+      return { success: false, error: "plugin-unloading" };
+    }
+
     try {
       await this.initialize();
 

--- a/src/core/storage/__tests__/StorageManager.test.ts
+++ b/src/core/storage/__tests__/StorageManager.test.ts
@@ -430,4 +430,53 @@ describe("StorageManager", () => {
       expect(storage.isInitialized()).toBe(true);
     });
   });
+
+  // #214: disabled means fully inert. StorageManager is the single chokepoint
+  // through which every diagnostics/log/backup writer funnels, so guarding it
+  // makes "no disk writes after the plugin unloads" hold structurally — even if
+  // a timer or flush closure is still mid-flight (the #158 root cause).
+  describe("inert once the plugin is unloading (#214, #158)", () => {
+    const makeStorage = (unloading: boolean) => {
+      const app = createMockApp();
+      const plugin = { isPluginUnloading: () => unloading };
+      return { app, storage: new StorageManager(app as any, plugin as any) };
+    };
+
+    it("writeFile is a no-op and never touches the adapter", async () => {
+      const { app, storage } = makeStorage(true);
+
+      const result = await storage.writeFile("diagnostics", "leak.json", { a: 1 });
+
+      expect(result.success).toBe(false);
+      expect(app.vault.adapter.write).not.toHaveBeenCalled();
+    });
+
+    it("appendToFile is a no-op and never touches the adapter", async () => {
+      const { app, storage } = makeStorage(true);
+
+      const result = await storage.appendToFile("diagnostics", "leak.log", "leaked line");
+
+      expect(result.success).toBe(false);
+      expect(app.vault.adapter.write).not.toHaveBeenCalled();
+      expect(app.vault.adapter.append).not.toHaveBeenCalled();
+    });
+
+    it("ensureDirectory is a no-op and never creates folders or markers", async () => {
+      const { app, storage } = makeStorage(true);
+
+      await storage.ensureDirectory(".systemsculpt/diagnostics", true);
+
+      expect(app.vault.createFolder).not.toHaveBeenCalled();
+      expect(app.vault.adapter.write).not.toHaveBeenCalled();
+    });
+
+    it("still writes normally while the plugin is active", async () => {
+      const { app, storage } = makeStorage(false);
+
+      const result = await storage.writeFile("diagnostics", "active.json", { a: 1 });
+
+      expect(result.success).toBe(true);
+      expect(app.vault.adapter.write).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/core/storage/__tests__/StorageManager.test.ts
+++ b/src/core/storage/__tests__/StorageManager.test.ts
@@ -478,5 +478,39 @@ describe("StorageManager", () => {
       expect(result.success).toBe(true);
       expect(app.vault.adapter.write).toHaveBeenCalled();
     });
+
+    // TOCTOU: an entry-only check would still let an adapter write through if
+    // unload begins during an internal await. Each write path must re-check the
+    // unloading flag immediately before it mutates the vault.
+    it("writeFile bails if unload flips after entry but before the adapter write", async () => {
+      const app = createMockApp();
+      let unloading = false;
+      const storage = new StorageManager(app as any, { isPluginUnloading: () => unloading } as any);
+      jest.spyOn(storage, "initialize").mockImplementation(async () => {
+        unloading = true; // unload begins while we await initialization
+      });
+
+      const result = await storage.writeFile("diagnostics", "race.json", { a: 1 });
+
+      expect(result.success).toBe(false);
+      expect(app.vault.adapter.write).not.toHaveBeenCalled();
+    });
+
+    it("appendToFile bails if unload flips after entry but before the adapter mutation", async () => {
+      const app = createMockApp();
+      let unloading = false;
+      const storage = new StorageManager(app as any, { isPluginUnloading: () => unloading } as any);
+      jest.spyOn(storage, "initialize").mockResolvedValue(undefined);
+      app.vault.adapter.exists.mockImplementation(async () => {
+        unloading = true; // unload begins while we await exists()
+        return false;
+      });
+
+      const result = await storage.appendToFile("diagnostics", "race.log", "line");
+
+      expect(result.success).toBe(false);
+      expect(app.vault.adapter.write).not.toHaveBeenCalled();
+      expect(app.vault.adapter.append).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1983,6 +1983,17 @@ export default class SystemSculptPlugin extends Plugin {
 
   async onunload() {
     this.isUnloading = true;
+
+    // Halt self-rescheduling timers first and unconditionally (#214/#158): the
+    // FreezeMonitor interval and PluginLogger flush timer never auto-clean, so
+    // they must stop even if a later teardown step throws.
+    try {
+      FreezeMonitor.stop();
+      this.pluginLogger?.dispose();
+    } catch (error) {
+      // Best-effort; teardown continues regardless.
+    }
+
     const tracer = this.getInitializationTracer();
     tracer.flushOpenPhases("plugin-unload");
     const phase = tracer.startPhase("plugin.onunload", {
@@ -2008,11 +2019,6 @@ export default class SystemSculptPlugin extends Plugin {
         this.resourceMonitor.stop();
         this.resourceMonitor = null;
       }
-
-      // Stop the global freeze-detection interval (#214/#158). Its 50ms timer is
-      // never auto-cleaned and would otherwise keep firing after the plugin is
-      // disabled — the core #158 timer leak.
-      FreezeMonitor.stop();
 
       await this.stopDesktopAutomationBridge();
 
@@ -2161,9 +2167,7 @@ export default class SystemSculptPlugin extends Plugin {
 
 
       // Plugin unloaded successfully silently
-      // Cancel the logger's self-rescheduling flush timer before dropping it
-      // (#214/#158) so no diagnostics flush fires after the plugin is disabled.
-      this.pluginLogger?.dispose();
+      // The logger's flush timer was already disposed at the top of onunload.
       this.pluginLogger = null;
       phase.complete();
       logger.info("SystemSculpt plugin unloaded", {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2009,6 +2009,11 @@ export default class SystemSculptPlugin extends Plugin {
         this.resourceMonitor = null;
       }
 
+      // Stop the global freeze-detection interval (#214/#158). Its 50ms timer is
+      // never auto-cleaned and would otherwise keep firing after the plugin is
+      // disabled — the core #158 timer leak.
+      FreezeMonitor.stop();
+
       await this.stopDesktopAutomationBridge();
 
       // Clean up settings manager (stop automatic backups)
@@ -2156,6 +2161,9 @@ export default class SystemSculptPlugin extends Plugin {
 
 
       // Plugin unloaded successfully silently
+      // Cancel the logger's self-rescheduling flush timer before dropping it
+      // (#214/#158) so no diagnostics flush fires after the plugin is disabled.
+      this.pluginLogger?.dispose();
       this.pluginLogger = null;
       phase.complete();
       logger.info("SystemSculpt plugin unloaded", {

--- a/src/utils/PluginLogger.ts
+++ b/src/utils/PluginLogger.ts
@@ -163,6 +163,11 @@ export class PluginLogger {
     if (this.isFlushing || this.pendingFlush.length === 0) {
       return;
     }
+    // Disabled means inert (#214/#158): never flush once unloading; drop queue.
+    if (this.plugin?.isPluginUnloading?.()) {
+      this.pendingFlush.length = 0;
+      return;
+    }
     this.isFlushing = true;
     try {
       const storage = this.plugin.storage;
@@ -204,6 +209,11 @@ export class PluginLogger {
   }
 
   private async enforceSizeLimit() {
+    // Disabled means inert (#214/#158): this trims the log via a direct adapter
+    // write that bypasses the StorageManager guard, so it must bail on unload.
+    if (this.plugin?.isPluginUnloading?.()) {
+      return;
+    }
     const adapter: any = this.plugin.app?.vault?.adapter;
     const storage = this.plugin.storage;
     if (!adapter || typeof adapter.stat !== "function" || !storage) {
@@ -217,6 +227,10 @@ export class PluginLogger {
         return;
       }
 
+      // Re-check after awaiting stat: unload may have begun mid-flight (#214).
+      if (this.plugin?.isPluginUnloading?.()) {
+        return;
+      }
       // Trim file to the last portion of buffered entries to keep context
       const recent = this.buffer.slice(-200).map((entry) => JSON.stringify(entry)).join("\n");
       await adapter.write(path, `${recent}\n`);

--- a/src/utils/PluginLogger.ts
+++ b/src/utils/PluginLogger.ts
@@ -82,6 +82,11 @@ export class PluginLogger {
   }
 
   private write(level: PluginLogLevel, message: string, error?: unknown, context?: PluginLogContext) {
+    // Disabled means inert (#214/#158): once the plugin is unloading, stop
+    // buffering and scheduling new diagnostics so nothing writes after disable.
+    if (this.plugin?.isPluginUnloading?.()) {
+      return;
+    }
     if (!this.shouldLog(level, context)) {
       return;
     }
@@ -137,6 +142,21 @@ export class PluginLogger {
 
   public async flushNow(): Promise<void> {
     await this.flushPendingEntries(true);
+  }
+
+  /**
+   * Stop the logger for plugin unload (#214/#158): cancel the self-rescheduling
+   * flush timer and drop any pending entries so the logger does not keep writing
+   * diagnostics to disk after the plugin is disabled.
+   */
+  public dispose(): void {
+    if (this.flushTimer !== null) {
+      if (typeof window !== "undefined") {
+        window.clearTimeout(this.flushTimer);
+      }
+      this.flushTimer = null;
+    }
+    this.pendingFlush.length = 0;
   }
 
   private async flushPendingEntries(force: boolean = false) {

--- a/src/utils/__tests__/PluginLogger.test.ts
+++ b/src/utils/__tests__/PluginLogger.test.ts
@@ -361,5 +361,37 @@ describe("PluginLogger", () => {
 
       expect(mockStorage.appendToFile).not.toHaveBeenCalled();
     });
+
+    it("a flush scheduled while active does not write once the timer fires after disable", async () => {
+      mockPlugin.settings.debugMode = true;
+      let unloading = false;
+      mockPlugin.isPluginUnloading = jest.fn(() => unloading);
+
+      logger.info("buffered while active"); // schedules a flush timer
+      unloading = true;                      // plugin disabled before the timer fires
+
+      jest.advanceTimersByTime(3000);
+      await Promise.resolve();
+
+      expect(mockStorage.appendToFile).not.toHaveBeenCalled();
+    });
+
+    it("enforceSizeLimit performs no direct adapter write when unload flips mid-flush", async () => {
+      mockPlugin.settings.debugMode = true;
+      let unloading = false;
+      mockPlugin.isPluginUnloading = jest.fn(() => unloading);
+      // The append step is where unload begins; enforceSizeLimit runs next and
+      // must not perform its direct (keystone-bypassing) adapter stat/write.
+      mockStorage.appendToFile.mockImplementation(async () => {
+        unloading = true;
+      });
+
+      logger.info("entry");
+      await logger.flushNow();
+
+      expect(mockStorage.appendToFile).toHaveBeenCalled();
+      expect(mockPlugin.app.vault.adapter.stat).not.toHaveBeenCalled();
+      expect(mockPlugin.app.vault.adapter.write).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/utils/__tests__/PluginLogger.test.ts
+++ b/src/utils/__tests__/PluginLogger.test.ts
@@ -331,4 +331,35 @@ describe("PluginLogger", () => {
       expect(() => logger.error("Test")).not.toThrow();
     });
   });
+
+  // #214/#158: once the plugin is unloading the logger must stop buffering and
+  // stop its self-rescheduling flush timer, so diagnostics never keep writing
+  // to disk after the plugin is disabled.
+  describe("inert once the plugin is unloading (#214, #158)", () => {
+    it("drops new entries while the plugin is unloading", async () => {
+      mockPlugin.settings.debugMode = true;
+      mockPlugin.isPluginUnloading = jest.fn(() => true);
+
+      logger.info("after disable");
+
+      expect(logger.getRecentEntries()).toHaveLength(0);
+
+      jest.advanceTimersByTime(3000);
+      await Promise.resolve();
+
+      expect(mockStorage.appendToFile).not.toHaveBeenCalled();
+    });
+
+    it("dispose() cancels the pending flush timer so nothing writes after disable", async () => {
+      mockPlugin.settings.debugMode = true;
+
+      logger.info("buffered before disable"); // schedules a flush timer
+      logger.dispose();
+
+      jest.advanceTimersByTime(3000);
+      await Promise.resolve();
+
+      expect(mockStorage.appendToFile).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Closes #214. Makes a disabled/unloaded plugin fully inert — no disk writes, timers, or DOM mutations after disable.

- **Keystone:** `StorageManager` write paths (`writeFile`/`appendToFile`/`ensureDirectory`) no-op once the plugin is unloading. Every diagnostics/log/metrics/backup writer funnels through here, so "no disk writes after disable" holds even if a flush closure is mid-flight (#158).
- `onunload` now stops the `FreezeMonitor` 50ms interval and disposes the `PluginLogger` flush timer, ending the diagnostics timer leak (#158).
- `RibbonManager` skips init while unloading, so the deferred ribbon `setTimeout` can't re-add icons to a disabled plugin (#134).

Failing-test-first unit guards lock each regression at the cheapest layer.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin shutdown so ribbons, storage writes, and logging become inert once unload begins, preventing late updates and dangling activity.
  * Plugin teardown now best-effort stops the background freeze monitor and disposes logger flush timers to avoid work after shutdown.

* **Tests**
  * Added/expanded coverage to verify ribbons, storage operations, and logger buffering/flush behavior remain inactive during unload, including mid-flight unload transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->