### PR TITLE
fix(chat): honor toolUse stopReason so agent stalls surface an actionable error (#210)

### DIFF
--- a/src/views/chatview/InputHandler.ts
+++ b/src/views/chatview/InputHandler.ts
@@ -388,8 +388,24 @@ export class InputHandler extends Component {
     return renderedMessages.find((messageEl) => messageEl.dataset.messageId === messageId) ?? null;
   }
 
-  private shouldContinueHostedToolLoop(message: ChatMessage, _stopReason?: string): boolean {
+  private shouldContinueHostedToolLoop(message: ChatMessage, stopReason?: string): boolean {
     const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
+
+    // The model signalled it wants to use a tool (stopReason "toolUse") but no
+    // tool call materialised on the message — e.g. a provider continuation error
+    // dropped the call. Continuing would re-prompt with nothing to execute, and
+    // returning here would look like the agent silently died after its first
+    // tool call (#146). Surface it as an actionable error, never a silent stall
+    // (#210). The turn cap and empty-completion retries above remain the
+    // backstops for the other terminal paths.
+    if (stopReason === "toolUse" && toolCalls.length === 0) {
+      this.failHostedToolTurn(
+        "The model requested a tool call but none was returned. Stopping to avoid a silent stall — please try again.",
+        502,
+        { reason: "tool-use-without-tool-calls", stopReason }
+      );
+    }
+
     if (toolCalls.length === 0) {
       return false;
     }

--- a/src/views/chatview/__tests__/input-handler-tool-loop.test.ts
+++ b/src/views/chatview/__tests__/input-handler-tool-loop.test.ts
@@ -619,6 +619,50 @@ describe("InputHandler hosted tool loop", () => {
     expect(streamAssistantTurn).toHaveBeenCalledTimes(3);
   });
 
+  it("surfaces a toolUse stop with no tool calls instead of stalling silently (#210, #146)", async () => {
+    const { aiService, handler, onError } = createHostedToolLoopHarness();
+
+    // The model signals it wants a tool (stopReason "toolUse") but no tool call
+    // materialised on the message — the #146 continuation-failure shape. The
+    // turn must surface an actionable error, not end silently after one round.
+    const streamAssistantTurn = jest
+      .spyOn(handler as any, "streamAssistantTurn")
+      .mockResolvedValue({
+        messageId: "assistant-tooluse-empty",
+        message: {
+          role: "assistant",
+          content: "Let me read that file for you.",
+          message_id: "assistant-tooluse-empty",
+          tool_calls: [],
+        } as any,
+        messageEl: document.createElement("div"),
+        completed: true,
+        completionState: "completed",
+        stopReason: "toolUse",
+      });
+
+    handler.setValue("Read my note.");
+
+    await expect(
+      handler.submitForAutomation({
+        includeContextFiles: false,
+        approvalMode: "auto-approve",
+        focusAfterSend: false,
+      })
+    ).rejects.toThrow(/tool call/i);
+
+    expect(streamAssistantTurn).toHaveBeenCalledTimes(1);
+    expect(aiService.executeHostedToolCall).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]?.metadata).toEqual(
+      expect.objectContaining({
+        recoverCommittedTurn: true,
+        reason: "tool-use-without-tool-calls",
+        stopReason: "toolUse",
+      })
+    );
+  });
+
   it("keeps the submitted user message and completed tool result when continuation retries are exhausted", async () => {
     const { aiService, handler, messages, onError } = createHostedToolLoopHarness();
 


### PR DESCRIPTION
Part of #210 (rework: agent mode session control). Second slice — honor the model's stop reason so an agent stall surfaces as an actionable error. Fixes the #146 symptom ("agent stops responding after using a tool").

**Problem.** `InputHandler.shouldContinueHostedToolLoop` ignored the `stopReason` it was passed (`_stopReason`) and decided continue-vs-stop purely from tool-call state. When a provider signalled `toolUse` but no tool call materialised on the message (the #146 continuation-failure shape), `toolCalls.length === 0` → the loop returned and the turn ended **silently** — the agent "stopped responding after its first tool call."

**Fix.** `shouldContinueHostedToolLoop` now consumes `stopReason`: a `toolUse` stop with no tool calls routes through `failHostedToolTurn` (actionable `SystemSculptError`, `recoverCommittedTurn: true`) instead of a silent `return`. Satisfies #210's "a stall must surface as an actionable error, not silence." The existing turn cap (8) and empty-completion retry watchdog remain the backstops for other terminal paths.

**Test (failing-first).** New case in `input-handler-tool-loop.test.ts`: a turn returning `stopReason: "toolUse"` with empty `tool_calls` now ends in one round via `onError` (not a silent resolve) and never calls a tool.

Local gates green: `check:plugin:fast`, full unit (5566 passed), `test:integration`.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the assistant could stall indefinitely when attempting a tool operation without providing the required tool information. The system now properly detects such mismatches and reports them with appropriate status codes, enabling better error handling and recovery in automated agent workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->