### PR TITLE
fix(agent-tools): resolve Folder Notes paths across all file tools (#210)

### DIFF
--- a/src/mcp-tools/filesystem/__tests__/folderNotes.test.ts
+++ b/src/mcp-tools/filesystem/__tests__/folderNotes.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import { App, TFile, TFolder } from "obsidian";
+import { resolveFolderNotePath, resolveExistingVaultFile } from "../folderNotes";
+
+describe("folderNotes (#154)", () => {
+  let app: App;
+
+  // Wire getAbstractFileByPath to a fixed Folder Notes vault layout:
+  //   Projects/        (folder)
+  //   Projects/Projects.md   (the folder note)
+  //   loose.md         (an ordinary note)
+  const folder = new TFolder();
+  (folder as any).path = "Projects";
+  const folderNote = new TFile({ path: "Projects/Projects.md" });
+  const looseNote = new TFile({ path: "loose.md" });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = new App();
+    (app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((p: string) => {
+      if (p === "Projects") return folder;
+      if (p === "Projects/Projects.md") return folderNote;
+      if (p === "loose.md") return looseNote;
+      return null;
+    });
+  });
+
+  describe("resolveFolderNotePath", () => {
+    it("resolves a folder-style path to the folder note (X.md -> X/X.md)", () => {
+      expect(resolveFolderNotePath(app, "Projects.md")).toBe("Projects/Projects.md");
+    });
+
+    it("returns null for non-markdown paths", () => {
+      expect(resolveFolderNotePath(app, "Projects")).toBeNull();
+      expect(resolveFolderNotePath(app, "image.png")).toBeNull();
+    });
+
+    it("returns null when the sibling folder does not exist", () => {
+      expect(resolveFolderNotePath(app, "Ghost.md")).toBeNull();
+    });
+
+    it("returns null when the candidate folder note does not exist", () => {
+      (app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((p: string) =>
+        p === "Empty" ? folder : null
+      );
+      expect(resolveFolderNotePath(app, "Empty.md")).toBeNull();
+    });
+
+    it("does not resolve an ordinary note that has no matching folder", () => {
+      expect(resolveFolderNotePath(app, "loose.md")).toBeNull();
+    });
+  });
+
+  describe("resolveExistingVaultFile", () => {
+    it("returns the file directly when it exists at the requested path", () => {
+      expect(resolveExistingVaultFile(app, "loose.md")).toBe(looseNote);
+    });
+
+    it("falls back to the folder note when the direct path is not a file", () => {
+      expect(resolveExistingVaultFile(app, "Projects.md")).toBe(folderNote);
+    });
+
+    it("returns null when neither the direct path nor a folder note exists", () => {
+      expect(resolveExistingVaultFile(app, "Ghost.md")).toBeNull();
+    });
+  });
+});

--- a/src/mcp-tools/filesystem/folderNotes.ts
+++ b/src/mcp-tools/filesystem/folderNotes.ts
@@ -1,0 +1,70 @@
+import { App, TFile, TFolder } from "obsidian";
+
+/**
+ * Folder-note aware path resolution shared by every agent file tool.
+ *
+ * The Folder Notes community plugin associates a note with a folder by storing
+ * it inside the folder under the folder's own name — folder `Projects` has its
+ * note at `Projects/Projects.md`. To the user the note *is* the folder, so the
+ * model is handed the folder-style path `Projects.md`. A plain
+ * `getAbstractFileByPath("Projects.md")` then resolves to the folder (or
+ * nothing), not the note, and the operation fails with "File not found" (#154).
+ *
+ * This module centralises the fallback so it behaves identically across read,
+ * edit, move, trash, and context tools — previously only `editFile` handled it.
+ * It is intentionally dependency-free (only the mobile-safe `obsidian` vault
+ * lookup) so it can run on every platform.
+ */
+
+/**
+ * Resolve a folder-style path to the real Folder Notes path when one exists.
+ *
+ * Resolution is conservative: it only fires when the requested path is a
+ * markdown file, the sibling target is a real folder, and the candidate note
+ * already exists. It never invents a path, so callers that create new files are
+ * unaffected.
+ *
+ * @returns the resolved `Folder/Folder.md` path, or `null` when no folder note
+ *   applies to the requested path.
+ */
+export function resolveFolderNotePath(app: App, requestedPath: string): string | null {
+  if (!requestedPath.endsWith(".md")) return null;
+
+  const withoutExt = requestedPath.slice(0, -3);
+  if (!withoutExt) return null;
+
+  const lastSlash = withoutExt.lastIndexOf("/");
+  const noteName = lastSlash >= 0 ? withoutExt.slice(lastSlash + 1) : withoutExt;
+  if (!noteName) return null;
+
+  const candidatePath = `${withoutExt}/${noteName}.md`;
+  if (candidatePath === requestedPath) return null;
+
+  const folder = app.vault.getAbstractFileByPath(withoutExt);
+  if (!(folder instanceof TFolder)) return null;
+
+  const candidate = app.vault.getAbstractFileByPath(candidatePath);
+  if (!(candidate instanceof TFile)) return null;
+
+  return candidatePath;
+}
+
+/**
+ * Resolve a requested path to an existing `TFile`, transparently falling back to
+ * the Folder Notes layout. Returns `null` when no existing file matches (the
+ * path is missing, or points at a folder with no associated folder note).
+ *
+ * Use this for file-only operations (read, edit). Operations that also accept
+ * folders (move, trash, add-folder-to-context) should look the path up directly
+ * and only use {@link resolveFolderNotePath} as a fallback.
+ */
+export function resolveExistingVaultFile(app: App, requestedPath: string): TFile | null {
+  const direct = app.vault.getAbstractFileByPath(requestedPath);
+  if (direct instanceof TFile) return direct;
+
+  const folderNotePath = resolveFolderNotePath(app, requestedPath);
+  if (!folderNotePath) return null;
+
+  const candidate = app.vault.getAbstractFileByPath(folderNotePath);
+  return candidate instanceof TFile ? candidate : null;
+}

--- a/src/mcp-tools/filesystem/tools/DirectoryOperations.ts
+++ b/src/mcp-tools/filesystem/tools/DirectoryOperations.ts
@@ -22,6 +22,7 @@ import {
   statAdapterPath,
 } from "../utils";
 import SystemSculptPlugin from "../../../main";
+import { resolveFolderNotePath } from "../folderNotes";
 
 /**
  * Directory operations for MCP Filesystem tools
@@ -397,8 +398,15 @@ export class DirectoryOperations {
           const normalizedSource = normalizePath(normalizeVaultPath(source));
           const normalizedDestination = normalizePath(normalizeVaultPath(destination));
 
-          // Get the source file/folder
-          const sourceFile = this.app.vault.getAbstractFileByPath(normalizedSource);
+          // Get the source file/folder, falling back to the Folder Notes
+          // layout (X.md -> X/X.md) so moves work on folder notes too (#154).
+          let sourceFile = this.app.vault.getAbstractFileByPath(normalizedSource);
+          if (!sourceFile) {
+            const folderNotePath = resolveFolderNotePath(this.app, normalizedSource);
+            if (folderNotePath) {
+              sourceFile = this.app.vault.getAbstractFileByPath(folderNotePath);
+            }
+          }
           if (!sourceFile) {
             throw new Error(`Item not found: ${source}`);
           }
@@ -478,9 +486,16 @@ export class DirectoryOperations {
       return { path, success: true };
     }
     
-    // Get the file/folder
+    // Get the file/folder, falling back to the Folder Notes layout
+    // (X.md -> X/X.md) so trashing works on folder notes too (#154).
     const normalizedPath = normalizePath(normalizeVaultPath(path));
-    const file = this.app.vault.getAbstractFileByPath(normalizedPath);
+    let file = this.app.vault.getAbstractFileByPath(normalizedPath);
+    if (!file) {
+      const folderNotePath = resolveFolderNotePath(this.app, normalizedPath);
+      if (folderNotePath) {
+        file = this.app.vault.getAbstractFileByPath(folderNotePath);
+      }
+    }
     if (!file) {
       throw new Error(`File not found: ${path}`);
     }

--- a/src/mcp-tools/filesystem/tools/FileOperations.ts
+++ b/src/mcp-tools/filesystem/tools/FileOperations.ts
@@ -1,4 +1,4 @@
-import { App, TFile, TFolder, normalizePath } from "obsidian";
+import { App, TFile, normalizePath } from "obsidian";
 import { FileReadMetadata, ReadFilesParams, WriteFileParams, EditFileParams, FileEdit } from "../types";
 import { FILESYSTEM_LIMITS } from "../constants";
 import {
@@ -14,6 +14,7 @@ import {
   statAdapterPath,
 } from "../utils";
 import { assertValidObsidianBasesYaml } from "../../../utils/obsidianBasesYaml";
+import { resolveExistingVaultFile } from "../folderNotes";
 
 /**
  * File operations for MCP Filesystem tools (read, write, edit)
@@ -64,7 +65,7 @@ export class FileOperations {
         continue;
       }
       const normalizedPath = normalizePath(normalizeVaultPath(path));
-      const file = this.app.vault.getAbstractFileByPath(normalizedPath);
+      const file = resolveExistingVaultFile(this.app, normalizedPath);
       if (file instanceof TFile) {
         try {
           const fullContent = await this.app.vault.read(file);
@@ -108,8 +109,8 @@ export class FileOperations {
             hasMore: hasMore
           };
           
-          files.push({ 
-            path: normalizedPath || path, 
+          files.push({
+            path: file.path,
             content: windowContent,
             metadata
           });
@@ -257,32 +258,6 @@ export class FileOperations {
     return { path: normalizedPath || path, success: true };
   }
 
-  private resolveFolderNotePath(requestedPath: string): string | null {
-    // Folder Notes plugin can store folder note "X" at "X/X.md".
-    // We only fall back when the requested path is a markdown file and the
-    // resolved target is unambiguous and already exists.
-    if (!requestedPath.endsWith(".md")) return null;
-
-    const withoutExt = requestedPath.slice(0, -3);
-    if (!withoutExt) return null;
-
-    const lastSlash = withoutExt.lastIndexOf("/");
-    const noteName = lastSlash >= 0 ? withoutExt.slice(lastSlash + 1) : withoutExt;
-    if (!noteName) return null;
-
-    const folderPath = withoutExt;
-    const candidatePath = `${folderPath}/${noteName}.md`;
-    if (candidatePath === requestedPath) return null;
-
-    const folder = this.app.vault.getAbstractFileByPath(folderPath);
-    if (!(folder instanceof TFolder)) return null;
-
-    const candidate = this.app.vault.getAbstractFileByPath(candidatePath);
-    if (!(candidate instanceof TFile)) return null;
-
-    return candidatePath;
-  }
-
   /**
    * Apply file edits using the clean MCP filesystem server approach
    */
@@ -317,19 +292,11 @@ export class FileOperations {
       return diff;
     }
 
-    let resolvedPath = normalizedPath;
-    let abstractFile = this.app.vault.getAbstractFileByPath(resolvedPath);
-    if (!(abstractFile instanceof TFile)) {
-      const fallback = this.resolveFolderNotePath(resolvedPath);
-      if (fallback) {
-        resolvedPath = fallback;
-        abstractFile = this.app.vault.getAbstractFileByPath(resolvedPath);
-      }
-    }
-
-    if (!(abstractFile instanceof TFile)) {
+    const abstractFile = resolveExistingVaultFile(this.app, normalizedPath);
+    if (!abstractFile) {
       throw new Error(`File not found: ${filePath}`);
     }
+    const resolvedPath = abstractFile.path;
 
     const content = normalizeLineEndings(await this.app.vault.read(abstractFile));
 

--- a/src/mcp-tools/filesystem/tools/ManagementOperations.ts
+++ b/src/mcp-tools/filesystem/tools/ManagementOperations.ts
@@ -9,6 +9,7 @@ import {
 import { FILESYSTEM_LIMITS } from "../constants";
 import { getFilesFromFolder, normalizeVaultPath } from "../utils";
 import { openFileInMainWorkspace } from '../../../utils/workspaceUtils';
+import { resolveFolderNotePath } from "../folderNotes";
 
 /**
  * Management operations for MCP Filesystem tools (workspace, context)
@@ -85,8 +86,16 @@ export class ManagementOperations {
       for (const path of paths) {
         try {
           const normalized = normalizePath(normalizeVaultPath(path));
-          const abstractFile = this.app.vault.getAbstractFileByPath(normalized);
-          
+          // Fall back to the Folder Notes layout (X.md -> X/X.md) so folder
+          // notes can be added to context too (#154).
+          let abstractFile = this.app.vault.getAbstractFileByPath(normalized);
+          if (!abstractFile) {
+            const folderNotePath = resolveFolderNotePath(this.app, normalized);
+            if (folderNotePath) {
+              abstractFile = this.app.vault.getAbstractFileByPath(folderNotePath);
+            }
+          }
+
           if (!abstractFile) {
             results.push({ path, success: false, reason: "File or directory not found" });
             continue;

--- a/src/mcp-tools/filesystem/tools/__tests__/DirectoryOperations.test.ts
+++ b/src/mcp-tools/filesystem/tools/__tests__/DirectoryOperations.test.ts
@@ -390,6 +390,26 @@ describe("DirectoryOperations", () => {
       // Notice is called but we don't mock it as a spy
       expect(app.fileManager.renameFile).toHaveBeenCalled();
     });
+
+    it("resolves a Folder Notes source path when moving (#154)", async () => {
+      const folder = new TFolder({ path: "Projects" });
+      const folderNote = new TFile({ path: "Projects/Projects.md" });
+      (app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((p: string) => {
+        if (p === "Projects") return folder;
+        if (p === "Projects/Projects.md") return folderNote;
+        return null;
+      });
+
+      const result = await dirOps.moveItems({
+        items: [{ source: "Projects.md", destination: "Archive/Projects.md" }],
+      });
+
+      expect(result.results[0].success).toBe(true);
+      expect(app.fileManager.renameFile).toHaveBeenCalledWith(
+        folderNote,
+        "Archive/Projects.md"
+      );
+    });
   });
 
   describe("trashFiles", () => {
@@ -444,6 +464,21 @@ describe("DirectoryOperations", () => {
       expect(result.results.length).toBe(3);
       expect(result.results.every((r) => r.success)).toBe(true);
       expect(app.vault.adapter.trashLocal).toHaveBeenCalledTimes(3);
+    });
+
+    it("resolves a Folder Notes path when trashing (#154)", async () => {
+      const folder = new TFolder({ path: "Projects" });
+      const folderNote = new TFile({ path: "Projects/Projects.md" });
+      (app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((p: string) => {
+        if (p === "Projects") return folder;
+        if (p === "Projects/Projects.md") return folderNote;
+        return null;
+      });
+
+      const result = await dirOps.trashFiles({ paths: ["Projects.md"] });
+
+      expect(result.results[0].success).toBe(true);
+      expect(app.vault.adapter.trashLocal).toHaveBeenCalledWith("Projects/Projects.md");
     });
   });
 });

--- a/src/mcp-tools/filesystem/tools/__tests__/FileOperations.test.ts
+++ b/src/mcp-tools/filesystem/tools/__tests__/FileOperations.test.ts
@@ -406,6 +406,24 @@ describe("FileOperations", () => {
       expect(result).toContain("missing/missing.md");
     });
 
+    it("reads a Folder Notes file when handed the folder-style path (#154)", async () => {
+      const folder = new TFolder();
+      (folder as any).path = "Projects";
+      const folderNote = new TFile({ path: "Projects/Projects.md" });
+      (app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((p: string) => {
+        if (p === "Projects") return folder;
+        if (p === "Projects/Projects.md") return folderNote;
+        return null;
+      });
+      (app.vault.read as jest.Mock).mockResolvedValue("folder note body");
+
+      const result = await fileOps.readFiles({ paths: ["Projects.md"] });
+
+      expect(result.files[0].error).toBeUndefined();
+      expect(result.files[0].content).toContain("folder note body");
+      expect(result.files[0].path).toBe("Projects/Projects.md");
+    });
+
     it("applies simple text replacement", async () => {
       const mockFile = new TFile({ path: "test.md" });
       (app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);

--- a/src/mcp-tools/filesystem/tools/__tests__/ManagementOperations.test.ts
+++ b/src/mcp-tools/filesystem/tools/__tests__/ManagementOperations.test.ts
@@ -232,6 +232,29 @@ describe("ManagementOperations", () => {
         expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith("test.md");
       });
 
+      it("resolves a Folder Notes path when adding to context (#154)", async () => {
+        const folder = new TFolder();
+        (folder as any).path = "Projects";
+        const folderNote = new TFile({ path: "Projects/Projects.md" });
+        (app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((p: string) => {
+          if (p === "Projects") return folder;
+          if (p === "Projects/Projects.md") return folderNote;
+          return null;
+        });
+
+        const result = await mgmtOps.manageContext({
+          action: "add",
+          paths: ["Projects.md"],
+        });
+
+        expect(result.results[0].success).toBe(true);
+        expect(mockDocumentContextManager.addFileToContext).toHaveBeenCalledWith(
+          folderNote,
+          mockContextManager,
+          expect.anything()
+        );
+      });
+
       it("handles file not found", async () => {
         (app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(null);
 


### PR DESCRIPTION
Part of #210 (rework: agent mode session control). Fourth slice — centralize vault path resolution for folder notes. Addresses #154 ("File Edit not working: File not found").

**Problem.** #154: in agentic mode, listing and reading every note worked, but editing each one failed with "File not found". #210 diagnoses this as the Folder Notes plugin: a folder's note is stored inside the folder under the folder's name (`Projects` → `Projects/Projects.md`) and is referred to by the folder-style path `Projects.md`. Only `editFile` resolved that fallback (and only the `X/X.md` layout); `read`, `move`, `trash`, and `add-to-context` looked up `Projects.md` directly, got the folder (or nothing), and failed. The tools resolved paths *inconsistently*, which is the root of the read-works/edit-fails report.

**Fix.** Extracted the resolution into a shared, dependency-free module `src/mcp-tools/filesystem/folderNotes.ts`:
- `resolveFolderNotePath(app, path)` — the conservative `X.md → X/X.md` fallback (only when the folder exists and the candidate note already exists; never invents a path, so create/write-new is unaffected).
- `resolveExistingVaultFile(app, path)` — direct lookup plus that fallback, for file-only operations.

Applied uniformly so every agent file tool resolves paths identically:
- `read` + `edit` → `resolveExistingVaultFile`.
- `move` (source), `trash`, `add-to-context` → direct lookup, then `resolveFolderNotePath` fallback (so they still handle real folders).

The duplicated private resolver in `FileOperations` is removed. The module is mobile-safe (only the `obsidian` vault lookup, no Node deps), so it carries into the upcoming mobile file-tools rework (#142).

**Tests (failing-first).** New `folderNotes.test.ts` covers the resolver directly (8 cases). New cross-tool cases in `FileOperations`/`DirectoryOperations`/`ManagementOperations` tests assert read/move/trash/context now resolve folder notes — all were red before the wiring, green after.

Local gates green: `check:plugin:fast`, full unit (folder-note suites pass; one unrelated flaky `sleep` timing test passes on isolated re-run), `test:integration` (21/21).

**Scope note.** This handles the default `X/X.md` layout uniformly across tools (the common case #210 calls out). The Folder Notes plugin's configurable note name/location and the sibling-`X.md` layout are deliberately out of scope here and can be a follow-up.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM
