### PR TITLE
feat(chat): restore favorite models in the composer model picker (#210)

### DIFF
--- a/src/css/views/chat.css
+++ b/src/css/views/chat.css
@@ -666,6 +666,7 @@
 }
 
 .systemsculpt-chat-model-modal-option {
+  position: relative;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 12px;
@@ -784,6 +785,85 @@
 .systemsculpt-chat-model-modal-pill.is-setup-required {
   border-color: color-mix(in srgb, var(--text-warning, var(--interactive-accent)) 40%, var(--background-modifier-border) 60%);
   color: var(--text-warning, var(--interactive-accent));
+}
+
+/* Favorites (restored for #210): a favorites-only filter chip in the search row
+   and a per-row star toggle that pins models to the top of their section. */
+.systemsculpt-chat-model-modal-favorites-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 4px 10px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    color 140ms ease,
+    border-color 140ms ease,
+    background 140ms ease;
+}
+
+.systemsculpt-chat-model-modal-favorites-toggle:hover,
+.systemsculpt-chat-model-modal-favorites-toggle:focus-visible {
+  color: var(--text-normal);
+  border-color: color-mix(in srgb, var(--interactive-accent) 40%, var(--background-modifier-border) 60%);
+}
+
+.systemsculpt-chat-model-modal-favorites-toggle.is-active {
+  color: var(--interactive-accent);
+  border-color: color-mix(in srgb, var(--interactive-accent) 52%, var(--background-modifier-border) 48%);
+  background: color-mix(in srgb, var(--interactive-accent) 12%, var(--background-primary) 88%);
+}
+
+.systemsculpt-chat-model-modal-favorites-toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.systemsculpt-chat-model-modal-option-favorite {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    color 140ms ease,
+    background 140ms ease,
+    opacity 140ms ease;
+}
+
+/* Reveal the star on row hover/focus, and keep it visible whenever favorited. */
+.systemsculpt-chat-model-modal-option:hover .systemsculpt-chat-model-modal-option-favorite,
+.systemsculpt-chat-model-modal-option.is-active .systemsculpt-chat-model-modal-option-favorite,
+.systemsculpt-chat-model-modal-option-favorite:focus-visible,
+.systemsculpt-chat-model-modal-option-favorite.is-favorite {
+  opacity: 1;
+}
+
+.systemsculpt-chat-model-modal-option-favorite:hover {
+  color: var(--text-normal);
+  background: color-mix(in srgb, var(--background-modifier-hover) 80%, var(--background-primary) 20%);
+}
+
+.systemsculpt-chat-model-modal-option-favorite.is-favorite {
+  color: var(--color-yellow, #e0af00);
 }
 
 .systemsculpt-chat-model-modal-empty {

--- a/src/views/chatview/ChatModelPickerModal.ts
+++ b/src/views/chatview/ChatModelPickerModal.ts
@@ -1,19 +1,29 @@
 import { App, Notice, setIcon } from "obsidian";
 import { StandardModal } from "../../core/ui/modals/standard/StandardModal";
+import { ensureCanonicalId } from "../../utils/modelUtils";
 import { rankStudioFuzzyItems } from "../studio/StudioFuzzySearch";
 import {
+  applyChatModelFavorites,
   compareChatModelPickerOptions,
   getChatModelPickerSearchText,
   getChatModelPickerSectionLabel,
+  type ChatModelFavoritesState,
   type ChatModelPickerOption,
   type ChatModelSetupTab,
 } from "./modelSelection";
+
+type ChatModelPickerFavoritesConfig = {
+  state: ChatModelFavoritesState;
+  onToggleFavorite: (modelValue: string) => Promise<void> | void;
+  onToggleFavoritesOnly: () => Promise<boolean> | boolean;
+};
 
 type ChatModelPickerModalOptions = {
   currentValue: string;
   loadOptions: () => Promise<ChatModelPickerOption[]>;
   onSelect: (value: string) => Promise<void> | void;
   onOpenSetup: (targetTab: ChatModelSetupTab) => void;
+  favorites?: ChatModelPickerFavoritesConfig;
 };
 
 export class ChatModelPickerModal extends StandardModal {
@@ -23,14 +33,25 @@ export class ChatModelPickerModal extends StandardModal {
   private listEl!: HTMLElement;
   private emptyStateEl!: HTMLElement;
   private summaryValueEl!: HTMLElement;
+  private favoritesToggleEl: HTMLButtonElement | null = null;
+  private rawOptions: ChatModelPickerOption[] = [];
   private loadedOptions: ChatModelPickerOption[] = [];
   private filteredOptions: ChatModelPickerOption[] = [];
+  private readonly favoritesState: { favoriteIds: Set<string>; showFavoritesOnly: boolean; favoritesFirst: boolean };
   private selectedIndex = -1;
   private loading = false;
 
   constructor(app: App, options: ChatModelPickerModalOptions) {
     super(app);
     this.options = options;
+    // Own a mutable copy of the favorite ids so per-row toggles update the modal
+    // optimistically without mutating the caller's set. Absent favorites config
+    // (the default picker) collapses to an identity reorder via applyChatModelFavorites.
+    this.favoritesState = {
+      favoriteIds: new Set(options.favorites?.state.favoriteIds ?? []),
+      showFavoritesOnly: options.favorites?.state.showFavoritesOnly ?? false,
+      favoritesFirst: options.favorites?.state.favoritesFirst ?? false,
+    };
     this.setSize("medium");
     this.modalEl.addClass("systemsculpt-chat-model-picker-modal");
   }
@@ -53,8 +74,10 @@ export class ChatModelPickerModal extends StandardModal {
 
   onClose(): void {
     super.onClose();
+    this.rawOptions = [];
     this.loadedOptions = [];
     this.filteredOptions = [];
+    this.favoritesToggleEl = null;
   }
 
   private renderShell(): void {
@@ -92,6 +115,29 @@ export class ChatModelPickerModal extends StandardModal {
       },
     });
     this.clearButtonEl.style.display = "none";
+
+    if (this.options.favorites) {
+      this.favoritesToggleEl = searchRowEl.createEl("button", {
+        cls: "systemsculpt-chat-model-modal-favorites-toggle",
+        attr: {
+          type: "button",
+          "aria-label": "Show favorites only",
+          "aria-pressed": "false",
+        },
+      });
+      const favoritesIconEl = this.favoritesToggleEl.createSpan({
+        cls: "systemsculpt-chat-model-modal-favorites-toggle-icon",
+      });
+      setIcon(favoritesIconEl, "star");
+      this.favoritesToggleEl.createSpan({
+        cls: "systemsculpt-chat-model-modal-favorites-toggle-label",
+        text: "Favorites",
+      });
+      this.syncFavoritesToggle();
+      this.registerDomEvent(this.favoritesToggleEl, "click", () => {
+        void this.handleToggleFavoritesOnly();
+      });
+    }
 
     this.listEl = bodyEl.createDiv({
       cls: "systemsculpt-chat-model-modal-list",
@@ -181,9 +227,9 @@ export class ChatModelPickerModal extends StandardModal {
   private async reloadOptions(): Promise<void> {
     try {
       const loaded = await this.options.loadOptions();
-      this.loadedOptions = [...loaded].sort(compareChatModelPickerOptions);
+      this.rawOptions = [...loaded];
       this.loading = false;
-      this.applyFilter(this.searchInputEl.value);
+      this.recomputeOptions();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error || "Unknown error");
       this.loading = false;
@@ -191,6 +237,61 @@ export class ChatModelPickerModal extends StandardModal {
         icon: "alert-triangle",
         showRetry: true,
       });
+    }
+  }
+
+  /**
+   * Re-derive the visible list from the raw catalog and the current favorites
+   * state (annotate, favorites-only filter, favorites-first order), then refilter
+   * for the active search query. The single funnel for any favorites change.
+   */
+  private recomputeOptions(): void {
+    this.loadedOptions = applyChatModelFavorites(this.rawOptions, this.favoritesState);
+    this.applyFilter(this.searchInputEl.value);
+  }
+
+  private syncFavoritesToggle(): void {
+    if (!this.favoritesToggleEl) {
+      return;
+    }
+    const active = this.favoritesState.showFavoritesOnly;
+    this.favoritesToggleEl.classList.toggle("is-active", active);
+    this.favoritesToggleEl.setAttribute("aria-pressed", active ? "true" : "false");
+  }
+
+  private async handleToggleFavoritesOnly(): Promise<void> {
+    if (!this.options.favorites) {
+      return;
+    }
+    try {
+      this.favoritesState.showFavoritesOnly = await this.options.favorites.onToggleFavoritesOnly();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || "Unknown error");
+      new Notice(`Unable to update the favorites filter: ${message}`, 6000);
+      return;
+    }
+    this.syncFavoritesToggle();
+    this.recomputeOptions();
+  }
+
+  private async handleToggleFavorite(option: ChatModelPickerOption): Promise<void> {
+    if (!this.options.favorites) {
+      return;
+    }
+    const canonicalId = ensureCanonicalId(option.value);
+    // Optimistically flip the local set so the star + ordering respond instantly;
+    // recompute re-annotates every row from this set as the source of truth.
+    if (this.favoritesState.favoriteIds.has(canonicalId)) {
+      this.favoritesState.favoriteIds.delete(canonicalId);
+    } else {
+      this.favoritesState.favoriteIds.add(canonicalId);
+    }
+    this.recomputeOptions();
+    try {
+      await this.options.favorites.onToggleFavorite(option.value);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || "Unknown error");
+      new Notice(`Unable to update favorites: ${message}`, 6000);
     }
   }
 
@@ -301,6 +402,24 @@ export class ChatModelPickerModal extends StandardModal {
         metaEl.createDiv({
           cls: "systemsculpt-chat-model-modal-pill is-setup-required",
           text: "Needs setup",
+        });
+      }
+
+      if (this.options.favorites) {
+        const favoriteButtonEl = optionEl.createEl("button", {
+          cls: "systemsculpt-chat-model-modal-option-favorite",
+          attr: {
+            type: "button",
+            "aria-label": option.isFavorite ? "Remove from favorites" : "Add to favorites",
+            "aria-pressed": option.isFavorite ? "true" : "false",
+          },
+        });
+        favoriteButtonEl.classList.toggle("is-favorite", Boolean(option.isFavorite));
+        setIcon(favoriteButtonEl, "star");
+        // Starring is a row-local action — it must not bubble up to select the model.
+        this.registerDomEvent(favoriteButtonEl, "click", (event: Event) => {
+          event.stopPropagation();
+          void this.handleToggleFavorite(option);
         });
       }
 

--- a/src/views/chatview/ChatModelSelectionController.ts
+++ b/src/views/chatview/ChatModelSelectionController.ts
@@ -1,6 +1,8 @@
 import { App, Component, setIcon } from "obsidian";
 import type SystemSculptPlugin from "../../main";
 import type { SystemSculptModel } from "../../types/llm";
+import { FavoritesService } from "../../services/FavoritesService";
+import { ensureCanonicalId } from "../../utils/modelUtils";
 import {
   buildPiTextProviderSetupMessage,
 } from "../../services/pi-native/PiTextAuth";
@@ -90,6 +92,31 @@ export class ChatModelSelectionController extends Component {
     return await this.modelPickerOptionsPromise;
   }
 
+  private getFavoritesService(): FavoritesService {
+    return FavoritesService.getInstance(this.options.plugin);
+  }
+
+  /**
+   * Toggle a model's favorite state from the picker. Resolves the catalog record
+   * by canonical id and syncs its in-memory `isFavorite` flag to the persisted
+   * truth first, so FavoritesService.toggleFavorite always flips the right way
+   * regardless of any stale flag on the cached record.
+   */
+  private async toggleModelFavorite(modelValue: string): Promise<void> {
+    const favoritesService = this.getFavoritesService();
+    const modelService = this.options.plugin.modelService;
+    const models = modelService?.getModels
+      ? await modelService.getModels().catch(() => [] as SystemSculptModel[])
+      : [];
+    const canonicalId = ensureCanonicalId(modelValue);
+    const model = models.find((candidate) => ensureCanonicalId(candidate.id) === canonicalId);
+    if (!model) {
+      return;
+    }
+    model.isFavorite = favoritesService.getFavoriteIds().has(canonicalId);
+    await favoritesService.toggleFavorite(model);
+  }
+
   public ensureHost(composer: {
     modelSlot?: HTMLElement | null;
     toolbar?: HTMLElement | null;
@@ -175,6 +202,7 @@ export class ChatModelSelectionController extends Component {
 
     this.registerDomEvent(triggerButtonEl, "click", () => {
       triggerButtonEl.setAttribute("aria-expanded", "true");
+      const favoritesService = this.getFavoritesService();
       const modal = new ChatModelPickerModal(this.options.app, {
         currentValue: currentModelId,
         loadOptions: async () => await this.loadOptions(true),
@@ -185,6 +213,17 @@ export class ChatModelSelectionController extends Component {
         },
         onOpenSetup: (tab: ChatModelSetupTab) => {
           this.openSetupTab(tab);
+        },
+        favorites: {
+          state: {
+            favoriteIds: favoritesService.getFavoriteIds(),
+            showFavoritesOnly: favoritesService.getShowFavoritesOnly(),
+            favoritesFirst: favoritesService.getFavoritesFirst(),
+          },
+          onToggleFavorite: async (modelValue: string) => {
+            await this.toggleModelFavorite(modelValue);
+          },
+          onToggleFavoritesOnly: async () => await favoritesService.toggleShowFavoritesOnly(),
         },
       });
       const originalOnClose = modal.onClose.bind(modal);

--- a/src/views/chatview/__tests__/ChatModelPickerModal.test.ts
+++ b/src/views/chatview/__tests__/ChatModelPickerModal.test.ts
@@ -473,4 +473,157 @@ describe("ChatModelPickerModal", () => {
     ).map((el) => el.textContent?.trim());
     expect(optionTitles).toContain("GPT-4.1");
   });
+
+  it("surfaces favorites: a favorites-only toggle plus per-row stars that reflect state", async () => {
+    const modal = new ChatModelPickerModal(new App(), {
+      currentValue: "anthropic@@claude-3-7-sonnet",
+      loadOptions: async () => [
+        buildOption({
+          value: "anthropic@@claude-3-7-sonnet",
+          label: "Claude 3.7 Sonnet",
+          providerLabel: "Anthropic",
+          providerId: "anthropic",
+          section: "pi",
+        }),
+        buildOption({
+          value: "openai@@gpt-4.1",
+          label: "GPT-4.1",
+          providerLabel: "OpenAI",
+          providerId: "openai",
+          section: "pi",
+        }),
+      ],
+      onSelect: jest.fn(),
+      onOpenSetup: jest.fn(),
+      favorites: {
+        state: {
+          favoriteIds: new Set(["openai@@gpt-4.1"]),
+          showFavoritesOnly: false,
+          favoritesFirst: true,
+        },
+        onToggleFavorite: jest.fn().mockResolvedValue(undefined),
+        onToggleFavoritesOnly: jest.fn().mockResolvedValue(true),
+      },
+    });
+
+    modal.onOpen();
+    await flush();
+
+    expect(
+      modal.contentEl.querySelector(".systemsculpt-chat-model-modal-favorites-toggle"),
+    ).not.toBeNull();
+
+    const gptStar = modal.contentEl.querySelector(
+      '[data-model-value="openai@@gpt-4.1"] .systemsculpt-chat-model-modal-option-favorite',
+    );
+    const claudeStar = modal.contentEl.querySelector(
+      '[data-model-value="anthropic@@claude-3-7-sonnet"] .systemsculpt-chat-model-modal-option-favorite',
+    );
+    expect(gptStar).not.toBeNull();
+    expect(gptStar?.classList.contains("is-favorite")).toBe(true);
+    expect(claudeStar?.classList.contains("is-favorite")).toBe(false);
+  });
+
+  it("toggles a model's favorite when its star is clicked, without selecting the model", async () => {
+    const onSelect = jest.fn();
+    const onToggleFavorite = jest.fn().mockResolvedValue(undefined);
+    const modal = new ChatModelPickerModal(new App(), {
+      currentValue: "anthropic@@claude-3-7-sonnet",
+      loadOptions: async () => [
+        buildOption({
+          value: "anthropic@@claude-3-7-sonnet",
+          label: "Claude 3.7 Sonnet",
+          providerLabel: "Anthropic",
+          providerId: "anthropic",
+          section: "pi",
+        }),
+      ],
+      onSelect,
+      onOpenSetup: jest.fn(),
+      favorites: {
+        state: {
+          favoriteIds: new Set<string>(),
+          showFavoritesOnly: false,
+          favoritesFirst: true,
+        },
+        onToggleFavorite,
+        onToggleFavoritesOnly: jest.fn().mockResolvedValue(false),
+      },
+    });
+
+    modal.onOpen();
+    await flush();
+
+    const star = modal.contentEl.querySelector(
+      '[data-model-value="anthropic@@claude-3-7-sonnet"] .systemsculpt-chat-model-modal-option-favorite',
+    ) as HTMLElement;
+    star.click();
+    await flush();
+
+    expect(onToggleFavorite).toHaveBeenCalledWith("anthropic@@claude-3-7-sonnet");
+    // Optimistic: the star now reflects the favorited state…
+    expect(
+      modal.contentEl
+        .querySelector(
+          '[data-model-value="anthropic@@claude-3-7-sonnet"] .systemsculpt-chat-model-modal-option-favorite',
+        )
+        ?.classList.contains("is-favorite"),
+    ).toBe(true);
+    // …and starring must never double as selecting the model.
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("filters to favorites (keeping the toggle) when the favorites-only control is activated", async () => {
+    const onToggleFavoritesOnly = jest.fn().mockResolvedValue(true);
+    const modal = new ChatModelPickerModal(new App(), {
+      currentValue: "openai@@gpt-4.1",
+      loadOptions: async () => [
+        buildOption({
+          value: "openai@@gpt-4.1",
+          label: "GPT-4.1",
+          providerLabel: "OpenAI",
+          providerId: "openai",
+          section: "pi",
+        }),
+        buildOption({
+          value: "anthropic@@claude-3-7-sonnet",
+          label: "Claude 3.7 Sonnet",
+          providerLabel: "Anthropic",
+          providerId: "anthropic",
+          section: "pi",
+        }),
+      ],
+      onSelect: jest.fn(),
+      onOpenSetup: jest.fn(),
+      favorites: {
+        state: {
+          favoriteIds: new Set(["openai@@gpt-4.1"]),
+          showFavoritesOnly: false,
+          favoritesFirst: true,
+        },
+        onToggleFavorite: jest.fn().mockResolvedValue(undefined),
+        onToggleFavoritesOnly,
+      },
+    });
+
+    modal.onOpen();
+    await flush();
+
+    expect(
+      modal.contentEl.querySelectorAll(".systemsculpt-chat-model-modal-option").length,
+    ).toBe(2);
+
+    (
+      modal.contentEl.querySelector(
+        ".systemsculpt-chat-model-modal-favorites-toggle",
+      ) as HTMLElement
+    ).click();
+    await flush();
+
+    expect(onToggleFavoritesOnly).toHaveBeenCalled();
+    const remaining = Array.from(
+      modal.contentEl.querySelectorAll(".systemsculpt-chat-model-modal-option"),
+    ).map((el) => (el as HTMLElement).dataset.modelValue);
+    expect(remaining).toEqual(["openai@@gpt-4.1"]);
+  });
 });

--- a/src/views/chatview/__tests__/modelSelection.test.ts
+++ b/src/views/chatview/__tests__/modelSelection.test.ts
@@ -11,10 +11,13 @@ import {
 } from "../../../services/pi-native/PiTextAuth";
 import { hasManagedSystemSculptAccess } from "../../../services/systemsculpt/ManagedSystemSculptModel";
 import {
+  applyChatModelFavorites,
   loadChatModelPickerOptions,
   openChatModelSetupTab,
   promptChatModelSetup,
+  type ChatModelPickerOption,
 } from "../modelSelection";
+import { ensureCanonicalId } from "../../../utils/modelUtils";
 
 jest.mock("../../../core/ui/", () => ({
   showPopup: jest.fn(),
@@ -239,5 +242,134 @@ describe("chat model setup helpers", () => {
     } as any;
 
     await expect(loadChatModelPickerOptions(plugin)).resolves.toEqual([]);
+  });
+});
+
+describe("applyChatModelFavorites", () => {
+  const favOption = (
+    overrides: Partial<ChatModelPickerOption> &
+      Pick<ChatModelPickerOption, "value" | "label" | "section" | "providerLabel">,
+  ): ChatModelPickerOption => ({
+    value: overrides.value,
+    label: overrides.label,
+    description: overrides.description,
+    badge: overrides.badge,
+    keywords: overrides.keywords,
+    providerAuthenticated: overrides.providerAuthenticated ?? true,
+    providerId: overrides.providerId || overrides.providerLabel.toLowerCase(),
+    providerLabel: overrides.providerLabel,
+    contextLabel: overrides.contextLabel,
+    section: overrides.section,
+    icon: overrides.icon || "cloud",
+    isFavorite: overrides.isFavorite,
+    setupSurface: overrides.setupSurface || {
+      targetTab: "providers",
+      title: "Finish setup",
+      primaryButton: "Open Providers",
+    },
+  });
+
+  // Section order (systemsculpt -> pi -> local) and, within pi, provider label
+  // order put Claude (Anthropic) ahead of GPT-4.1 (OpenAI) by default — so
+  // favoriting GPT-4.1 is what proves favorites-first actually reorders.
+  const baseOptions = (): ChatModelPickerOption[] => [
+    favOption({
+      value: "systemsculpt@@systemsculpt/ai-agent",
+      label: "SystemSculpt Agent",
+      section: "systemsculpt",
+      providerLabel: "SystemSculpt",
+      providerId: "systemsculpt",
+      icon: "sparkles",
+    }),
+    favOption({
+      value: "anthropic@@claude-3-7-sonnet",
+      label: "Claude 3.7 Sonnet",
+      section: "pi",
+      providerLabel: "Anthropic",
+      providerId: "anthropic",
+    }),
+    favOption({
+      value: "openai@@gpt-4.1",
+      label: "GPT-4.1",
+      section: "pi",
+      providerLabel: "OpenAI",
+      providerId: "openai",
+    }),
+    favOption({
+      value: "local-ollama@@qwen2.5-coder",
+      label: "Qwen 2.5 Coder",
+      section: "local",
+      providerLabel: "Ollama",
+      providerId: "ollama",
+      icon: "hard-drive",
+    }),
+  ];
+
+  it("annotates isFavorite by canonical id and preserves default order when no flags are set", () => {
+    const favoriteIds = new Set([ensureCanonicalId("openai@@gpt-4.1")]);
+    const result = applyChatModelFavorites(baseOptions(), {
+      favoriteIds,
+      showFavoritesOnly: false,
+      favoritesFirst: false,
+    });
+
+    expect(result.map((option) => option.value)).toEqual([
+      "systemsculpt@@systemsculpt/ai-agent",
+      "anthropic@@claude-3-7-sonnet",
+      "openai@@gpt-4.1",
+      "local-ollama@@qwen2.5-coder",
+    ]);
+    expect(result.find((option) => option.value === "openai@@gpt-4.1")?.isFavorite).toBe(true);
+    expect(result.find((option) => option.value === "anthropic@@claude-3-7-sonnet")?.isFavorite).toBe(
+      false,
+    );
+  });
+
+  it("bubbles favorites to the top of their section when favoritesFirst is enabled", () => {
+    const favoriteIds = new Set([ensureCanonicalId("openai@@gpt-4.1")]);
+    const result = applyChatModelFavorites(baseOptions(), {
+      favoriteIds,
+      showFavoritesOnly: false,
+      favoritesFirst: true,
+    });
+
+    // GPT-4.1 (favorited) now leads the Pi section ahead of Claude, while the
+    // section grouping (systemsculpt -> pi -> local) stays intact.
+    expect(result.map((option) => option.value)).toEqual([
+      "systemsculpt@@systemsculpt/ai-agent",
+      "openai@@gpt-4.1",
+      "anthropic@@claude-3-7-sonnet",
+      "local-ollama@@qwen2.5-coder",
+    ]);
+  });
+
+  it("filters to favorites only, always keeping managed SystemSculpt models visible", () => {
+    const favoriteIds = new Set([ensureCanonicalId("openai@@gpt-4.1")]);
+    const result = applyChatModelFavorites(baseOptions(), {
+      favoriteIds,
+      showFavoritesOnly: true,
+      favoritesFirst: true,
+    });
+
+    expect(result.map((option) => option.value)).toEqual([
+      "systemsculpt@@systemsculpt/ai-agent",
+      "openai@@gpt-4.1",
+    ]);
+  });
+
+  it("is an identity reorder with no favorites (back-compat with the default picker)", () => {
+    const result = applyChatModelFavorites(baseOptions(), {
+      favoriteIds: new Set<string>(),
+      showFavoritesOnly: false,
+      favoritesFirst: false,
+    });
+
+    expect(result.map((option) => option.value)).toEqual([
+      "systemsculpt@@systemsculpt/ai-agent",
+      "anthropic@@claude-3-7-sonnet",
+      "openai@@gpt-4.1",
+      "local-ollama@@qwen2.5-coder",
+    ]);
+    expect(result.every((option) => option.isFavorite === false)).toBe(true);
   });
 });

--- a/src/views/chatview/modelSelection.ts
+++ b/src/views/chatview/modelSelection.ts
@@ -49,6 +49,18 @@ export type ChatModelPickerOption = {
   section: ChatModelPickerSection;
   icon: string;
   setupSurface: ChatModelSetupSurface;
+  /** Whether this model is in the user's favorites (annotated by applyChatModelFavorites). */
+  isFavorite?: boolean;
+};
+
+/**
+ * Favorite-model state used to annotate, filter, and order picker options.
+ * `favoriteIds` holds canonical model ids (see FavoritesService.getFavoriteIds).
+ */
+export type ChatModelFavoritesState = {
+  favoriteIds: ReadonlySet<string>;
+  showFavoritesOnly: boolean;
+  favoritesFirst: boolean;
 };
 
 export function getEffectiveChatModelId(
@@ -302,6 +314,58 @@ export function compareChatModelPickerOptions(
   }
 
   return left.label.localeCompare(right.label);
+}
+
+/**
+ * Compare two picker options, bubbling favorites to the top of their section
+ * when `favoritesFirst` is enabled. Section grouping is always preserved first
+ * so the modal's section headers stay contiguous.
+ */
+export function compareChatModelPickerFavorites(
+  left: ChatModelPickerOption,
+  right: ChatModelPickerOption,
+  favoritesFirst: boolean,
+): number {
+  const sectionCompare =
+    getChatModelPickerSectionOrder(left.section) - getChatModelPickerSectionOrder(right.section);
+  if (sectionCompare !== 0) {
+    return sectionCompare;
+  }
+
+  if (favoritesFirst) {
+    const favoriteCompare = Number(Boolean(right.isFavorite)) - Number(Boolean(left.isFavorite));
+    if (favoriteCompare !== 0) {
+      return favoriteCompare;
+    }
+  }
+
+  return compareChatModelPickerOptions(left, right);
+}
+
+/**
+ * Annotate picker options with their favorite state, optionally filter to
+ * favorites-only (managed SystemSculpt models always stay visible), and order
+ * them favorites-first within each section. Pure — callers own the I/O of
+ * reading favorite ids and persisting toggles.
+ */
+export function applyChatModelFavorites(
+  options: ChatModelPickerOption[],
+  state: ChatModelFavoritesState,
+): ChatModelPickerOption[] {
+  const annotated = options.map((option) => ({
+    ...option,
+    isFavorite: state.favoriteIds.has(ensureCanonicalId(option.value)),
+  }));
+
+  const visible = state.showFavoritesOnly
+    ? annotated.filter(
+        (option) => option.isFavorite || isManagedSystemSculptModelId(option.value),
+      )
+    : annotated;
+
+  return visible.sort((left, right) =>
+    compareChatModelPickerFavorites(left, right, state.favoritesFirst),
+  );
 }
 
 export function getChatModelPickerSearchText(option: ChatModelPickerOption): string {


### PR DESCRIPTION
Final slice of **#210** ("Restore Prompts/Favorites as part of the chat composer modularization"). The **Prompts** chip already survives the composer modularization (`createPromptChip`/`PromptSelector` → `systemPromptOverride`, wired in `InputHandler`), so this PR restores the **Favorites** half: favorite *models*, whose filter/sort/toggle UI was dropped in `08b7c3f` when the legacy selection modal was removed (leaving `FavoritesService` live but unsurfaced).

Per the repo's "re-architect, don't perpetuate legacy" rule, favorites is integrated cleanly into the **new** modular picker rather than resurrecting the deleted `FavoritesFilter.ts`/`EmptyFavoritesState.ts` components.

## What changed
- **`modelSelection.ts`** — new pure `applyChatModelFavorites(options, state)`: annotates `isFavorite` by canonical id, applies a favorites-only filter (managed SystemSculpt models always stay visible, mirroring `FavoritesService.filterModelsByFavorites`), and orders favorites-first **within each section** so section grouping stays intact. Plus `compareChatModelPickerFavorites`.
- **`ChatModelPickerModal.ts`** — optional `favorites` config: a favorites-only filter chip in the search row and a per-row star toggle (optimistic; `stopPropagation` so starring never selects the row). With no config it collapses to the previous identity ordering — existing picker tests pass unchanged.
- **`ChatModelSelectionController.ts`** — wires favorites through the existing `FavoritesService` singleton (`getFavoriteIds`/`getShowFavoritesOnly`/`getFavoritesFirst`, `toggleFavorite`, `toggleShowFavoritesOnly`); resolves the catalog record by canonical id and syncs its `isFavorite` flag to the persisted truth before toggling.
- **`chat.css`** — styles for the filter chip and per-row star.

No new settings or services: reuses `FavoritesService`, `favoriteModels`, and `favoritesFilterSettings` (already defaulted + validated/migrated by `SettingsManager`).

## Tests (failing-first)
- `modelSelection.test.ts` — `applyChatModelFavorites`: annotate by canonical id, favorites-first within section, favorites-only keeps managed SystemSculpt, and a back-compat identity reorder with no favorites.
- `ChatModelPickerModal.test.ts` — favorites-only toggle + per-row stars reflecting state, star toggles a favorite without selecting the row, favorites-only filtering.

Local gates green: `check:plugin:fast` (tsc + bundle + script-tests + unit), `npm run test:integration` (21/21 incl. mobile/no-node bundle-load + provider-listing).

Closes the last #210 acceptance criterion.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added favorites system to chat model picker with a star button to mark/unmark favorite models.
  * Added toggle option to display only favorited chat models.
  * Favorited models appear with visual star indicator and can be prioritized at the top of the selection list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->