### PR TITLE
feat(chat): add "Attach Context File" to the slash palette (#117)

### DIFF
--- a/src/views/chatview/SlashCommandMenu.ts
+++ b/src/views/chatview/SlashCommandMenu.ts
@@ -147,6 +147,15 @@ export class SlashCommandMenu extends Component {
         }
       },
       {
+        id: 'attach-context',
+        name: 'Attach Context File',
+        description: 'Add a vault file as context for this chat',
+        icon: 'paperclip',
+        execute: async (chatView: ChatView) => {
+          await chatView.contextManager.addContextFile();
+        }
+      },
+      {
         id: 'export',
         name: 'Export Chat',
         description: 'Export chat as markdown note',

--- a/src/views/chatview/__tests__/slash-command-menu.test.ts
+++ b/src/views/chatview/__tests__/slash-command-menu.test.ts
@@ -209,4 +209,38 @@ describe("SlashCommandMenu", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(copyChatArtifactPathsToClipboard).toHaveBeenCalled();
   });
+
+  it("executes the attach context file command when selected (#117)", async () => {
+    const input = document.createElement("textarea");
+    input.value = "/attach";
+    const addContextFile = jest.fn(async () => {});
+    const chatView = {
+      contextManager: { addContextFile },
+    } as any;
+
+    const menu = new SlashCommandMenu({
+      plugin: {
+        app: { workspace: { getLeaf: jest.fn(), setActiveLeaf: jest.fn() } },
+        settings: { selectedModelId: "systemsculpt@@systemsculpt/ai-agent" },
+      } as any,
+      chatView,
+      inputElement: input,
+      inputHandler: { handleOpenChatHistoryFile: jest.fn(async () => {}) },
+      onClose: jest.fn(),
+      onExecute: async (command) => {
+        await command.execute(chatView);
+      },
+    });
+
+    menu.show("attach");
+
+    const attachItem = Array.from(document.querySelectorAll(".systemsculpt-slash-result-item")).find(
+      (el) => el.textContent?.includes("Attach Context File")
+    );
+    expect(attachItem).not.toBeNull();
+    attachItem?.dispatchEvent(new dom.window.Event("click"));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(addContextFile).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Part of #213 — closes the last small chat papercut, #117.

- Adds an **Attach Context File** entry to the composer slash palette that opens the existing context-file picker (`contextManager.addContextFile()`). The capability already existed via the paperclip button and `@`-mention; this just surfaces it where users look for commands.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Attach Context File" slash command, enabling users to attach vault files as context within chat conversations.

* **Tests**
  * Added test suite for the new "Attach Context File" slash command to verify proper functionality and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->