### PR TITLE
fix(chat): stop the local Pi agent loop on repeated identical failing tool calls (#210)

### DIFF
--- a/src/services/pi-native/PiLocalAgentExecutor.ts
+++ b/src/services/pi-native/PiLocalAgentExecutor.ts
@@ -294,6 +294,12 @@ function normalizePiToolExecutionResult(result: unknown, isError: boolean): Tool
   };
 }
 
+// A tool call that keeps failing with identical arguments is the "stuck in
+// agent loop" failure (#136): the SDK re-issues it every turn and the user is
+// re-prompted forever. Stop the local turn after this many identical
+// consecutive failures and surface an actionable error (#210).
+const MAX_CONSECUTIVE_IDENTICAL_TOOL_FAILURES = 3;
+
 export async function* streamPiLocalAgentTurn(
   options: PiLocalAgentRunOptions
 ): AsyncGenerator<StreamEvent, void, unknown> {
@@ -332,6 +338,8 @@ export async function* streamPiLocalAgentTurn(
     let streamedText = "";
     let streamedReasoning = "";
     let finished = false;
+    let repeatedToolFailureKey: string | null = null;
+    let repeatedToolFailureCount = 0;
 
     const push = (item: QueueItem) => {
       if (finished && item.kind === "event") {
@@ -474,19 +482,42 @@ export async function* streamPiLocalAgentTurn(
             executionStartedAt: existing?.executionStartedAt,
           };
           toolCallsById.delete(toolCallId);
+          const isError = Boolean(sessionEvent.isError);
           push({
             kind: "event",
-            event: buildPiToolCallEvent(
-              snapshot,
-              Boolean(sessionEvent.isError) ? "failed" : "completed",
-              {
-                result: normalizePiToolExecutionResult(
-                  sessionEvent.result,
-                  Boolean(sessionEvent.isError)
-                ),
-              }
-            ),
+            event: buildPiToolCallEvent(snapshot, isError ? "failed" : "completed", {
+              result: normalizePiToolExecutionResult(sessionEvent.result, isError),
+            }),
           });
+
+          // Loop guard (#136): a tool call that keeps failing with identical
+          // arguments means the agent is stuck re-issuing the same failing
+          // action. Stop after a few identical consecutive failures and surface
+          // an actionable error (#210) instead of letting the local loop run
+          // unbounded. A successful (or different) call resets the counter.
+          if (isError) {
+            const failureKey = `${snapshot.name} ${snapshot.arguments}`;
+            if (failureKey === repeatedToolFailureKey) {
+              repeatedToolFailureCount += 1;
+            } else {
+              repeatedToolFailureKey = failureKey;
+              repeatedToolFailureCount = 1;
+            }
+            if (repeatedToolFailureCount >= MAX_CONSECUTIVE_IDENTICAL_TOOL_FAILURES) {
+              finished = true;
+              void activeSession.abort().catch(() => {});
+              push({
+                kind: "error",
+                error: new Error(
+                  `The agent repeatedly attempted the same failing tool call (${snapshot.name}) ${repeatedToolFailureCount} times and was stopped to avoid a loop. Adjust the request or try a different approach.`
+                ),
+              });
+              return;
+            }
+          } else {
+            repeatedToolFailureKey = null;
+            repeatedToolFailureCount = 0;
+          }
         }
         return;
       }

--- a/src/services/pi-native/__tests__/PiLocalAgentExecutor.test.ts
+++ b/src/services/pi-native/__tests__/PiLocalAgentExecutor.test.ts
@@ -152,6 +152,41 @@ describe("PiLocalAgentExecutor", () => {
     expect(latestSession().dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("stops the local agent loop after repeated identical failing tool calls (#136, #210)", async () => {
+    const failingArgs = { path: "inbox/note.md", frontmatter: { status: "filed" } };
+    configureNextSession = (session) => {
+      session.setPromptImplementation(async () => {
+        // The model re-issues the same tool call that keeps failing — the
+        // "stuck in agent loop" shape from #136. agent_end is never emitted, so
+        // without a loop guard the turn would never terminate.
+        for (let round = 1; round <= 6; round += 1) {
+          session.emit({
+            type: "tool_execution_start",
+            toolCallId: `call_${round}`,
+            toolName: "edit_file",
+            args: failingArgs,
+          });
+          session.emit({
+            type: "tool_execution_end",
+            toolCallId: `call_${round}`,
+            toolName: "edit_file",
+            isError: true,
+            result: { error: "permission denied" },
+          });
+        }
+      });
+    };
+
+    const generator = streamPiLocalAgentTurn({
+      plugin: createPlugin(),
+      modelId: "openai/gpt-5-mini",
+      messages: [{ role: "user", content: "File my inbox notes.", message_id: "loop_1" } as any],
+    });
+
+    await expect(collectEvents(generator)).rejects.toThrow(/repeated|loop/i);
+    expect(latestSession().abort).toHaveBeenCalled();
+  });
+
   it("reuses an existing Pi session file when provided", async () => {
     configureNextSession = (session) => {
       session.setPromptImplementation(async () => {


### PR DESCRIPTION
Part of #210 (rework: agent mode session control). Third slice — bound the local Pi agent loop. Fixes #136 ("stuck in agent loop").

**Problem.** The local Pi (BYOK / pi-coding-agent) path runs the model→tool→model loop inside the SDK (`activeSession.prompt(...)`), and the plugin only ends the turn on `agent_end`. There was no turn budget or loop guard. When a tool call kept failing with identical arguments — the #136 report (file-move + frontmatter edit fails, the agent re-issues the same call every turn, the user is re-prompted "approve→fail→approve→fail…" forever) — nothing stopped it. The hosted loop's `maxToolContinuationRounds` cap doesn't help: the SDK runs every tool round inside a single `streamAssistantTurn` drain, so it's structurally bypassed.

**Fix.** `streamPiLocalAgentTurn` now tracks consecutive identical failing tool calls (keyed by name + arguments). After `MAX_CONSECUTIVE_IDENTICAL_TOOL_FAILURES` (3), it aborts the SDK session and surfaces an actionable error — satisfying #210's "a stall must surface as an actionable error, not silence." A successful or different tool call resets the counter, so legitimate multi-tool tasks are unaffected.

**Test (failing-first).** New case in `PiLocalAgentExecutor.test.ts`: a session that emits the same failing tool call repeatedly with no `agent_end` previously hung forever; it now terminates with an actionable error and aborts the session.

Local gates green: `check:plugin:fast`, full unit (5567 passed), `test:integration`.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against infinite agent loops when the same tool call fails repeatedly. The agent will now stop and report an error after reaching a failure threshold, preventing unresponsive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->