### PR TITLE
fix(agent-tools): run filesystem tools on mobile (#142)

### DIFF
--- a/src/mcp-tools/filesystem/__tests__/mobile-load.test.ts
+++ b/src/mcp-tools/filesystem/__tests__/mobile-load.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment node
+ *
+ * Mobile-load guard for the agent filesystem tools (#142, #207).
+ *
+ * The filesystem tool graph (MCPFilesystemServer → FileOperations /
+ * DirectoryOperations / utils) must run on Android/iOS, where there is no Node
+ * runtime. esbuild lowers a top-level `import … from "node:…"` to an EAGER
+ * `require` that runs at module-eval, which hard-crashes a phone the moment the
+ * module is reached ("Failed to load SystemSculpt AI", the #181 class). Node
+ * builtins are therefore allowed ONLY behind a lazy, capability-gated boundary
+ * (`loadDesktopOnly(() => require("node:…"))`), never as a static import.
+ *
+ * This test pins that invariant on the mobile-critical files so a future edit
+ * cannot silently re-introduce an eager Node import and regress mobile load. It
+ * is the cheapest layer that catches the regression: pure source inspection, no
+ * build, no device. The built-bundle proof lives in
+ * `testing/integration/bundle-load.no-node.test.ts`.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const FILESYSTEM_DIR = path.resolve(__dirname, "..");
+
+// Files reached when the agent runs a filesystem tool on a phone. Each must be
+// free of eager Node imports so the graph module-evaluates without a runtime.
+const MOBILE_CRITICAL_FILES = [
+  "utils.ts",
+  "tools/FileOperations.ts",
+  "tools/DirectoryOperations.ts",
+];
+
+describe("agent filesystem tools: no eager Node import (mobile load, #142/#207)", () => {
+  for (const relPath of MOBILE_CRITICAL_FILES) {
+    describe(relPath, () => {
+      const source = readFileSync(path.join(FILESYSTEM_DIR, relPath), "utf8");
+
+      it("has no top-level `import … from \"node:…\"` (esbuild would eager-require it)", () => {
+        const eagerNodeImports = source
+          .split("\n")
+          .filter((line) => /^import\s+.*\bfrom\s+["']node:/.test(line));
+        expect(eagerNodeImports).toEqual([]);
+      });
+
+      it("touches Node builtins only through the lazy desktop-only boundary", () => {
+        // Any `require("node:…")` that survives must sit inside a thunk passed
+        // to loadDesktopOnly (so it never evaluates on a phone). A bare,
+        // column-0 require would run at module-eval — forbid it.
+        const topLevelNodeRequires = source
+          .split("\n")
+          .filter((line) => /^(?:const|let|var)?\s*require\(["']node:/.test(line));
+        expect(topLevelNodeRequires).toEqual([]);
+
+        if (source.includes('require("node:')) {
+          // Every node require present must be wrapped by the canonical boundary.
+          expect(source).toMatch(/loadDesktopOnly\(\s*\(\)\s*=>\s*require\(["']node:/);
+        }
+      });
+    });
+  }
+});

--- a/src/mcp-tools/filesystem/__tests__/utils-pure.test.ts
+++ b/src/mcp-tools/filesystem/__tests__/utils-pure.test.ts
@@ -1321,3 +1321,136 @@ describe("normalizeLineEndings additional coverage", () => {
     expect(normalizeLineEndings("\r\n\r\n")).toBe("\n\n");
   });
 });
+
+// Robust folder creation for the agent write path (#142). On mobile a note
+// write must create every missing ancestor through the Vault API alone, never a
+// fragile single `createFolder` whose errors are swallowed.
+describe("ensureVaultFolder", () => {
+  const { ensureVaultFolder } = require("../utils");
+  const { TFolder, TFile } = require("obsidian");
+
+  function makeApp(existing: Record<string, "folder" | "file"> = {}) {
+    const tree = new Map<string, "folder" | "file">(Object.entries(existing));
+    const createFolder = jest.fn(async (p: string) => {
+      if (tree.has(p)) throw new Error(`Folder already exists: ${p}`);
+      tree.set(p, "folder");
+    });
+    const getAbstractFileByPath = jest.fn((p: string) => {
+      const kind = tree.get(p);
+      if (kind === "folder") return new TFolder({ path: p, children: [] });
+      if (kind === "file") return new TFile({ path: p });
+      return null;
+    });
+    return { app: { vault: { getAbstractFileByPath, createFolder } } as any, tree, createFolder };
+  }
+
+  const createdPaths = (createFolder: jest.Mock) => createFolder.mock.calls.map((c) => c[0]);
+
+  it("creates each missing ancestor segment-by-segment", async () => {
+    const { app, createFolder } = makeApp();
+    await ensureVaultFolder(app, "A/B/C");
+    expect(createdPaths(createFolder)).toEqual(["A", "A/B", "A/B/C"]);
+  });
+
+  it("skips ancestors that already exist", async () => {
+    const { app, createFolder } = makeApp({ A: "folder" });
+    await ensureVaultFolder(app, "A/B/C");
+    expect(createdPaths(createFolder)).toEqual(["A/B", "A/B/C"]);
+  });
+
+  it("no-ops when the target folder already exists", async () => {
+    const { app, createFolder } = makeApp({ A: "folder", "A/B": "folder" });
+    await ensureVaultFolder(app, "A/B");
+    expect(createFolder).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a racing create that throws but leaves the folder present", async () => {
+    const { app, tree } = makeApp();
+    (app.vault.createFolder as jest.Mock).mockImplementation(async (p: string) => {
+      tree.set(p, "folder");
+      throw new Error("Folder already exists.");
+    });
+    await expect(ensureVaultFolder(app, "A/B")).resolves.toBeUndefined();
+  });
+
+  it("throws when a file blocks a folder segment", async () => {
+    const { app } = makeApp({ A: "file" });
+    await expect(ensureVaultFolder(app, "A/B")).rejects.toThrow(/file/i);
+  });
+
+  it("no-ops for empty or root paths", async () => {
+    const { app, createFolder } = makeApp();
+    await ensureVaultFolder(app, "");
+    await ensureVaultFolder(app, "/");
+    expect(createFolder).not.toHaveBeenCalled();
+  });
+});
+
+// Mobile move/trash for hidden (.systemsculpt) paths must run through the
+// adapter API — there is no Node `fs` and no base path on a phone (#142).
+describe("renameAdapterPath (mobile, no base path)", () => {
+  const { renameAdapterPath } = require("../utils");
+
+  it("renames via the adapter API using normalized vault paths", async () => {
+    const adapter = { rename: jest.fn(async () => {}) }; // no getBasePath → mobile
+    await renameAdapterPath(adapter, "\\Notes\\a.md", "/Notes/b.md");
+    expect(adapter.rename).toHaveBeenCalledWith("Notes/a.md", "Notes/b.md");
+  });
+
+  it("throws a clear error when the adapter cannot rename", async () => {
+    await expect(renameAdapterPath({}, "a.md", "b.md")).rejects.toThrow(/adapter/i);
+  });
+});
+
+describe("removeAdapterPath (mobile, no base path)", () => {
+  const { removeAdapterPath } = require("../utils");
+
+  it("removes a file via adapter.remove", async () => {
+    const adapter = {
+      stat: jest.fn(async () => ({ type: "file" })),
+      remove: jest.fn(async () => {}),
+      rmdir: jest.fn(async () => {}),
+    };
+    await removeAdapterPath(adapter, "Notes/a.md");
+    expect(adapter.remove).toHaveBeenCalledWith("Notes/a.md");
+    expect(adapter.rmdir).not.toHaveBeenCalled();
+  });
+
+  it("removes a folder via adapter.rmdir(recursive)", async () => {
+    const adapter = {
+      stat: jest.fn(async () => ({ type: "folder" })),
+      remove: jest.fn(async () => {}),
+      rmdir: jest.fn(async () => {}),
+    };
+    await removeAdapterPath(adapter, "Notes/sub");
+    expect(adapter.rmdir).toHaveBeenCalledWith("Notes/sub", true);
+  });
+});
+
+// CapacitorAdapter.mkdir is not recursive, so a missing mid-level folder used to
+// abort the whole create on mobile. ensureAdapterFolder must build each ancestor.
+describe("ensureAdapterFolder (mobile, no base path)", () => {
+  const { ensureAdapterFolder } = require("../utils");
+  const mkdirPaths = (mkdir: jest.Mock) => mkdir.mock.calls.map((c) => c[0]);
+
+  it("creates each missing ancestor segment-by-segment via adapter.mkdir", async () => {
+    const created = new Set<string>();
+    const adapter = {
+      exists: jest.fn(async (p: string) => created.has(p)),
+      mkdir: jest.fn(async (p: string) => {
+        created.add(p);
+      }),
+    };
+    await ensureAdapterFolder(adapter, "A/B/C");
+    expect(mkdirPaths(adapter.mkdir as jest.Mock)).toEqual(["A", "A/B", "A/B/C"]);
+  });
+
+  it("skips ancestors that already exist", async () => {
+    const adapter = {
+      exists: jest.fn(async (p: string) => p === "A"),
+      mkdir: jest.fn(async () => {}),
+    };
+    await ensureAdapterFolder(adapter, "A/B");
+    expect(mkdirPaths(adapter.mkdir as jest.Mock)).toEqual(["A/B"]);
+  });
+});

--- a/src/mcp-tools/filesystem/tools/DirectoryOperations.ts
+++ b/src/mcp-tools/filesystem/tools/DirectoryOperations.ts
@@ -1,12 +1,11 @@
 import { App, TFile, TFolder, normalizePath, Notice } from "obsidian";
-import fs from "node:fs/promises";
-import { 
-  FileInfo, 
-  DirectoryInfo, 
-  CreateDirectoriesParams, 
-  ListDirectoriesParams, 
-  MoveItemsParams, 
-  TrashFilesParams 
+import {
+  FileInfo,
+  DirectoryInfo,
+  CreateDirectoriesParams,
+  ListDirectoriesParams,
+  MoveItemsParams,
+  TrashFilesParams
 } from "../types";
 import { FILESYSTEM_LIMITS } from "../constants";
 import {
@@ -18,7 +17,8 @@ import {
   isHiddenSystemPath,
   ensureAdapterFolder,
   listAdapterDirectory,
-  resolveAdapterPath,
+  renameAdapterPath,
+  removeAdapterPath,
   statAdapterPath,
 } from "../utils";
 import SystemSculptPlugin from "../../../main";
@@ -381,16 +381,12 @@ export class DirectoryOperations {
 
           if (this.shouldUseAdapter(source) || this.shouldUseAdapter(destination)) {
             const adapter: any = this.app.vault.adapter as any;
-            const sourceFull = resolveAdapterPath(adapter, source);
-            const destFull = resolveAdapterPath(adapter, destination);
-            if (!sourceFull || !destFull) {
-              throw new Error("Adapter base path unavailable");
-            }
             const destFolder = destination.split("/").slice(0, -1).join("/");
             if (destFolder) {
               await ensureAdapterFolder(adapter, destFolder);
             }
-            await fs.rename(sourceFull, destFull);
+            // Desktop uses the Node fast-path; mobile renames through the adapter.
+            await renameAdapterPath(adapter, source, destination);
             results.push({ source, destination, success: true });
             continue;
           }
@@ -478,11 +474,8 @@ export class DirectoryOperations {
 
     if (this.shouldUseAdapter(path)) {
       const adapter: any = this.app.vault.adapter as any;
-      const fullPath = resolveAdapterPath(adapter, path);
-      if (!fullPath) {
-        throw new Error("Adapter base path unavailable");
-      }
-      await fs.rm(fullPath, { recursive: true, force: true });
+      // Desktop uses the Node fast-path; mobile removes through the adapter.
+      await removeAdapterPath(adapter, path);
       return { path, success: true };
     }
     

--- a/src/mcp-tools/filesystem/tools/FileOperations.ts
+++ b/src/mcp-tools/filesystem/tools/FileOperations.ts
@@ -8,6 +8,7 @@ import {
   normalizeVaultPath,
   isHiddenSystemPath,
   ensureAdapterFolder,
+  ensureVaultFolder,
   adapterPathExists,
   readAdapterText,
   writeAdapterText,
@@ -244,12 +245,15 @@ export class FileOperations {
       if (isBaseFile) {
         assertValidObsidianBasesYaml(normalizedPath || path, content);
       }
-      // Ensure parent directories exist if requested
+      // Ensure parent directories exist if requested. ensureVaultFolder builds
+      // every missing ancestor through the Vault API (mobile-safe) and only
+      // swallows "already exists", so a missing mid-level folder no longer
+      // silently fails the write (#142).
       if (createDirs) {
         const lastSlash = normalizedPath.lastIndexOf('/');
         if (lastSlash > 0) {
           const folderPath = normalizedPath.substring(0, lastSlash);
-          try { await this.app.vault.createFolder(folderPath); } catch {}
+          await ensureVaultFolder(this.app, folderPath);
         }
       }
       await this.app.vault.create(normalizedPath, content);

--- a/src/mcp-tools/filesystem/tools/__tests__/DirectoryOperations.test.ts
+++ b/src/mcp-tools/filesystem/tools/__tests__/DirectoryOperations.test.ts
@@ -36,6 +36,8 @@ jest.mock("../../utils", () => ({
   listAdapterDirectory: jest.fn(async () => ({ files: [], folders: [] })),
   resolveAdapterPath: jest.fn(() => null),
   statAdapterPath: jest.fn(async () => null),
+  renameAdapterPath: jest.fn(async () => {}),
+  removeAdapterPath: jest.fn(async () => {}),
 }));
 
 // Mock constants

--- a/src/mcp-tools/filesystem/tools/__tests__/FileOperations.test.ts
+++ b/src/mcp-tools/filesystem/tools/__tests__/FileOperations.test.ts
@@ -23,6 +23,7 @@ jest.mock("../../utils", () => ({
   createSimpleDiff: jest.fn((original, modified, path) => `diff for ${path}`),
   isHiddenSystemPath: jest.fn(() => false),
   ensureAdapterFolder: jest.fn(async () => {}),
+  ensureVaultFolder: jest.fn(async () => {}),
   adapterPathExists: jest.fn(async () => false),
   readAdapterText: jest.fn(async () => ""),
   writeAdapterText: jest.fn(async () => {}),
@@ -269,8 +270,12 @@ describe("FileOperations", () => {
       expect(result.path).toBe("new.md");
     });
 
-    it("creates parent directories when createDirs is true", async () => {
+    it("creates parent directories via ensureVaultFolder when createDirs is true", async () => {
+      // Robust, mobile-safe nested folder creation (#142): writeFile must
+      // delegate to ensureVaultFolder, not the fragile inline createFolder whose
+      // errors were swallowed.
       (app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(null);
+      const { ensureVaultFolder } = require("../../utils");
 
       await fileOps.writeFile({
         path: "parent/child/file.md",
@@ -278,7 +283,8 @@ describe("FileOperations", () => {
         createDirs: true,
       } as any);
 
-      expect(app.vault.createFolder).toHaveBeenCalledWith("parent/child");
+      expect(ensureVaultFolder).toHaveBeenCalledWith(app, "parent/child");
+      expect(app.vault.create).toHaveBeenCalledWith("parent/child/file.md", "hello");
     });
 
     it("overwrites existing file by default", async () => {

--- a/src/mcp-tools/filesystem/utils.ts
+++ b/src/mcp-tools/filesystem/utils.ts
@@ -1,12 +1,29 @@
 import { App, TFile, TFolder, normalizePath } from "obsidian";
-import path from "node:path";
-import fs from "node:fs/promises";
+import { loadDesktopOnly } from "../../platform/desktopOnly";
 import { FILESYSTEM_LIMITS } from "./constants";
 export { fuzzyMatchScore, shouldExcludeFromSearch } from "./searchUtils";
 
 /**
  * Utility functions for MCP Filesystem tools
  */
+
+/**
+ * Node `fs`/`path` are reached ONLY through the canonical desktop-only boundary
+ * (#207, #142): the `require` runs inside a thunk so it is lazy — never an eager
+ * module-eval touch that would crash mobile bundle load — and `loadDesktopOnly`
+ * returns null on a phone, where the Vault/adapter APIs take over. A static
+ * `import … from "node:…"` here would hard-crash Obsidian on Android/iOS.
+ */
+type NodeFsPromises = typeof import("node:fs/promises");
+type NodePath = typeof import("node:path");
+
+function nodeFs(): NodeFsPromises | null {
+  return loadDesktopOnly(() => require("node:fs/promises") as NodeFsPromises);
+}
+
+function nodePath(): NodePath | null {
+  return loadDesktopOnly(() => require("node:path") as NodePath);
+}
 
 /**
  * Format bytes to human readable string
@@ -56,50 +73,79 @@ export function isHiddenSystemPath(path: string): boolean {
  * Ensures a resolved path stays within the base directory.
  * Throws an error if the path would escape the base directory via traversal sequences.
  */
-function assertWithinBase(basePath: string, resolvedPath: string): void {
-  const realBase = path.resolve(basePath);
-  const realResolved = path.resolve(resolvedPath);
+function assertWithinBase(nodePathMod: NodePath, basePath: string, resolvedPath: string): void {
+  const realBase = nodePathMod.resolve(basePath);
+  const realResolved = nodePathMod.resolve(resolvedPath);
 
   // Allow exact match (accessing base directory itself)
   if (realResolved === realBase) return;
 
   // Ensure resolved path is within base (with path separator to prevent prefix attacks)
-  if (!realResolved.startsWith(realBase + path.sep)) {
+  if (!realResolved.startsWith(realBase + nodePathMod.sep)) {
     throw new Error("Path traversal detected: path escapes vault directory");
   }
 }
 
+/**
+ * Resolve a vault path to an absolute filesystem path for the Node fast-path
+ * (desktop only). Returns null when there is no Node runtime or the adapter
+ * exposes no base path (mobile) — callers then fall back to the adapter API.
+ */
 export function resolveAdapterPath(adapter: any, vaultPath: string): string | null {
   if (!adapter || typeof adapter.getBasePath !== "function") return null;
+  const nodePathMod = nodePath();
+  if (!nodePathMod) return null;
   const basePath = adapter.getBasePath();
   if (!basePath) return null;
   const normalized = normalizeVaultPath(String(vaultPath ?? ""));
   if (!normalized) return basePath;
 
-  const resolved = path.join(basePath, normalized);
-  assertWithinBase(basePath, resolved);
+  const resolved = nodePathMod.join(basePath, normalized);
+  assertWithinBase(nodePathMod, basePath, resolved);
   return resolved;
 }
 
 export async function ensureAdapterFolder(adapter: any, folderPath: string): Promise<void> {
   const fullPath = resolveAdapterPath(adapter, folderPath);
-  if (fullPath) {
-    await fs.mkdir(fullPath, { recursive: true });
+  const fsMod = fullPath ? nodeFs() : null;
+  if (fullPath && fsMod) {
+    await fsMod.mkdir(fullPath, { recursive: true });
     return;
   }
+  // Mobile / no-base-path: CapacitorAdapter.mkdir is NOT recursive, so build each
+  // ancestor segment-by-segment, skipping ones that already exist (#142).
   if (adapter && typeof adapter.mkdir === "function") {
     const normalized = normalizeVaultPath(String(folderPath ?? ""));
-    if (normalized) {
-      await adapter.mkdir(normalized);
+    if (!normalized) return;
+    const segments = normalized.split("/").filter(Boolean);
+    let current = "";
+    for (const segment of segments) {
+      current = current ? `${current}/${segment}` : segment;
+      let exists = false;
+      if (typeof adapter.exists === "function") {
+        try {
+          exists = await adapter.exists(current);
+        } catch {
+          exists = false;
+        }
+      }
+      if (!exists) {
+        try {
+          await adapter.mkdir(current);
+        } catch {
+          // Tolerate races / "already exists" — a sibling op may have created it.
+        }
+      }
     }
   }
 }
 
 export async function adapterPathExists(adapter: any, vaultPath: string): Promise<boolean> {
   const fullPath = resolveAdapterPath(adapter, vaultPath);
-  if (fullPath) {
+  const fsMod = fullPath ? nodeFs() : null;
+  if (fullPath && fsMod) {
     try {
-      await fs.access(fullPath);
+      await fsMod.access(fullPath);
       return true;
     } catch {
       return false;
@@ -117,8 +163,9 @@ export async function adapterPathExists(adapter: any, vaultPath: string): Promis
 
 export async function readAdapterText(adapter: any, vaultPath: string): Promise<string> {
   const fullPath = resolveAdapterPath(adapter, vaultPath);
-  if (fullPath) {
-    return await fs.readFile(fullPath, "utf8");
+  const fsMod = fullPath ? nodeFs() : null;
+  if (fullPath && fsMod) {
+    return await fsMod.readFile(fullPath, "utf8");
   }
   if (adapter && typeof adapter.read === "function") {
     return await adapter.read(normalizeVaultPath(String(vaultPath ?? "")));
@@ -128,8 +175,9 @@ export async function readAdapterText(adapter: any, vaultPath: string): Promise<
 
 export async function writeAdapterText(adapter: any, vaultPath: string, content: string): Promise<void> {
   const fullPath = resolveAdapterPath(adapter, vaultPath);
-  if (fullPath) {
-    await fs.writeFile(fullPath, content, "utf8");
+  const fsMod = fullPath ? nodeFs() : null;
+  if (fullPath && fsMod) {
+    await fsMod.writeFile(fullPath, content, "utf8");
     return;
   }
   if (adapter && typeof adapter.write === "function") {
@@ -141,8 +189,9 @@ export async function writeAdapterText(adapter: any, vaultPath: string, content:
 
 export async function statAdapterPath(adapter: any, vaultPath: string): Promise<{ size: number; ctime: number; mtime: number } | null> {
   const fullPath = resolveAdapterPath(adapter, vaultPath);
-  if (fullPath) {
-    const stat = await fs.stat(fullPath);
+  const fsMod = fullPath ? nodeFs() : null;
+  if (fullPath && fsMod) {
+    const stat = await fsMod.stat(fullPath);
     return { size: stat.size, ctime: stat.ctimeMs, mtime: stat.mtimeMs };
   }
   if (adapter && typeof adapter.stat === "function") {
@@ -160,21 +209,23 @@ export async function statAdapterPath(adapter: any, vaultPath: string): Promise<
 export async function listAdapterFiles(adapter: any, root: string): Promise<string[]> {
   const basePath = resolveAdapterPath(adapter, "");
   const rootPath = resolveAdapterPath(adapter, root);
-  if (basePath && rootPath) {
+  const fsMod = basePath && rootPath ? nodeFs() : null;
+  const nodePathMod = basePath && rootPath ? nodePath() : null;
+  if (basePath && rootPath && fsMod && nodePathMod) {
     const files: string[] = [];
     const walk = async (dir: string) => {
-      let entries: Array<import("node:fs").Dirent>;
+      let entries: any[];
       try {
-        entries = await fs.readdir(dir, { withFileTypes: true });
+        entries = await fsMod.readdir(dir, { withFileTypes: true });
       } catch {
         return;
       }
       for (const entry of entries) {
-        const full = path.join(dir, entry.name);
+        const full = nodePathMod.join(dir, entry.name);
         if (entry.isDirectory()) {
           await walk(full);
         } else if (entry.isFile()) {
-          const rel = path.relative(basePath, full).split(path.sep).join("/");
+          const rel = nodePathMod.relative(basePath, full).split(nodePathMod.sep).join("/");
           files.push(rel);
         }
       }
@@ -209,8 +260,9 @@ export async function listAdapterFiles(adapter: any, root: string): Promise<stri
 export async function listAdapterDirectory(adapter: any, dirPath: string): Promise<{ files: string[]; folders: string[] }> {
   const basePath = resolveAdapterPath(adapter, "");
   const fullPath = resolveAdapterPath(adapter, dirPath);
-  if (basePath && fullPath) {
-    const entries = await fs.readdir(fullPath, { withFileTypes: true });
+  const fsMod = basePath && fullPath ? nodeFs() : null;
+  if (basePath && fullPath && fsMod) {
+    const entries = await fsMod.readdir(fullPath, { withFileTypes: true });
     const normalizedDir = normalizeVaultPath(String(dirPath ?? ""));
     const files: string[] = [];
     const folders: string[] = [];
@@ -234,6 +286,97 @@ export async function listAdapterDirectory(adapter: any, dirPath: string): Promi
   }
 
   throw new Error("Adapter base path unavailable");
+}
+
+/**
+ * Move a vault path on disk. Desktop uses the Node fast-path; mobile (no base
+ * path / no Node) renames through the adapter API (#142).
+ */
+export async function renameAdapterPath(adapter: any, sourcePath: string, destPath: string): Promise<void> {
+  const sourceFull = resolveAdapterPath(adapter, sourcePath);
+  const destFull = resolveAdapterPath(adapter, destPath);
+  const fsMod = sourceFull && destFull ? nodeFs() : null;
+  if (sourceFull && destFull && fsMod) {
+    await fsMod.rename(sourceFull, destFull);
+    return;
+  }
+  if (adapter && typeof adapter.rename === "function") {
+    await adapter.rename(
+      normalizeVaultPath(String(sourcePath ?? "")),
+      normalizeVaultPath(String(destPath ?? "")),
+    );
+    return;
+  }
+  throw new Error("Adapter base path unavailable");
+}
+
+/**
+ * Permanently remove a vault path on disk (mirrors the desktop `fs.rm`). Mobile
+ * (no base path / no Node) removes files via `adapter.remove` and folders via
+ * `adapter.rmdir(path, recursive)` (#142).
+ */
+export async function removeAdapterPath(adapter: any, vaultPath: string): Promise<void> {
+  const fullPath = resolveAdapterPath(adapter, vaultPath);
+  const fsMod = fullPath ? nodeFs() : null;
+  if (fullPath && fsMod) {
+    await fsMod.rm(fullPath, { recursive: true, force: true });
+    return;
+  }
+  const normalized = normalizeVaultPath(String(vaultPath ?? ""));
+  if (!normalized) return;
+  let isFolder = false;
+  if (adapter && typeof adapter.stat === "function") {
+    try {
+      const stat = await adapter.stat(normalized);
+      isFolder = stat?.type === "folder";
+    } catch {
+      isFolder = false;
+    }
+  }
+  if (isFolder && adapter && typeof adapter.rmdir === "function") {
+    await adapter.rmdir(normalized, true);
+    return;
+  }
+  if (adapter && typeof adapter.remove === "function") {
+    await adapter.remove(normalized);
+    return;
+  }
+  if (adapter && typeof adapter.rmdir === "function") {
+    await adapter.rmdir(normalized, true);
+    return;
+  }
+  throw new Error("Adapter base path unavailable");
+}
+
+/**
+ * Ensure a folder (and every missing ancestor) exists via the Vault API alone —
+ * mobile-safe (no Node). Each ancestor is created segment-by-segment, skipping
+ * those that already exist and tolerating "already exists" races, so a note
+ * write never fails because a mid-level folder was missing (#142).
+ */
+export async function ensureVaultFolder(app: App, folderPath: string): Promise<void> {
+  const normalized = normalizePath(normalizeVaultPath(String(folderPath ?? "")));
+  if (!normalized || normalized === "/" || normalized === ".") return;
+
+  const segments = normalized.split("/").filter(Boolean);
+  let current = "";
+  for (const segment of segments) {
+    current = current ? `${current}/${segment}` : segment;
+    const node = app.vault.getAbstractFileByPath(current);
+    if (node instanceof TFolder) continue;
+    if (node instanceof TFile) {
+      throw new Error(`Cannot create folder "${current}": a file with that name already exists`);
+    }
+    try {
+      await app.vault.createFolder(current);
+    } catch (err) {
+      // Tolerate a concurrent create: only rethrow if the folder truly isn't there.
+      const after = app.vault.getAbstractFileByPath(current);
+      if (!(after instanceof TFolder)) {
+        throw err;
+      }
+    }
+  }
 }
 
 /**

--- a/src/mcp/adapters/FilesystemAdapter.ts
+++ b/src/mcp/adapters/FilesystemAdapter.ts
@@ -1,39 +1,31 @@
 import type { App } from "obsidian";
 import SystemSculptPlugin from "../../main";
 import { MCPToolInfo } from "../../types/mcp";
-import { loadDesktopOnly } from "../../platform/desktopOnly";
 import type { MCPFilesystemServer } from "../../mcp-tools/filesystem/MCPFilesystemServer";
 
 export class FilesystemAdapter {
-  // Null on mobile: the filesystem MCP server needs Node (fs/path), which a
-  // phone has not. The tools then degrade rather than crash.
-  private readonly fsServer: MCPFilesystemServer | null;
+  private readonly fsServer: MCPFilesystemServer;
 
   constructor(plugin: SystemSculptPlugin, app: App) {
-    // The filesystem MCP server pulls in node:fs / node:path. Load it through
-    // the canonical desktop-only boundary so the chain stays off the mobile
-    // bundle-load path and never initialises on a phone (#207).
-    const mod = loadDesktopOnly(
-      () =>
-        require("../../mcp-tools/filesystem/MCPFilesystemServer") as typeof import("../../mcp-tools/filesystem/MCPFilesystemServer"),
-    );
-    this.fsServer = mod ? new mod.MCPFilesystemServer(plugin, app) : null;
+    // Since #142 the filesystem MCP server and its whole tool graph are pure
+    // Obsidian-API code (no Node builtins), so the agent file tools run on
+    // mobile too — no desktop-only gate. The module is still reached through a
+    // lazy `require` rather than a static import so its graph stays off the
+    // eager bundle-eval path and only evaluates when the adapter is actually
+    // constructed (the #207 belt-and-suspenders against any future Node import).
+    const mod = require("../../mcp-tools/filesystem/MCPFilesystemServer") as typeof import("../../mcp-tools/filesystem/MCPFilesystemServer");
+    this.fsServer = new mod.MCPFilesystemServer(plugin, app);
   }
 
   async listTools(): Promise<MCPToolInfo[]> {
-    return this.fsServer ? await this.fsServer.getTools() : [];
+    return await this.fsServer.getTools();
   }
 
   async executeTool(toolName: string, args: any, chatView?: any, _options?: { timeoutMs?: number }): Promise<any> {
-    if (!this.fsServer) {
-      throw new Error(
-        "Filesystem MCP tools require a desktop runtime — they are unavailable on mobile (no Node).",
-      );
-    }
     return await this.fsServer.executeTool(toolName, args, chatView);
   }
 
   setAllowedPaths(paths: string[]): void {
-    this.fsServer?.setAllowedPaths(paths);
+    this.fsServer.setAllowedPaths(paths);
   }
 }

--- a/src/mcp/adapters/__tests__/FilesystemAdapter.test.ts
+++ b/src/mcp/adapters/__tests__/FilesystemAdapter.test.ts
@@ -49,7 +49,10 @@ describe("FilesystemAdapter", () => {
     expect(result).toEqual({ ok: true });
   });
 
-  describe("on mobile (no Node runtime, #207)", () => {
+  // Since #142 the filesystem tool graph is pure Vault-API code (no Node), so it
+  // runs on mobile too. The adapter must NOT gate the server off when the
+  // runtime reports mobile — agent file tools must work on a phone.
+  describe("on mobile (no Node runtime, #142)", () => {
     beforeEach(() => {
       jest
         .spyOn(PlatformContext, "get")
@@ -60,30 +63,39 @@ describe("FilesystemAdapter", () => {
       jest.restoreAllMocks();
     });
 
-    it("never constructs the Node-backed filesystem server", () => {
+    it("still constructs the filesystem server (no desktop-only gate)", () => {
       new FilesystemAdapter({} as any, {} as any);
 
-      expect(lastServerInstance).toBeNull();
+      expect(lastServerInstance).not.toBeNull();
     });
 
-    it("degrades listTools to an empty list instead of crashing", async () => {
+    it("delegates listTools to the server instead of degrading", async () => {
       const adapter = new FilesystemAdapter({} as any, {} as any);
+      const server = getLastServerInstance();
+      server.getTools.mockResolvedValue([{ name: "write" }]);
 
-      await expect(adapter.listTools()).resolves.toEqual([]);
+      await expect(adapter.listTools()).resolves.toEqual([{ name: "write" }]);
     });
 
-    it("throws a clear desktop-only error from executeTool", async () => {
+    it("executes tools on mobile instead of throwing a desktop-only error", async () => {
       const adapter = new FilesystemAdapter({} as any, {} as any);
+      const server = getLastServerInstance();
+      server.executeTool.mockResolvedValue({ ok: true });
 
-      await expect(adapter.executeTool("read", { path: "note.md" })).rejects.toThrow(
-        /desktop runtime/i,
-      );
+      await expect(adapter.executeTool("write", { path: "note.md" })).resolves.toEqual({
+        ok: true,
+      });
+      expect(server.executeTool).toHaveBeenCalledWith("write", { path: "note.md" }, undefined);
     });
 
-    it("treats setAllowedPaths as a no-op", () => {
+    it("forwards setAllowedPaths to the server", () => {
       const adapter = new FilesystemAdapter({} as any, {} as any);
+      const server = getLastServerInstance() as unknown as { setAllowedPaths?: jest.Mock };
+      server.setAllowedPaths = jest.fn();
 
-      expect(() => adapter.setAllowedPaths(["/vault"])).not.toThrow();
+      adapter.setAllowedPaths(["/vault"]);
+
+      expect(server.setAllowedPaths).toHaveBeenCalledWith(["/vault"]);
     });
   });
 });

--- a/src/tests/mocks/obsidian.js
+++ b/src/tests/mocks/obsidian.js
@@ -275,12 +275,20 @@ class App {
       createFolder: jest.fn(),
       modify: jest.fn(),
       configDir: "/.obsidian",
+      // Mobile-shaped DataAdapter (CapacitorAdapter): no getBasePath, so the
+      // filesystem tools take the Vault/adapter path that runs on a phone (#142).
       adapter: {
         exists: jest.fn(),
         read: jest.fn(),
         write: jest.fn(),
         list: jest.fn(() => ({ files: [], folders: [] })),
         trashLocal: jest.fn(),
+        getFullPath: jest.fn((p) => p),
+        mkdir: jest.fn(),
+        stat: jest.fn(),
+        remove: jest.fn(),
+        rmdir: jest.fn(),
+        rename: jest.fn(),
       },
     };
     this.fileManager = {


### PR DESCRIPTION
## What & why

Agent file tools never worked on Android/iOS (#142). Two root causes, fixed together:

1. **Mobile bundle-load crash.** The filesystem MCP graph eager-imported `node:fs` / `node:path` (`utils.ts`, `DirectoryOperations.ts`). esbuild lowers a top-level `import … from "node:…"` to an eager `require` that throws at module-eval on a phone — the #181 / #207 "Failed to load" class.
2. **A hard desktop-only gate.** `FilesystemAdapter` returned a null server whenever no Node runtime was present, so even once loaded the tools threw *"Filesystem MCP tools require a desktop runtime"* on mobile.

Note creation also leaned on a fragile single `vault.createFolder` whose errors were swallowed, so a missing mid-level folder silently failed the write.

## Changes

- **De-Node the filesystem graph.** `node:fs` / `node:path` are now reached **only** through the canonical lazy `loadDesktopOnly` boundary (`utils.ts` `nodeFs()` / `nodePath()`) — the `require` runs inside a thunk, never at module-eval, and returns null on mobile. Move/trash route through new `renameAdapterPath` / `removeAdapterPath` helpers so `DirectoryOperations` no longer imports `node:fs` at all. The desktop fast-path is unchanged; the whole graph now module-evaluates with **no Node**, so it loads on a phone.
- **Remove the desktop-only gate** in `FilesystemAdapter`: the server (pure Obsidian-API code now) is always constructed, so mobile runs the tools instead of throwing. Kept a lazy `require` so the graph stays off the eager bundle-eval path (#207 belt-and-suspenders).
- **`ensureAdapterFolder`** builds each ancestor segment-by-segment on mobile (CapacitorAdapter `mkdir` is not recursive).
- **`writeFile`** delegates parent-folder creation to a new robust **`ensureVaultFolder`** (Vault-API only, segment-by-segment, tolerates "already exists", throws only on a real file/folder collision).

## Tests (failing-first, cheapest layer)

- `mobile-load.test.ts` (new) — pins **"no eager node import"** on the three mobile-critical files. The permanent #142 regression guard.
- `utils-pure` — `ensureVaultFolder`, `renameAdapterPath`, `removeAdapterPath`, `ensureAdapterFolder` recursion (all real, not mocked).
- `FileOperations` — `writeFile` delegates nested creation to `ensureVaultFolder`.
- `FilesystemAdapter` — mobile block **inverted**: server constructed + delegated even when the runtime reports mobile (proves the gate is gone).

Confirmed RED before the fix (18 failures) → GREEN after.

## Local gates
- `check:plugin:fast` — PASS (tsc, bundle, script-tests, unit)
- `npm test` — 5597 passed, 1 skipped, **0 failed**
- `npm run test:integration` — 21/21, including `bundle-load.no-node.test.ts` (simulated-phone load) and `bundle-load.mobile.test.ts`

Part of #210 (centralize vault path handling; restore mobile file ops). The shipped `main.js` bundle is gitignored and rebuilt by CI.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of folder creation, ensuring missing parent directories are created consistently.
  * Enhanced cross-platform file operations to work reliably on both desktop and mobile environments.

* **Tests**
  * Added comprehensive test coverage for mobile filesystem operations and adapter behaviors.

* **Refactor**
  * Refactored file and directory operations to use unified adapter utilities instead of direct filesystem calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->