### PR TITLE
refactor(chat): remove orphaned message edit/delete handlers (#213)

### DIFF
--- a/src/views/chatview/messageHandling.ts
+++ b/src/views/chatview/messageHandling.ts
@@ -1,7 +1,7 @@
 import { ChatView } from "./ChatView";
 import { ChatRole, MultiPartContent, ChatMessage, MessagePart, UrlCitation } from "../../types";
 import { ButtonComponent, Notice } from "obsidian";
-import { appendMessageToGroupedContainer, removeMessageElement } from "./utils/MessageGrouping";
+import { appendMessageToGroupedContainer } from "./utils/MessageGrouping";
 // Tool call rendering is fully status-driven from PI tool events.
 
 export const messageHandling = {
@@ -182,82 +182,7 @@ export const messageHandling = {
       chatView.inputHandler.focus();
     };
     
-    const editHandler = async (e: CustomEvent) => {
-      if (chatView.isLegacyReadOnlyChat()) {
-        new Notice("Editing archived chats is disabled. Start a new chat instead.");
-        return;
-      }
-
-      if (chatView.getPiSessionFile() || chatView.getPiSessionId()) {
-        new Notice("Editing earlier SystemSculpt-session messages is not supported yet. Branch from that user message instead.");
-        return;
-      }
-
-      const { messageId, newContent } = e.detail;
-      const index = chatView.messages.findIndex((msg) => msg.message_id === messageId);
-      if (index !== -1) {
-        const existingMessage = chatView.messages[index];
-        const updatedMessage = {
-          ...existingMessage,
-          content: newContent,
-          messageParts: undefined
-        };
-        chatView.messages[index] = updatedMessage;
-        chatView.clearPiSessionState({ save: false });
-        
-        await chatView.saveChat();
-        
-        // Re-render just this message with updated content
-        const { contentEl: newContentEl } = await chatView.messageRenderer.renderMessage({
-          app: chatView.app,
-          messageId,
-          role: updatedMessage.role,
-          content: updatedMessage.content,
-          onResend:
-            updatedMessage.role === "user"
-              ? async (input) => this.runResendAction(chatView, input)
-              : undefined,
-        });
-        
-        // Re-apply assistant message rendering if needed
-        if (updatedMessage.role === 'assistant') {
-          await this.renderAssistantMessage(chatView, messageEl, updatedMessage);
-        }
-        
-        const oldContentEl = messageEl.querySelector(".systemsculpt-message-content");
-        if (oldContentEl && newContentEl) {
-          oldContentEl.replaceWith(newContentEl);
-        }
-        
-        const updatedStr = typeof updatedMessage.content === "string" ? updatedMessage.content : JSON.stringify(updatedMessage.content);
-        messageEl.dataset.content = updatedStr;
-      }
-    };
-    
-    const deleteHandler = async (e: CustomEvent) => {
-      if (chatView.isLegacyReadOnlyChat()) {
-        new Notice("Deleting turns from archived chats is disabled. Start a new chat instead.");
-        return;
-      }
-
-      if (chatView.getPiSessionFile() || chatView.getPiSessionId()) {
-        new Notice("Deleting individual messages is disabled for SystemSculpt-session chats. Branch from a user message instead.");
-        return;
-      }
-
-      const { messageId } = e.detail;
-      const index = chatView.messages.findIndex((msg) => msg.message_id === messageId);
-      if (index !== -1) {
-        chatView.messages.splice(index, 1);
-        chatView.clearPiSessionState({ save: false });
-        await chatView.saveChat();
-        removeMessageElement(messageEl);
-      }
-    };
-    
     registerHandler(messageEl, "reply", replyHandler as EventListener);
-    registerHandler(messageEl, "edit", editHandler as EventListener);
-    registerHandler(messageEl, "delete", deleteHandler as EventListener);
   },
 
 

--- a/src/views/chatview/uiSetup.ts
+++ b/src/views/chatview/uiSetup.ts
@@ -230,41 +230,6 @@ export const uiSetup = {
     // If we need DOM mutation tracking in the future, we can add it back
     // with more selective and less verbose logging
 
-    // Define the event listener function
-    const handleMessageEdited = async (event: Event) => {
-      // Cast to CustomEvent to access detail
-      const customEvent = event as CustomEvent;
-      const { messageId, newContent } = customEvent.detail;
-      const messageIndex = chatView.messages.findIndex(msg => msg.message_id === messageId);
-      if (messageIndex !== -1) {
-        // Ensure content type matches (simple string for now)
-        if (typeof chatView.messages[messageIndex].content === 'string') {
-           chatView.messages[messageIndex].content = newContent;
-           await chatView.saveChat();
-        } else {
-             // Handle potential MultiPartContent edits if needed in the future
-             // For now, let's assume it's text part if it's an array
-             if (Array.isArray(chatView.messages[messageIndex].content)) {
-                 const textPart = (chatView.messages[messageIndex].content as any[]).find(p => p.type === 'text');
-                 if (textPart) {
-                     textPart.text = newContent;
-                     await chatView.saveChat();
-                 } else {
-                 }
-             }
-        }
-      } else {
-      }
-    };
-
-    // Add the event listener using standard addEventListener
-    chatView.chatContainer.addEventListener('message-edited', handleMessageEdited);
-
-    // Register cleanup to remove the listener on unload
-    chatView.register(() => {
-      chatView.chatContainer.removeEventListener('message-edited', handleMessageEdited);
-    });
-
     // Create scroll-to-bottom button
     const scrollToBottomButton = document.createElement('button');
     scrollToBottomButton.className = 'systemsculpt-scroll-to-bottom';


### PR DESCRIPTION
Part of #213 cleanup — re-architect, don't perpetuate legacy.

- Removes the `edit`/`delete` `CustomEvent` handlers in `messageHandling.ts` and the duplicate `message-edited` listener in `uiSetup.ts`. Verified orphaned: nothing in `src/` dispatches these events and no tests reference them — only `reply` (and the resend flow) are wired to the UI. ~110 lines of unreachable code removed; live reply/resend behaviour unchanged.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM