### PR TITLE
feat(chat): per-chat toggle to hide system & tool messages (#213)

### DIFF
--- a/src/__tests__/settings-chat-tab.test.ts
+++ b/src/__tests__/settings-chat-tab.test.ts
@@ -71,7 +71,7 @@ describe("Chat tab native layout", () => {
     const names = Array.from(container.querySelectorAll('.setting-item .setting-item-name')).map((el) => el.textContent?.trim());
     expect(names).toContain("Default chat tag");
     expect(names).toContain("Default Chat Font Size");
-    expect(names).toContain("Hide SystemSculpt system messages");
+    expect(names).toContain("Hide SystemSculpt system & tool messages");
     expect(names).toContain("Honor OS Reduced Motion");
     expect(names).not.toContain("Default system prompt");
     expect(names).not.toContain("Favorite models");

--- a/src/css/components/tool-call-ui.css
+++ b/src/css/components/tool-call-ui.css
@@ -1,4 +1,15 @@
 /* Tool-call specific overrides for shared structured layout */
+
+/*
+ * Per-chat "hide system & tool messages" toggle (#213/#174/#167).
+ * When the chat container opts in, hide inline tool-call activity (the modern
+ * systemsculpt backend renders tool calls inline, not as tool-role messages).
+ * Reasoning (.systemsculpt-reasoning-wrapper) is intentionally left visible.
+ */
+.systemsculpt-hide-tool-activity .systemsculpt-tool-call-group {
+  display: none !important;
+}
+
 .systemsculpt-tool-call-group[data-group-status="failed"] .systemsculpt-chat-structured-title {
   color: var(--color-red);
   user-select: text;

--- a/src/settings/ChatTabContent.ts
+++ b/src/settings/ChatTabContent.ts
@@ -48,8 +48,8 @@ new Setting(containerEl)
 	    });
 
 new Setting(containerEl)
-    .setName("Hide SystemSculpt system messages")
-    .setDesc("Keep system-role messages in the saved chat history, but hide them from the chat view.")
+    .setName("Hide SystemSculpt system & tool messages")
+    .setDesc("Default for new chats: keep system and tool messages in the saved history but hide them from the chat view. Each chat has its own toggle in the composer toolbar that overrides this default.")
     .addToggle((toggle: ToggleComponent) => {
         toggle
             .setValue(plugin.settings.hideSystemMessagesInChat ?? false)

--- a/src/views/chatview/ChatStorageService.ts
+++ b/src/views/chatview/ChatStorageService.ts
@@ -22,6 +22,7 @@ type LoadedChatRecord = {
   chatFontSize?: "small" | "medium" | "large";
   selectedPromptPath?: string;
   agentModeEnabled?: boolean;
+  hideSystemMessages?: boolean;
   chatPath: string;
   chatBackend: ChatBackend;
   piSessionFile?: string;
@@ -37,6 +38,7 @@ type SaveChatOptions = {
   chatFontSize?: "small" | "medium" | "large";
   selectedPromptPath?: string;
   agentModeEnabled?: boolean;
+  hideSystemMessages?: boolean;
   piSessionFile?: string;
   piSessionId?: string;
   piLastEntryId?: string;
@@ -190,6 +192,7 @@ export class ChatStorageService {
         chatFontSize: options.chatFontSize || "medium",
         selectedPromptPath: options.selectedPromptPath || existingMetadata?.selectedPromptPath || undefined,
         agentModeEnabled: typeof options.agentModeEnabled === "boolean" ? options.agentModeEnabled : existingMetadata?.agentModeEnabled,
+        hideSystemMessages: typeof options.hideSystemMessages === "boolean" ? options.hideSystemMessages : existingMetadata?.hideSystemMessages,
         piSessionFile: piState.sessionFile,
         piSessionId: piState.sessionId,
         piLastEntryId: piState.lastEntryId || getLastMessagePiEntryId(messages),
@@ -474,6 +477,7 @@ export class ChatStorageService {
       chatFontSize: metadata.chatFontSize,
       selectedPromptPath: metadata.selectedPromptPath,
       agentModeEnabled: metadata.agentModeEnabled,
+      hideSystemMessages: metadata.hideSystemMessages,
       chatPath: filePath || `${this.chatDirectory}/${metadata.id}.md`,
       chatBackend,
       piSessionFile: piState.sessionFile,

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -118,6 +118,9 @@ export class ChatView extends ItemView {
   /** Tools trusted for this chat session (cleared on chat reload/close) */
   private dragDropCleanup: (() => void) | null = null;
   public chatFontSize: "small" | "medium" | "large";
+  // Per-chat override for hiding SystemSculpt system + tool messages (#213/#174/#167).
+  // undefined = follow the global `hideSystemMessagesInChat` setting.
+  public hideSystemMessages: boolean | undefined;
   private chatExportService: ChatExportService | null = null;
   private debugLogService: ChatDebugLogService | null = null;
   private warnedImageIncompatModels: Set<string> = new Set();
@@ -164,6 +167,7 @@ export class ChatView extends ItemView {
         piSessionId?: string;
         piLastEntryId?: string;
         piLastSyncedAt?: string;
+        hideSystemMessages?: boolean;
     }) || {};
 
     this.messages = [];
@@ -187,6 +191,7 @@ export class ChatView extends ItemView {
 
     // Initialize chat font size from saved state or plugin settings
     this.chatFontSize = initialState.chatFontSize || (plugin.settings as any).chatFontSize || "medium";
+    this.hideSystemMessages = initialState.hideSystemMessages;
   }
 
   private ensureCoreServicesReady(): void {
@@ -318,6 +323,7 @@ export class ChatView extends ItemView {
           chatFontSize: this.chatFontSize,
           selectedPromptPath: this.inputHandler?.getSelectedPromptPath?.() || "",
           agentModeEnabled: this.inputHandler?.isAgentModeEnabled?.(),
+          hideSystemMessages: this.hideSystemMessages,
           piSessionFile: this.piSessionFile,
           piSessionId: this.piSessionId,
           piLastEntryId: this.piLastEntryId,
@@ -1190,7 +1196,36 @@ export class ChatView extends ItemView {
   }
 
   public shouldRenderMessageRole(role: ChatRole): boolean {
-    return !(this.plugin.settings.hideSystemMessagesInChat && role === "system");
+    if (this.isSystemNoiseHidden() && (role === "system" || role === "tool")) {
+      return false;
+    }
+    return true;
+  }
+
+  // Effective visibility for SystemSculpt system + tool messages (#213/#174/#167):
+  // a per-chat preference wins; otherwise fall back to the global default.
+  public isSystemNoiseHidden(): boolean {
+    return this.hideSystemMessages ?? this.plugin.settings.hideSystemMessagesInChat ?? false;
+  }
+
+  // Flip the per-chat preference, then re-render and persist so long chats stay
+  // de-cluttered across reloads.
+  public toggleSystemNoiseHidden(): void {
+    this.hideSystemMessages = !this.isSystemNoiseHidden();
+    this.applyHideToolActivityClass();
+    this.inputHandler?.syncHideSystemMessagesButton?.();
+    void this.renderMessagesInChunks();
+    void this.saveChat();
+  }
+
+  // Inline tool-call blocks live inside assistant messages, so for reloaded chats
+  // (where tool-role messages are not persisted) we hide tool activity via a
+  // container class rather than the role filter.
+  public applyHideToolActivityClass(): void {
+    this.chatContainer?.classList.toggle(
+      "systemsculpt-hide-tool-activity",
+      this.isSystemNoiseHidden(),
+    );
   }
 
 
@@ -1498,6 +1533,7 @@ export class ChatView extends ItemView {
       selectedModelId: this.getPersistedSelectedModelId(),
       version: this.chatVersion,
       chatFontSize: this.chatFontSize,
+      hideSystemMessages: this.hideSystemMessages,
       chatBackend: this.chatBackend,
       piSessionFile: this.piSessionFile,
       piSessionId: this.piSessionId,
@@ -1533,6 +1569,8 @@ export class ChatView extends ItemView {
         this.chatFontSize = state.chatFontSize;
         this.scheduleChatFontSizeClassSync();
       }
+      this.hideSystemMessages =
+        typeof state?.hideSystemMessages === "boolean" ? state.hideSystemMessages : undefined;
       this.virtualStartIndex = 0;
       this.hasAdjustedInitialWindow = false;
       this.messages = [];
@@ -1567,6 +1605,9 @@ export class ChatView extends ItemView {
     this.chatVersion = state.version !== undefined ? state.version : -1;
 
     this.applyChatLeafState(state);
+    if (typeof state.hideSystemMessages === "boolean") {
+      this.hideSystemMessages = state.hideSystemMessages;
+    }
     // Restore chat font size
     if (state.chatFontSize) {
       this.chatFontSize = state.chatFontSize;
@@ -1687,6 +1728,13 @@ export class ChatView extends ItemView {
           }
         }
 
+        // Restore per-chat system/tool message visibility (#213/#174/#167).
+        if (typeof chatData.hideSystemMessages === "boolean") {
+          this.hideSystemMessages = chatData.hideSystemMessages;
+        }
+        this.applyHideToolActivityClass();
+        this.inputHandler?.syncHideSystemMessagesButton?.();
+
         // Restore context files without blocking first render.
         if (this.contextManager) {
           const contextFiles = (chatData.context_files || []).filter(Boolean);
@@ -1804,6 +1852,8 @@ export class ChatView extends ItemView {
 
   public async renderMessagesInChunks(): Promise<void> {
     if (!this.chatContainer) return;
+
+    this.applyHideToolActivityClass();
 
     const renderEpoch = ++this.renderEpoch;
     const visibleMessages = this.messages.filter((message) =>

--- a/src/views/chatview/InputHandler.ts
+++ b/src/views/chatview/InputHandler.ts
@@ -105,6 +105,8 @@ export class InputHandler extends Component {
   private webSearchEnabled = false;
   private agentModeEnabled: boolean;
   private agentModeButtonEl: HTMLElement | null = null;
+  // ButtonComponent for the per-chat hide system/tool toggle (#213/#174/#167).
+  private hideSystemButton: any = null;
   private selectedPromptPath: string | null = null;
   private selectedPromptName: string | null = null;
   private promptChip: HTMLElement | null = null;
@@ -765,6 +767,8 @@ export class InputHandler extends Component {
         void this.plugin.saveSettings();
       },
       isAgentModeEnabled: () => this.agentModeEnabled,
+      onToggleHideSystemMessages: () => this.chatView?.toggleSystemNoiseHidden?.(),
+      isHideSystemMessagesEnabled: () => this.chatView?.isSystemNoiseHidden?.() ?? false,
     });
 
     this.input = composer.input;
@@ -776,6 +780,7 @@ export class InputHandler extends Component {
     this.settingsButton = composer.settingsButton;
     this.attachButton = composer.attachButton;
     this.agentModeButtonEl = composer.agentModeButton?.buttonEl || null;
+    this.hideSystemButton = composer.hideSystemButton || null;
     this.modelSelectionController.ensureHost({
       modelSlot: (composer as any).modelSlot,
       toolbar: (composer as any).toolbar,
@@ -1455,6 +1460,16 @@ export class InputHandler extends Component {
   private syncAgentModeButton(): void {
     if (!this.agentModeButtonEl) return;
     this.agentModeButtonEl.classList.toggle("ss-active", this.agentModeEnabled);
+  }
+
+  // Keep the composer toggle in sync when the per-chat preference changes outside
+  // a click (e.g. restored on chat load) (#213/#174/#167).
+  public syncHideSystemMessagesButton(): void {
+    if (!this.hideSystemButton) return;
+    const hidden = this.chatView?.isSystemNoiseHidden?.() ?? false;
+    this.hideSystemButton.setIcon(hidden ? "eye-off" : "eye");
+    this.hideSystemButton.setTooltip(hidden ? "Show system & tool messages" : "Hide system & tool messages");
+    this.hideSystemButton.buttonEl?.classList.toggle("ss-active", hidden);
   }
 
   public getSelectedPromptPath(): string | null {

--- a/src/views/chatview/__tests__/ChatStorageService.test.ts
+++ b/src/views/chatview/__tests__/ChatStorageService.test.ts
@@ -141,6 +141,16 @@ describe("ChatStorageService", () => {
       expect(createdContent).not.toContain("prompts/custom.md");
     });
 
+    it("persists the per-chat hide system/tool preference to frontmatter (#213, #174, #167)", async () => {
+      await service.saveChat("chat-hidden", testMessages, { hideSystemMessages: true });
+      expect(mockVault.create.mock.calls[0][1] as string).toContain("hideSystemMessages: true");
+    });
+
+    it("persists an explicit show preference so it can override a hidden global default", async () => {
+      await service.saveChat("chat-shown", testMessages, { hideSystemMessages: false });
+      expect(mockVault.create.mock.calls[0][1] as string).toContain("hideSystemMessages: false");
+    });
+
     it("adds default chat tag to new history files", async () => {
       (mockApp as any).plugins.plugins["systemsculpt-ai"] = {
         settings: { defaultChatTag: "#project" },

--- a/src/views/chatview/__tests__/chatview-hide-system-messages.test.ts
+++ b/src/views/chatview/__tests__/chatview-hide-system-messages.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { ChatView } from "../ChatView";
+
+jest.mock("../../../core/ui/", () => ({ showPopup: jest.fn() }));
+jest.mock("../../../utils/externalUrl", () => ({ openExternalUrl: jest.fn() }));
+jest.mock("../uiSetup", () => ({
+  uiSetup: {
+    showLicenseBanner: jest.fn(),
+    hideLicenseBanner: jest.fn(),
+    updateToolCompatibilityWarning: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Per-chat visibility of SystemSculpt system + tool messages (#213 → #174/#167).
+// shouldRenderMessageRole is the single role filter the render loop consults, so
+// its logic is the behavioral contract for the hide toggle.
+const makeView = (opts: { perChat?: boolean; global?: boolean }): any =>
+  Object.assign(Object.create(ChatView.prototype), {
+    hideSystemMessages: opts.perChat,
+    plugin: { settings: { hideSystemMessagesInChat: opts.global ?? false } },
+  });
+
+const shouldRender = (view: any, role: string): boolean =>
+  view.shouldRenderMessageRole(role as any);
+
+const isHidden = (view: any): boolean => view.isSystemNoiseHidden();
+
+describe("ChatView system/tool message visibility (#213, #174, #167)", () => {
+  it("renders every role when nothing is hidden", () => {
+    const view = makeView({ perChat: undefined, global: false });
+    for (const role of ["user", "assistant", "system", "tool"]) {
+      expect(shouldRender(view, role)).toBe(true);
+    }
+    expect(isHidden(view)).toBe(false);
+  });
+
+  it("hides both system and tool messages (not just system) when hidden per-chat", () => {
+    const view = makeView({ perChat: true, global: false });
+    expect(shouldRender(view, "system")).toBe(false);
+    expect(shouldRender(view, "tool")).toBe(false);
+    expect(shouldRender(view, "user")).toBe(true);
+    expect(shouldRender(view, "assistant")).toBe(true);
+    expect(isHidden(view)).toBe(true);
+  });
+
+  it("falls back to the global setting when no per-chat preference is set", () => {
+    const view = makeView({ perChat: undefined, global: true });
+    expect(shouldRender(view, "system")).toBe(false);
+    expect(shouldRender(view, "tool")).toBe(false);
+    expect(isHidden(view)).toBe(true);
+  });
+
+  it("lets a per-chat preference override the global default", () => {
+    const shown = makeView({ perChat: false, global: true });
+    expect(shouldRender(shown, "system")).toBe(true);
+    expect(shouldRender(shown, "tool")).toBe(true);
+    expect(isHidden(shown)).toBe(false);
+
+    const hidden = makeView({ perChat: true, global: false });
+    expect(shouldRender(hidden, "system")).toBe(false);
+    expect(isHidden(hidden)).toBe(true);
+  });
+});

--- a/src/views/chatview/storage/ChatMarkdownSerializer.ts
+++ b/src/views/chatview/storage/ChatMarkdownSerializer.ts
@@ -370,6 +370,7 @@ export class ChatMarkdownSerializer {
         ? parsed.selectedPromptPath.trim()
         : undefined,
       agentModeEnabled: typeof parsed.agentModeEnabled === "boolean" ? parsed.agentModeEnabled : undefined,
+      hideSystemMessages: typeof parsed.hideSystemMessages === "boolean" ? parsed.hideSystemMessages : undefined,
       chatBackend: resolveChatBackend({
         explicitBackend: parsed.chatBackend,
         piSessionFile: piState.sessionFile,

--- a/src/views/chatview/storage/ChatPersistenceTypes.ts
+++ b/src/views/chatview/storage/ChatPersistenceTypes.ts
@@ -26,6 +26,7 @@ export interface ChatMetadata {
   chatFontSize?: "small" | "medium" | "large";
   selectedPromptPath?: string;
   agentModeEnabled?: boolean;
+  hideSystemMessages?: boolean;
   chatBackend?: ChatBackend;
   piSessionFile?: string;
   piSessionId?: string;

--- a/src/views/chatview/storage/__tests__/ChatMarkdownSerializer.test.ts
+++ b/src/views/chatview/storage/__tests__/ChatMarkdownSerializer.test.ts
@@ -19,6 +19,8 @@ jest.mock("obsidian", () => ({
           result[key] = JSON.parse(value.replace(/'/g, '"'));
         } else if (value === "null" || value === "") {
           result[key] = null;
+        } else if (value === "true" || value === "false") {
+          result[key] = value === "true";
         } else if (!isNaN(Number(value))) {
           result[key] = Number(value);
         } else {
@@ -273,6 +275,30 @@ Hello!
       expect(result?.metadata.title).toBe("Test Chat");
       expect(result?.metadata.chatBackend).toBe("systemsculpt");
       expect(result?.metadata.systemMessage).toBeUndefined();
+    });
+
+    it("round-trips the per-chat hide system/tool preference (#213, #174, #167)", () => {
+      const base = {
+        model: "gpt-4",
+        title: "Test Chat",
+        created: "2024-01-01T00:00:00Z",
+        lastModified: "2024-01-01T12:00:00Z",
+      };
+
+      const hidden = ChatMarkdownSerializer.parseMarkdown(
+        createMarkdown({ id: "chat-hidden", ...base, hideSystemMessages: true }, "")
+      );
+      expect(hidden?.metadata.hideSystemMessages).toBe(true);
+
+      const shown = ChatMarkdownSerializer.parseMarkdown(
+        createMarkdown({ id: "chat-shown", ...base, hideSystemMessages: false }, "")
+      );
+      expect(shown?.metadata.hideSystemMessages).toBe(false);
+
+      const unset = ChatMarkdownSerializer.parseMarkdown(
+        createMarkdown({ id: "chat-unset", ...base }, "")
+      );
+      expect(unset?.metadata.hideSystemMessages).toBeUndefined();
     });
 
     it("marks legacy prompt metadata as legacy-only compatibility state", () => {

--- a/src/views/chatview/ui/createInputUI.ts
+++ b/src/views/chatview/ui/createInputUI.ts
@@ -19,6 +19,8 @@ export interface ChatComposerDeps {
   isWebSearchEnabled?: () => boolean;
   onToggleAgentMode?: () => void;
   isAgentModeEnabled?: () => boolean;
+  onToggleHideSystemMessages?: () => void;
+  isHideSystemMessagesEnabled?: () => boolean;
   onOpenPromptSelector?: () => void;
 }
 
@@ -33,6 +35,7 @@ export interface ChatComposerElements {
   attachButton: ButtonComponent;
   webSearchButton: ButtonComponent;
   agentModeButton: ButtonComponent;
+  hideSystemButton: ButtonComponent;
   promptSlot: HTMLDivElement;
   sendButton: ButtonComponent;
   stopButton: ButtonComponent;
@@ -103,6 +106,26 @@ export function createChatComposer(parent: HTMLElement, deps: ChatComposerDeps):
   agentModeButton.buttonEl.classList.add("systemsculpt-chat-composer-button");
   if (deps.isAgentModeEnabled?.()) {
     agentModeButton.buttonEl.classList.add("ss-active");
+  }
+
+  // Per-chat toggle to hide distracting SystemSculpt system + tool messages in
+  // long chats (#213/#174/#167). Mirrors the agent-mode toggle convention.
+  const hideSystemHidden = () => deps.isHideSystemMessagesEnabled?.() ?? false;
+  const hideSystemButton = new ButtonComponent(leftGroup)
+    .setIcon(hideSystemHidden() ? "eye-off" : "eye")
+    .setTooltip(hideSystemHidden() ? "Show system & tool messages" : "Hide system & tool messages")
+    .setClass("clickable-icon")
+    .onClick(() => {
+      deps.onToggleHideSystemMessages?.();
+      const hidden = hideSystemHidden();
+      hideSystemButton.setIcon(hidden ? "eye-off" : "eye");
+      hideSystemButton.setTooltip(hidden ? "Show system & tool messages" : "Hide system & tool messages");
+      hideSystemButton.buttonEl.classList.toggle("ss-active", hidden);
+    });
+  hideSystemButton.buttonEl.setAttribute("aria-label", "Toggle system and tool messages");
+  hideSystemButton.buttonEl.classList.add("systemsculpt-chat-composer-button");
+  if (hideSystemHidden()) {
+    hideSystemButton.buttonEl.classList.add("ss-active");
   }
 
   const settingsButton = new ButtonComponent(rightGroup)
@@ -192,6 +215,7 @@ export function createChatComposer(parent: HTMLElement, deps: ChatComposerDeps):
     attachButton,
     webSearchButton,
     agentModeButton,
+    hideSystemButton,
     sendButton,
     stopButton,
     micButton,

--- a/src/views/chatview/uiSetup.ts
+++ b/src/views/chatview/uiSetup.ts
@@ -187,6 +187,9 @@ export const uiSetup = {
         }
 
         if (messageVisibilityChanged) {
+          // A chat with no per-chat preference follows the global default, so a
+          // global flip must refresh its messages and the composer toggle (#213).
+          chatView.inputHandler?.syncHideSystemMessagesButton?.();
           if (chatView.messages.length === 0) {
             chatView.displayChatStatus();
           } else {


### PR DESCRIPTION
Part of #213 — first ChatView UX papercut. Implements the long-standing #174/#167 request ("hide SystemSculpt messages in chat; they're distracting in long chats").

- Adds a composer-toolbar eye toggle that hides SystemSculpt **system + tool** messages per chat (inline tool-call activity is hidden via a container CSS class so reloaded chats are de-cluttered too; reasoning stays visible).
- The preference persists in chat frontmatter (`hideSystemMessages`) and falls back to the global default when unset — a per-chat "show" also overrides a hidden global default. The global setting now covers tool messages too.

UI note: the toggle lives in the composer toolbar for consistency with agent-mode/web-search. Easy to relocate if the #139 UX-cleanup pass wants it elsewhere.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-chat toggle button to hide system and tool messages, overriding global settings when enabled
  * Updated chat settings label to clarify hiding applies to "system & tool messages"
  * Per-chat hiding preferences now save and restore with chat files

* **Tests**
  * Added test coverage for per-chat message-hiding functionality and storage persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->