### PR TITLE
fix(chat): scope agent mode to the chat, not the global setting (#210)

### DIFF
--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -121,6 +121,9 @@ export class ChatView extends ItemView {
   // Per-chat override for hiding SystemSculpt system + tool messages (#213/#174/#167).
   // undefined = follow the global `hideSystemMessagesInChat` setting.
   public hideSystemMessages: boolean | undefined;
+  // Per-chat override for agent mode (#210/#149/#185).
+  // undefined = follow the global `agentModeEnabled` setting.
+  public agentModeEnabled: boolean | undefined;
   private chatExportService: ChatExportService | null = null;
   private debugLogService: ChatDebugLogService | null = null;
   private warnedImageIncompatModels: Set<string> = new Set();
@@ -168,6 +171,7 @@ export class ChatView extends ItemView {
         piLastEntryId?: string;
         piLastSyncedAt?: string;
         hideSystemMessages?: boolean;
+        agentModeEnabled?: boolean;
     }) || {};
 
     this.messages = [];
@@ -192,6 +196,7 @@ export class ChatView extends ItemView {
     // Initialize chat font size from saved state or plugin settings
     this.chatFontSize = initialState.chatFontSize || (plugin.settings as any).chatFontSize || "medium";
     this.hideSystemMessages = initialState.hideSystemMessages;
+    this.agentModeEnabled = initialState.agentModeEnabled;
   }
 
   private ensureCoreServicesReady(): void {
@@ -322,7 +327,7 @@ export class ChatView extends ItemView {
           title: this.chatTitle,
           chatFontSize: this.chatFontSize,
           selectedPromptPath: this.inputHandler?.getSelectedPromptPath?.() || "",
-          agentModeEnabled: this.inputHandler?.isAgentModeEnabled?.(),
+          agentModeEnabled: this.agentModeEnabled,
           hideSystemMessages: this.hideSystemMessages,
           piSessionFile: this.piSessionFile,
           piSessionId: this.piSessionId,
@@ -1228,6 +1233,20 @@ export class ChatView extends ItemView {
     );
   }
 
+  // Effective agent mode (#210/#149/#185): a per-chat preference wins; otherwise
+  // fall back to the global `agentModeEnabled` default (enabled when unset).
+  public isAgentModeActive(): boolean {
+    return this.agentModeEnabled ?? this.plugin.settings.agentModeEnabled ?? true;
+  }
+
+  // Flip the per-chat preference, sync the composer toggle, and persist — without
+  // mutating the global default (the v5 regression behind #149/#185).
+  public toggleAgentMode(): void {
+    this.agentModeEnabled = !this.isAgentModeActive();
+    this.inputHandler?.syncAgentModeButton?.();
+    void this.saveChat();
+  }
+
 
   public async getCurrentSystemPrompt(): Promise<string> {
     this.ensureCoreServicesReady();
@@ -1534,6 +1553,7 @@ export class ChatView extends ItemView {
       version: this.chatVersion,
       chatFontSize: this.chatFontSize,
       hideSystemMessages: this.hideSystemMessages,
+      agentModeEnabled: this.agentModeEnabled,
       chatBackend: this.chatBackend,
       piSessionFile: this.piSessionFile,
       piSessionId: this.piSessionId,
@@ -1571,6 +1591,8 @@ export class ChatView extends ItemView {
       }
       this.hideSystemMessages =
         typeof state?.hideSystemMessages === "boolean" ? state.hideSystemMessages : undefined;
+      this.agentModeEnabled =
+        typeof state?.agentModeEnabled === "boolean" ? state.agentModeEnabled : undefined;
       this.virtualStartIndex = 0;
       this.hasAdjustedInitialWindow = false;
       this.messages = [];
@@ -1607,6 +1629,9 @@ export class ChatView extends ItemView {
     this.applyChatLeafState(state);
     if (typeof state.hideSystemMessages === "boolean") {
       this.hideSystemMessages = state.hideSystemMessages;
+    }
+    if (typeof state.agentModeEnabled === "boolean") {
+      this.agentModeEnabled = state.agentModeEnabled;
     }
     // Restore chat font size
     if (state.chatFontSize) {
@@ -1723,10 +1748,11 @@ export class ChatView extends ItemView {
         // Restore selected prompt and agent mode for this chat
         if (this.inputHandler) {
           this.inputHandler.setSelectedPromptPath(chatData.selectedPromptPath || null);
-          if (typeof chatData.agentModeEnabled === "boolean") {
-            this.inputHandler.setAgentModeEnabled(chatData.agentModeEnabled);
-          }
         }
+        // Restore per-chat agent mode (#210/#149/#185); undefined follows the global default.
+        this.agentModeEnabled =
+          typeof chatData.agentModeEnabled === "boolean" ? chatData.agentModeEnabled : undefined;
+        this.inputHandler?.syncAgentModeButton?.();
 
         // Restore per-chat system/tool message visibility (#213/#174/#167).
         if (typeof chatData.hideSystemMessages === "boolean") {
@@ -2550,11 +2576,12 @@ export class ChatView extends ItemView {
   }
 
   public isAgentModeEnabled(): boolean {
-    return this.inputHandler?.isAgentModeEnabled?.() ?? false;
+    return this.isAgentModeActive();
   }
 
   public setAgentModeEnabled(enabled: boolean): void {
-    this.inputHandler?.setAgentModeEnabled?.(enabled);
+    this.agentModeEnabled = enabled;
+    this.inputHandler?.syncAgentModeButton?.();
   }
 
   public async sendAutomationMessage(options?: {
@@ -2573,7 +2600,7 @@ export class ChatView extends ItemView {
     }
 
     if (typeof options?.agentModeEnabled === "boolean") {
-      this.inputHandler.setAgentModeEnabled(options.agentModeEnabled);
+      this.setAgentModeEnabled(options.agentModeEnabled);
     }
 
     if (options && "text" in options && options.text !== undefined) {

--- a/src/views/chatview/InputHandler.ts
+++ b/src/views/chatview/InputHandler.ts
@@ -853,11 +853,22 @@ export class InputHandler extends Component {
     };
 
     this.registerEvent(
-      this.app.workspace.on("systemsculpt:settings-updated", () => {
-        this.updateGeneratingState();
-        this.onModelChange({ refreshOptions: true });
-      })
+      this.app.workspace.on("systemsculpt:settings-updated", () => this.handleSettingsUpdated())
     );
+  }
+
+  /**
+   * React to a global settings change. Refresh the generating-state UI and
+   * model options, and re-sync the composer toggles whose active state follows
+   * a per-chat value with a global-default fallback — a chat that follows the
+   * global default (per-chat value unset) would otherwise show a stale toggle
+   * after the global setting changes (#210, #213).
+   */
+  public handleSettingsUpdated(): void {
+    this.updateGeneratingState();
+    this.onModelChange({ refreshOptions: true });
+    this.syncAgentModeButton();
+    this.syncHideSystemMessagesButton();
   }
 
   private initializeSlashCommands(): void {

--- a/src/views/chatview/InputHandler.ts
+++ b/src/views/chatview/InputHandler.ts
@@ -103,7 +103,6 @@ export class InputHandler extends Component {
   private attachmentPillsByKey: Map<string, HTMLElement> = new Map();
   private isGenerating = false;
   private webSearchEnabled = false;
-  private agentModeEnabled: boolean;
   private agentModeButtonEl: HTMLElement | null = null;
   // ButtonComponent for the per-chat hide system/tool toggle (#213/#174/#167).
   private hideSystemButton: any = null;
@@ -187,7 +186,6 @@ export class InputHandler extends Component {
     this.getChatId = options.getChatId;
     this.notifyModelChange = options.onModelChange || (() => {});
     this.chatView = options.chatView;
-    this.agentModeEnabled = this.plugin.settings.agentModeEnabled ?? true;
     this.selectedPromptPath = this.plugin.settings.lastUsedPromptPath || null;
     this.promptService = new PromptService(
       this.app,
@@ -333,7 +331,7 @@ export class InputHandler extends Component {
           this.chatView?.setPiSessionState?.(session);
         },
         webSearchEnabled: this.webSearchEnabled,
-        ...(this.agentModeEnabled ? {} : { allowTools: false }),
+        ...((this.chatView?.isAgentModeActive?.() ?? true) ? {} : { allowTools: false }),
         ...(systemPromptOverride ? { systemPromptOverride } : {}),
         ...(options?.transientSystemPromptSuffix
           ? { transientSystemPromptSuffix: options.transientSystemPromptSuffix }
@@ -761,12 +759,8 @@ export class InputHandler extends Component {
       hasProLicense: () => !!(this.plugin.settings.licenseKey?.trim() && this.plugin.settings.licenseValid),
       onToggleWebSearch: () => { this.webSearchEnabled = !this.webSearchEnabled; },
       isWebSearchEnabled: () => this.webSearchEnabled,
-      onToggleAgentMode: () => {
-        this.agentModeEnabled = !this.agentModeEnabled;
-        this.plugin.settings.agentModeEnabled = this.agentModeEnabled;
-        void this.plugin.saveSettings();
-      },
-      isAgentModeEnabled: () => this.agentModeEnabled,
+      onToggleAgentMode: () => this.chatView?.toggleAgentMode?.(),
+      isAgentModeEnabled: () => this.chatView?.isAgentModeActive?.() ?? true,
       onToggleHideSystemMessages: () => this.chatView?.toggleSystemNoiseHidden?.(),
       isHideSystemMessagesEnabled: () => this.chatView?.isSystemNoiseHidden?.() ?? false,
     });
@@ -1448,18 +1442,12 @@ export class InputHandler extends Component {
     this.automationApprovalMode = mode;
   }
 
-  public isAgentModeEnabled(): boolean {
-    return this.agentModeEnabled;
-  }
-
-  public setAgentModeEnabled(enabled: boolean): void {
-    this.agentModeEnabled = enabled;
-    this.syncAgentModeButton();
-  }
-
-  private syncAgentModeButton(): void {
+  // Keep the composer agent-mode toggle's active state in sync with the per-chat
+  // value owned by ChatView (e.g. restored on chat load) (#210/#149/#185).
+  public syncAgentModeButton(): void {
     if (!this.agentModeButtonEl) return;
-    this.agentModeButtonEl.classList.toggle("ss-active", this.agentModeEnabled);
+    const active = this.chatView?.isAgentModeActive?.() ?? true;
+    this.agentModeButtonEl.classList.toggle("ss-active", active);
   }
 
   // Keep the composer toggle in sync when the per-chat preference changes outside
@@ -1489,7 +1477,6 @@ export class InputHandler extends Component {
   public resetForFreshChat(): void {
     this.pendingLargeTextContent = null;
     this.webSearchEnabled = false;
-    this.agentModeEnabled = this.plugin.settings.agentModeEnabled ?? true;
     this.syncAgentModeButton();
     this.selectedPromptPath = this.plugin.settings.lastUsedPromptPath || null;
     this.selectedPromptName = this.selectedPromptPath

--- a/src/views/chatview/__tests__/chatview-agent-mode-per-chat.test.ts
+++ b/src/views/chatview/__tests__/chatview-agent-mode-per-chat.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { ChatView } from "../ChatView";
+
+jest.mock("../../../core/ui/", () => ({ showPopup: jest.fn() }));
+jest.mock("../../../utils/externalUrl", () => ({ openExternalUrl: jest.fn() }));
+jest.mock("../uiSetup", () => ({
+  uiSetup: {
+    showLicenseBanner: jest.fn(),
+    hideLicenseBanner: jest.fn(),
+    updateToolCompatibilityWarning: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Per-chat agent mode (#210 → #149/#185). Agent mode must be a per-chat decision
+// that persists in the chat (mirroring the hideSystemMessages toggle), NOT a write
+// to the global setting. isAgentModeActive() is the resolver the send path consults;
+// toggleAgentMode() is the composer toggle's behavioral contract.
+const makeView = (opts: { perChat?: boolean; global?: boolean }): any =>
+  Object.assign(Object.create(ChatView.prototype), {
+    agentModeEnabled: opts.perChat,
+    plugin: {
+      settings: { agentModeEnabled: opts.global },
+      saveSettings: jest.fn(),
+    },
+    inputHandler: { syncAgentModeButton: jest.fn() },
+    saveChat: jest.fn().mockResolvedValue(undefined),
+  });
+
+describe("ChatView per-chat agent mode (#210, #149, #185)", () => {
+  it("isAgentModeActive uses the per-chat value when set", () => {
+    expect(makeView({ perChat: false, global: true }).isAgentModeActive()).toBe(false);
+    expect(makeView({ perChat: true, global: false }).isAgentModeActive()).toBe(true);
+  });
+
+  it("isAgentModeActive falls back to the global setting when no per-chat value is set", () => {
+    expect(makeView({ perChat: undefined, global: false }).isAgentModeActive()).toBe(false);
+    expect(makeView({ perChat: undefined, global: true }).isAgentModeActive()).toBe(true);
+  });
+
+  it("isAgentModeActive defaults to enabled when neither per-chat nor global is set", () => {
+    expect(makeView({ perChat: undefined, global: undefined }).isAgentModeActive()).toBe(true);
+  });
+
+  it("toggleAgentMode flips the per-chat value WITHOUT mutating the global setting", () => {
+    const view = makeView({ perChat: undefined, global: true });
+    view.toggleAgentMode(); // active (true via global) -> false, recorded per-chat
+    expect(view.agentModeEnabled).toBe(false);
+    expect(view.plugin.settings.agentModeEnabled).toBe(true); // global default untouched
+    expect(view.plugin.saveSettings).not.toHaveBeenCalled();
+  });
+
+  it("toggleAgentMode persists the chat and syncs the composer button", () => {
+    const view = makeView({ perChat: false, global: false });
+    view.toggleAgentMode(); // false -> true
+    expect(view.agentModeEnabled).toBe(true);
+    expect(view.saveChat).toHaveBeenCalledTimes(1);
+    expect(view.inputHandler.syncAgentModeButton).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/views/chatview/__tests__/input-handler-settings-updated.test.ts
+++ b/src/views/chatview/__tests__/input-handler-settings-updated.test.ts
@@ -31,6 +31,7 @@ describe("InputHandler.handleSettingsUpdated (#210, #213)", () => {
     const handler = makeHandler();
     handler.handleSettingsUpdated();
     expect(handler.updateGeneratingState).toHaveBeenCalledTimes(1);
-    expect(handler.onModelChange).toHaveBeenCalledWith({ refreshOptions: true });
+    expect(handler.onModelChange).toHaveBeenCalledTimes(1);
+    expect(handler.onModelChange).toHaveBeenNthCalledWith(1, { refreshOptions: true });
   });
 });

--- a/src/views/chatview/__tests__/input-handler-settings-updated.test.ts
+++ b/src/views/chatview/__tests__/input-handler-settings-updated.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { InputHandler } from "../InputHandler";
+
+// A chat that follows the global default (per-chat toggle unset) must refresh
+// its composer toggle buttons when the global settings change — otherwise the
+// button shows a stale active state until the next toggle or chat reload. The
+// workspace "systemsculpt:settings-updated" listener delegates to
+// handleSettingsUpdated(); this guards that it re-syncs BOTH global-fallback
+// toggles (agent mode #210/#149/#185, hide-system #213/#174/#167) in addition
+// to the generating-state UI and model options.
+const makeHandler = (): any =>
+  Object.assign(Object.create(InputHandler.prototype), {
+    updateGeneratingState: jest.fn(),
+    onModelChange: jest.fn(),
+    syncAgentModeButton: jest.fn(),
+    syncHideSystemMessagesButton: jest.fn(),
+  });
+
+describe("InputHandler.handleSettingsUpdated (#210, #213)", () => {
+  it("re-syncs both per-chat toggle buttons on a global settings change", () => {
+    const handler = makeHandler();
+    handler.handleSettingsUpdated();
+    expect(handler.syncAgentModeButton).toHaveBeenCalledTimes(1);
+    expect(handler.syncHideSystemMessagesButton).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refreshes generating state and model options", () => {
+    const handler = makeHandler();
+    handler.handleSettingsUpdated();
+    expect(handler.updateGeneratingState).toHaveBeenCalledTimes(1);
+    expect(handler.onModelChange).toHaveBeenCalledWith({ refreshOptions: true });
+  });
+});

--- a/src/views/chatview/storage/__tests__/ChatMarkdownSerializer.test.ts
+++ b/src/views/chatview/storage/__tests__/ChatMarkdownSerializer.test.ts
@@ -301,6 +301,31 @@ Hello!
       expect(unset?.metadata.hideSystemMessages).toBeUndefined();
     });
 
+    it("round-trips the per-chat agent-mode preference (#210, #149, #185)", () => {
+      const base = {
+        model: "gpt-4",
+        title: "Test Chat",
+        created: "2024-01-01T00:00:00Z",
+        lastModified: "2024-01-01T12:00:00Z",
+      };
+
+      const on = ChatMarkdownSerializer.parseMarkdown(
+        createMarkdown({ id: "chat-agent-on", ...base, agentModeEnabled: true }, "")
+      );
+      expect(on?.metadata.agentModeEnabled).toBe(true);
+
+      const off = ChatMarkdownSerializer.parseMarkdown(
+        createMarkdown({ id: "chat-agent-off", ...base, agentModeEnabled: false }, "")
+      );
+      expect(off?.metadata.agentModeEnabled).toBe(false);
+
+      // Unset means "follow the global default" — must not coerce to a boolean.
+      const unset = ChatMarkdownSerializer.parseMarkdown(
+        createMarkdown({ id: "chat-agent-unset", ...base }, "")
+      );
+      expect(unset?.metadata.agentModeEnabled).toBeUndefined();
+    });
+
     it("marks legacy prompt metadata as legacy-only compatibility state", () => {
       const content = createMarkdown(
         {


### PR DESCRIPTION
Part of #210 (rework: agent mode session control). First slice — the per-chat agent-mode toggle. Original symptom reports: #149, #185.

**Problem.** The composer's agent-mode toggle wrote `plugin.settings.agentModeEnabled` — the *global* default. Turning agent mode off in one chat silently flipped it off for every other chat and every new chat.

**Fix.** Agent mode is now a per-chat decision, mirroring the existing `hideSystemMessages` toggle:
- `ChatView` owns `agentModeEnabled` per-chat (`undefined` = follow the global default). `isAgentModeActive()` is the resolver the send path consults; `toggleAgentMode()` flips the per-chat value, persists via `saveChat()`, and **never** mutates the global setting. `InputHandler` delegates to it (no local agent-mode state).
- The global setting stays the default for **new** chats only, and the per-chat value round-trips through getState/setState/save/load.

**Tests (failing-first).** ChatView resolver + toggle behavior — including a guard that the toggle does **not** call `saveSettings` — plus a `ChatMarkdownSerializer` round-trip guard (`undefined` stays unset → follows global).

Local gates green: `check:plugin:fast`, full unit (5563 passed), `test:integration` (21 passed).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-chat agent mode control: Enable or disable agent mode per conversation, independently of the global setting, with automatic save and restore when reopening chats.

* **Improvements**
  * Composer agent-mode toggle stays in sync with restored chat state and responds correctly to settings changes.
  * Agent mode is now driven by effective per-chat state when sending streamed/hosted assistant responses.

* **Tests**
  * Added coverage for per-chat agent mode state, toggle persistence, and markdown front-matter round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->