### PR TITLE
feat(embeddings): portable index that survives Sync/restore (#208)

### DIFF
--- a/src/services/__tests__/EmbeddingsManager.portableIndex.test.ts
+++ b/src/services/__tests__/EmbeddingsManager.portableIndex.test.ts
@@ -1,0 +1,122 @@
+jest.mock("../embeddings/storage/EmbeddingsStorage", () => {
+  const storageMock = {
+    initialize: jest.fn(),
+    loadEmbeddings: jest.fn(),
+    clear: jest.fn(),
+    countVectors: jest.fn(async () => 0),
+    importFromLegacyGlobalDb: jest.fn(async () => ({ imported: 0, skipped: 0 })),
+    upgradeVectorsToCanonicalFormat: jest.fn(async () => ({ updated: 0, skipped: 0, removed: 0 })),
+    backfillRootCompleteness: jest.fn(async () => ({ updated: 0, skipped: 0 })),
+    getAllVectors: jest.fn(() => []),
+    size: jest.fn(() => 0),
+    storeVectors: jest.fn(),
+    purgeCorruptedVectors: jest.fn(() => ({
+      removedCount: 0,
+      correctedCount: 0,
+      removedPaths: [],
+      correctedPaths: [],
+    })),
+  };
+  const EmbeddingsStorage = jest.fn(() => storageMock);
+  (EmbeddingsStorage as any).buildDbName = jest.fn(() => "SystemSculptEmbeddings::test-vault");
+  return { EmbeddingsStorage };
+});
+
+jest.mock("../embeddings/processing/EmbeddingsProcessor", () => ({
+  EmbeddingsProcessor: jest.fn().mockImplementation(() => ({
+    processFiles: jest.fn(),
+    cancel: jest.fn(),
+    setProvider: jest.fn(),
+    setConfig: jest.fn(),
+    cleanup: jest.fn(),
+  })),
+}));
+
+jest.mock("../embeddings/storage/EmbeddingsPortableIndex", () => ({
+  restoreEmbeddingsIndexIfEmpty: jest.fn(async () => ({ restored: false, imported: 0, reason: "no-snapshot" })),
+  writeEmbeddingsIndexSnapshot: jest.fn(async () => ({ written: false, count: 0 })),
+}));
+
+jest.mock("../../core/ui/notifications", () => ({
+  showNoticeWhenReady: jest.fn(),
+}));
+
+import { TFile } from "obsidian";
+import { EmbeddingsManager } from "../embeddings/EmbeddingsManager";
+import { EmbeddingsIndexFile } from "../embeddings/storage/EmbeddingsIndexFile";
+import { restoreEmbeddingsIndexIfEmpty } from "../embeddings/storage/EmbeddingsPortableIndex";
+
+function createPluginStub(settingsOverrides: Record<string, unknown> = {}) {
+  const settings = {
+    vaultInstanceId: "test-vault",
+    embeddingsVectorFormatVersion: 4,
+    embeddingsProvider: "systemsculpt",
+    embeddingsCustomEndpoint: "",
+    embeddingsCustomApiKey: "",
+    embeddingsCustomModel: "",
+    embeddingsModel: "",
+    embeddingsBatchSize: 8,
+    embeddingsAutoProcess: false,
+    embeddingsExclusions: {
+      folders: [],
+      patterns: [],
+      ignoreChatHistory: true,
+      respectObsidianExclusions: true,
+    },
+    embeddingsRateLimitPerMinute: 30,
+    embeddingsEnabled: false,
+    embeddingsQuietPeriodMs: 500,
+    licenseKey: "fake-license",
+    licenseValid: true,
+    serverUrl: "https://api.systemsculpt.com/api/v1",
+    ...settingsOverrides,
+  };
+
+  const vault = {
+    getMarkdownFiles: jest.fn(() => [new TFile({ path: "Note.md", name: "Note.md", extension: "md" })]),
+    getAbstractFileByPath: jest.fn(() => null),
+    read: jest.fn(),
+    on: jest.fn(() => jest.fn()),
+    offref: jest.fn(),
+    adapter: {
+      exists: jest.fn(async () => false),
+      read: jest.fn(),
+      write: jest.fn(),
+      mkdir: jest.fn(),
+    },
+  };
+
+  return {
+    app: { vault },
+    settings,
+    emitter: { emit: jest.fn(), on: jest.fn(() => jest.fn()) },
+    getSettingsManager: jest.fn(() => ({ updateSettings: jest.fn(async () => {}) })),
+  };
+}
+
+describe("EmbeddingsManager portable index restore", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("restores from the vault snapshot on init when enabled (default)", async () => {
+    const pluginStub = createPluginStub();
+    const manager = new EmbeddingsManager(pluginStub.app as any, pluginStub as any);
+
+    await manager.initialize();
+
+    expect(restoreEmbeddingsIndexIfEmpty).toHaveBeenCalledTimes(1);
+    const call = (restoreEmbeddingsIndexIfEmpty as jest.Mock).mock.calls[0][0];
+    expect(call.file).toBeInstanceOf(EmbeddingsIndexFile);
+    expect(call.store).toBeTruthy();
+  });
+
+  it("does not restore when the portable-index setting is disabled", async () => {
+    const pluginStub = createPluginStub({ embeddingsPortableIndex: false });
+    const manager = new EmbeddingsManager(pluginStub.app as any, pluginStub as any);
+
+    await manager.initialize();
+
+    expect(restoreEmbeddingsIndexIfEmpty).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/EmbeddingsStorage.portableIndex.test.ts
+++ b/src/services/__tests__/EmbeddingsStorage.portableIndex.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { EmbeddingsStorage } from "../embeddings/storage/EmbeddingsStorage";
+import {
+  EMBEDDINGS_INDEX_FORMAT,
+  serializeEmbeddingsIndex,
+} from "../embeddings/storage/EmbeddingsIndexSerialization";
+import type { EmbeddingVector } from "../embeddings/types";
+import { buildVectorId } from "../embeddings/utils/vectorId";
+
+function makeVector(path: string): EmbeddingVector {
+  const namespace = "systemsculpt:openai/text-embedding-3-small:v2:3";
+  return {
+    id: buildVectorId(namespace, path, 0),
+    path,
+    chunkId: 0,
+    vector: new Float32Array([1, 0, 0]),
+    metadata: {
+      title: path.replace(/\.md$/, ""),
+      mtime: 1,
+      contentHash: `${path}-hash`,
+      provider: "systemsculpt",
+      model: "openai/text-embedding-3-small",
+      dimension: 3,
+      createdAt: 1,
+      namespace,
+    },
+  };
+}
+
+describe("EmbeddingsStorage portable index", () => {
+  it("exportAll serializes the in-memory vectors into a versioned envelope", async () => {
+    const storage = new EmbeddingsStorage("SystemSculptEmbeddings::test");
+    const a = makeVector("A.md");
+    const b = makeVector("B.md");
+    (storage as unknown as { cache: Map<string, EmbeddingVector> }).cache.set(a.id, a);
+    (storage as unknown as { cache: Map<string, EmbeddingVector> }).cache.set(b.id, b);
+
+    const index = await storage.exportAll();
+
+    expect(index.format).toBe(EMBEDDINGS_INDEX_FORMAT);
+    expect(index.vectorCount).toBe(2);
+    expect(index.vectors.map((v) => v.path).sort()).toEqual(["A.md", "B.md"]);
+  });
+
+  it("importAll deserializes and delegates to storeVectors", async () => {
+    const storage = new EmbeddingsStorage("SystemSculptEmbeddings::test");
+    const stored: EmbeddingVector[][] = [];
+    jest
+      .spyOn(storage, "storeVectors")
+      .mockImplementation(async (vectors: EmbeddingVector[]) => {
+        stored.push(vectors);
+      });
+
+    const envelope = serializeEmbeddingsIndex([makeVector("A.md"), makeVector("B.md")]);
+    const result = await storage.importAll(envelope);
+
+    expect(result).toEqual({ imported: 2 });
+    expect(stored).toHaveLength(1);
+    expect(stored[0].map((v) => v.path).sort()).toEqual(["A.md", "B.md"]);
+    expect(stored[0][0].vector).toBeInstanceOf(Float32Array);
+  });
+
+  it("importAll ignores an unreadable envelope without storing anything", async () => {
+    const storage = new EmbeddingsStorage("SystemSculptEmbeddings::test");
+    const spy = jest.spyOn(storage, "storeVectors").mockResolvedValue();
+
+    const result = await storage.importAll({ format: 999, vectors: [] } as never);
+
+    expect(result).toEqual({ imported: 0 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/embeddings/EmbeddingsManager.ts
+++ b/src/services/embeddings/EmbeddingsManager.ts
@@ -23,6 +23,8 @@ import { CustomProvider } from './providers/CustomProvider';
 import { EmbeddingsProcessor } from './processing/EmbeddingsProcessor';
 import { ContentPreprocessor } from './processing/ContentPreprocessor';
 import { VectorSearch } from './search/VectorSearch';
+import { EmbeddingsIndexFile } from './storage/EmbeddingsIndexFile';
+import { restoreEmbeddingsIndexIfEmpty, writeEmbeddingsIndexSnapshot } from './storage/EmbeddingsPortableIndex';
 import { buildNamespace, buildNamespacePrefix, namespaceMatchesCurrentVersion, parseNamespace, parseNamespaceDimension } from './utils/namespace';
 import { buildVectorId } from "./utils/vectorId";
 import { normalizeInPlace, toFloat32Array } from './utils/vector';
@@ -99,6 +101,8 @@ export class EmbeddingsManager {
   private vaultCooldownUntil: number = 0;
   private scheduledVaultRun: ReturnType<typeof setTimeout> | null = null;
   private scheduledVaultRunAt: number | null = null;
+  private portableIndexFile: EmbeddingsIndexFile | null = null;
+  private portableIndexSnapshotTimer: ReturnType<typeof setTimeout> | null = null;
   private queryCooldownUntil: number = 0;
   private lastDimensionNoticeAt: number = 0;
   private failedFiles: Map<string, FailedEmbeddingFile> = new Map();
@@ -138,6 +142,10 @@ export class EmbeddingsManager {
     this.initializationPromise = (async () => {
       try {
         await this.storage.initialize();
+        // Restore from the synced vault snapshot before the legacy-DB migration,
+        // so a portable index wins over stale per-device legacy data on a fresh
+        // device. No-op when the local store already has vectors.
+        await this.restorePortableIndexIfEmpty();
         await this.migrateEmbeddingsStorageIfNeeded();
         await this.storage.loadEmbeddings();
 
@@ -249,6 +257,71 @@ export class EmbeddingsManager {
     try {
       await this.plugin.getSettingsManager().updateSettings({ embeddingsVectorFormatVersion: CURRENT_FORMAT_VERSION });
     } catch {}
+  }
+
+  private isPortableIndexEnabled(): boolean {
+    // Default on: undefined settings (older configs) opt in.
+    return this.plugin.settings.embeddingsPortableIndex !== false;
+  }
+
+  private getPortableIndexFile(): EmbeddingsIndexFile | null {
+    const adapter = this.app?.vault?.adapter;
+    if (!adapter) return null;
+    if (!this.portableIndexFile) {
+      this.portableIndexFile = new EmbeddingsIndexFile(adapter);
+    }
+    return this.portableIndexFile;
+  }
+
+  /**
+   * Restore the embedding index from the synced vault snapshot when the local
+   * IndexedDB store is empty (fresh device / wiped store). Best-effort: a
+   * missing, corrupt, or partially-synced snapshot must never block startup.
+   */
+  private async restorePortableIndexIfEmpty(): Promise<void> {
+    if (!this.isPortableIndexEnabled()) return;
+    const file = this.getPortableIndexFile();
+    if (!file) return;
+    try {
+      const result = await restoreEmbeddingsIndexIfEmpty({ store: this.storage, file });
+      if (result.restored) {
+        try {
+          new Notice(
+            `SystemSculpt restored ${result.imported} embeddings from the synced vault index.`,
+            5000,
+          );
+        } catch {}
+      }
+    } catch {
+      // Best-effort restore; fall through to normal (re)embedding.
+    }
+  }
+
+  /**
+   * Debounce a portable snapshot write after embeddings change, so a burst of
+   * processing collapses into a single vault write.
+   */
+  private schedulePortableIndexSnapshot(delayMs = 5000): void {
+    if (!this.isPortableIndexEnabled()) return;
+    if (!this.app?.vault?.adapter) return;
+    if (this.portableIndexSnapshotTimer) {
+      try { clearTimeout(this.portableIndexSnapshotTimer); } catch {}
+    }
+    this.portableIndexSnapshotTimer = setTimeout(() => {
+      this.portableIndexSnapshotTimer = null;
+      void this.writePortableIndexSnapshot();
+    }, delayMs);
+  }
+
+  private async writePortableIndexSnapshot(): Promise<void> {
+    if (!this.isPortableIndexEnabled()) return;
+    const file = this.getPortableIndexFile();
+    if (!file) return;
+    try {
+      await writeEmbeddingsIndexSnapshot({ store: this.storage, file });
+    } catch {
+      // Best-effort: a snapshot write must never disrupt embedding.
+    }
   }
 
   /**
@@ -391,6 +464,10 @@ export class EmbeddingsManager {
       }
 
       this.handleProcessingSuccess('vault');
+
+      // Persist a portable snapshot so the freshly-embedded index survives a
+      // device move via Obsidian Sync/backup.
+      this.schedulePortableIndexSnapshot();
 
       // If the provider signaled a model change, schedule a follow-up refresh (respect autoProcess)
       if ((this.provider as any).lastModelChanged === true) {
@@ -1161,6 +1238,10 @@ export class EmbeddingsManager {
   cleanup(): void {
     this.unregisterWatchers();
     this.processor.cleanup();
+    if (this.portableIndexSnapshotTimer) {
+      try { clearTimeout(this.portableIndexSnapshotTimer); } catch {}
+      this.portableIndexSnapshotTimer = null;
+    }
   }
 
   /** Public: Describe the active namespace components */

--- a/src/services/embeddings/storage/EmbeddingsIndexFile.ts
+++ b/src/services/embeddings/storage/EmbeddingsIndexFile.ts
@@ -1,0 +1,73 @@
+/**
+ * EmbeddingsIndexFile - reads/writes the portable embedding snapshot to a
+ * vault-relative path through Obsidian's `DataAdapter`.
+ *
+ * Living in the vault (default `.systemsculpt/embeddings/index.json`, alongside
+ * `.systemsculpt/diagnostics`) is what lets Obsidian Sync/backup capture and
+ * restore the index — unlike the per-device IndexedDB store.
+ *
+ * Uses only the Obsidian `DataAdapter` (read/write/exists/mkdir), which is the
+ * mobile-safe path (CapacitorAdapter on phones); no `node:fs`, so this stays
+ * within the no-eager-node-import boundary the embeddings tree relies on.
+ */
+
+import type { DataAdapter } from "obsidian";
+import type { SerializedEmbeddingsIndex } from "./EmbeddingsIndexSerialization";
+
+const DEFAULT_DIR = ".systemsculpt/embeddings";
+const DEFAULT_FILE_NAME = "index.json";
+
+export interface EmbeddingsIndexFileOptions {
+  dir?: string;
+  fileName?: string;
+}
+
+export class EmbeddingsIndexFile {
+  private readonly dir: string;
+  private readonly filePath: string;
+
+  constructor(
+    private readonly adapter: DataAdapter,
+    options: EmbeddingsIndexFileOptions = {},
+  ) {
+    this.dir = options.dir ?? DEFAULT_DIR;
+    const fileName = options.fileName ?? DEFAULT_FILE_NAME;
+    this.filePath = `${this.dir}/${fileName}`;
+  }
+
+  public getPath(): string {
+    return this.filePath;
+  }
+
+  public async exists(): Promise<boolean> {
+    try {
+      return await this.adapter.exists(this.filePath);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Read and JSON-parse the snapshot. Returns null when absent or unparseable
+   * (a partially-synced or hand-edited file must never crash startup).
+   */
+  public async read(): Promise<SerializedEmbeddingsIndex | null> {
+    try {
+      if (!(await this.adapter.exists(this.filePath))) return null;
+      const text = await this.adapter.read(this.filePath);
+      return JSON.parse(text) as SerializedEmbeddingsIndex;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Write the snapshot, creating the directory if needed.
+   */
+  public async write(index: SerializedEmbeddingsIndex): Promise<void> {
+    if (!(await this.adapter.exists(this.dir))) {
+      await this.adapter.mkdir(this.dir);
+    }
+    await this.adapter.write(this.filePath, JSON.stringify(index));
+  }
+}

--- a/src/services/embeddings/storage/EmbeddingsIndexSerialization.ts
+++ b/src/services/embeddings/storage/EmbeddingsIndexSerialization.ts
@@ -1,0 +1,166 @@
+/**
+ * EmbeddingsIndexSerialization - portable, device-independent encoding of the
+ * embedding index.
+ *
+ * The on-disk IndexedDB store is scoped to a per-install `vaultInstanceId`, so it
+ * is never captured by Obsidian Sync/backup and never restored on a new device.
+ * This module turns the store's `EmbeddingVector[]` into a versioned JSON
+ * envelope that CAN live in the synced vault, and back again.
+ *
+ * Vectors are encoded as explicit little-endian Float32 bytes (via DataView) and
+ * base64'd, so the snapshot round-trips byte-for-byte across platforms. The
+ * record `id`/`namespace` already encode `provider:model:vSchema:dimension` with
+ * no device identity, so a restored snapshot needs no remapping.
+ *
+ * Pure module: no IndexedDB, no Obsidian, no Node — safe to load on mobile.
+ */
+
+import type { EmbeddingVector } from "../types";
+
+/** Bump when the envelope shape changes incompatibly. */
+export const EMBEDDINGS_INDEX_FORMAT = 1;
+
+export interface SerializedEmbeddingVector {
+  id: string;
+  path: string;
+  chunkId: number;
+  /** Base64 of the vector's little-endian Float32 bytes ("" for empty vectors). */
+  vector: string;
+  metadata: EmbeddingVector["metadata"];
+}
+
+export interface SerializedEmbeddingsIndex {
+  format: number;
+  /** Snapshot creation time (caller-supplied; null when unknown). */
+  createdAt: number | null;
+  vectorCount: number;
+  vectors: SerializedEmbeddingVector[];
+}
+
+const BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/;
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, i + CHUNK);
+    binary += String.fromCharCode.apply(null, slice as unknown as number[]);
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  if (!BASE64_PATTERN.test(base64)) {
+    throw new Error("Invalid base64 payload.");
+  }
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function float32ToBase64(vector: Float32Array): string {
+  const bytes = new Uint8Array(vector.length * 4);
+  const view = new DataView(bytes.buffer);
+  for (let i = 0; i < vector.length; i++) {
+    view.setFloat32(i * 4, vector[i], true);
+  }
+  return bytesToBase64(bytes);
+}
+
+function base64ToFloat32(base64: string): Float32Array {
+  const bytes = base64ToBytes(base64);
+  const usable = bytes.length - (bytes.length % 4);
+  const out = new Float32Array(usable / 4);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, usable);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = view.getFloat32(i * 4, true);
+  }
+  return out;
+}
+
+function parseChunkId(value: unknown, id: string): number {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  const idx = id.lastIndexOf("#");
+  if (idx < 0) return 0;
+  const parsed = parseInt(id.slice(idx + 1), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+/**
+ * Encode an in-memory index into a portable, versioned envelope.
+ */
+export function serializeEmbeddingsIndex(
+  vectors: EmbeddingVector[],
+  opts: { createdAt?: number | null } = {},
+): SerializedEmbeddingsIndex {
+  const serializedVectors: SerializedEmbeddingVector[] = [];
+  for (const vector of vectors) {
+    if (!vector || typeof vector.id !== "string" || typeof vector.path !== "string") {
+      continue;
+    }
+    const float = vector.vector instanceof Float32Array ? vector.vector : new Float32Array(0);
+    serializedVectors.push({
+      id: vector.id,
+      path: vector.path,
+      chunkId: parseChunkId(vector.chunkId, vector.id),
+      vector: float32ToBase64(float),
+      metadata: vector.metadata,
+    });
+  }
+
+  return {
+    format: EMBEDDINGS_INDEX_FORMAT,
+    createdAt: typeof opts.createdAt === "number" ? opts.createdAt : null,
+    vectorCount: serializedVectors.length,
+    vectors: serializedVectors,
+  };
+}
+
+/**
+ * Decode a portable envelope back into `EmbeddingVector[]`.
+ *
+ * Fails safe: an unknown format or a non-array payload yields `[]` (the caller
+ * re-embeds), and individual malformed/corrupt records are skipped rather than
+ * aborting the whole restore.
+ */
+export function deserializeEmbeddingsIndex(input: unknown): EmbeddingVector[] {
+  if (!input || typeof input !== "object") return [];
+  const envelope = input as Partial<SerializedEmbeddingsIndex>;
+  if (envelope.format !== EMBEDDINGS_INDEX_FORMAT) return [];
+  if (!Array.isArray(envelope.vectors)) return [];
+
+  const vectors: EmbeddingVector[] = [];
+  for (const raw of envelope.vectors) {
+    if (!raw || typeof raw !== "object") continue;
+    const record = raw as Partial<SerializedEmbeddingVector>;
+    if (typeof record.id !== "string" || record.id.length === 0) continue;
+    if (typeof record.path !== "string" || record.path.length === 0) continue;
+    if (typeof record.vector !== "string") continue;
+    if (!record.metadata || typeof record.metadata !== "object") continue;
+    if (typeof record.metadata.namespace !== "string" || record.metadata.namespace.length === 0) {
+      continue;
+    }
+
+    let float: Float32Array;
+    try {
+      float = base64ToFloat32(record.vector);
+    } catch {
+      continue;
+    }
+
+    vectors.push({
+      id: record.id,
+      path: record.path,
+      chunkId: parseChunkId(record.chunkId, record.id),
+      vector: float,
+      metadata: record.metadata,
+    });
+  }
+
+  return vectors;
+}

--- a/src/services/embeddings/storage/EmbeddingsPortableIndex.ts
+++ b/src/services/embeddings/storage/EmbeddingsPortableIndex.ts
@@ -1,0 +1,81 @@
+/**
+ * EmbeddingsPortableIndex - the restore/snapshot decision logic that ties the
+ * IndexedDB store to the vault-relative snapshot file.
+ *
+ * Kept dependency-light (small interfaces, no IndexedDB/Obsidian imports) so the
+ * decisions — "restore only into an empty store", "never write an empty
+ * snapshot" — are unit-testable with fakes and the EmbeddingsManager wiring stays
+ * a thin call.
+ */
+
+import type { SerializedEmbeddingsIndex } from "./EmbeddingsIndexSerialization";
+
+export interface PortableIndexStore {
+  countVectors(): Promise<number>;
+  exportAll(): Promise<SerializedEmbeddingsIndex>;
+  importAll(index: SerializedEmbeddingsIndex): Promise<{ imported: number }>;
+}
+
+export interface PortableIndexFile {
+  read(): Promise<SerializedEmbeddingsIndex | null>;
+  write(index: SerializedEmbeddingsIndex): Promise<void>;
+}
+
+export interface RestoreResult {
+  restored: boolean;
+  imported: number;
+  reason: "restored" | "store-not-empty" | "no-snapshot" | "empty-snapshot";
+}
+
+export interface WriteResult {
+  written: boolean;
+  count: number;
+}
+
+/**
+ * Restore the index from the vault snapshot, but only when the local store is
+ * empty (a fresh device / wiped IndexedDB). A populated store always wins so we
+ * never clobber newer local vectors with a stale snapshot — mirroring the
+ * existing legacy-DB import guard.
+ */
+export async function restoreEmbeddingsIndexIfEmpty(deps: {
+  store: PortableIndexStore;
+  file: PortableIndexFile;
+}): Promise<RestoreResult> {
+  const { store, file } = deps;
+
+  const count = await store.countVectors();
+  if (count > 0) {
+    return { restored: false, imported: 0, reason: "store-not-empty" };
+  }
+
+  const snapshot = await file.read();
+  if (!snapshot) {
+    return { restored: false, imported: 0, reason: "no-snapshot" };
+  }
+
+  const { imported } = await store.importAll(snapshot);
+  if (imported > 0) {
+    return { restored: true, imported, reason: "restored" };
+  }
+  return { restored: false, imported: 0, reason: "empty-snapshot" };
+}
+
+/**
+ * Write the current store to the vault snapshot. Skips an empty index so we
+ * don't overwrite a good snapshot with nothing (e.g. before the first embed).
+ */
+export async function writeEmbeddingsIndexSnapshot(deps: {
+  store: PortableIndexStore;
+  file: PortableIndexFile;
+}): Promise<WriteResult> {
+  const { store, file } = deps;
+
+  const index = await store.exportAll();
+  if (index.vectorCount === 0) {
+    return { written: false, count: 0 };
+  }
+
+  await file.write(index);
+  return { written: true, count: index.vectorCount };
+}

--- a/src/services/embeddings/storage/EmbeddingsStorage.ts
+++ b/src/services/embeddings/storage/EmbeddingsStorage.ts
@@ -12,6 +12,11 @@ import { EmbeddingVector } from '../types';
 import { buildNamespaceWithSchema, normalizeModelForNamespace, parseNamespace } from '../utils/namespace';
 import { buildVectorId } from "../utils/vectorId";
 import { normalizeInPlace, toFloat32Array, VectorLike } from '../utils/vector';
+import {
+  deserializeEmbeddingsIndex,
+  serializeEmbeddingsIndex,
+  type SerializedEmbeddingsIndex,
+} from './EmbeddingsIndexSerialization';
 
 const LEGACY_DB_NAME = "SystemSculptEmbeddings";
 const DB_VERSION = 10;
@@ -1072,6 +1077,28 @@ export class EmbeddingsStorage {
       this.vectorsArrayCache = Array.from(this.cache.values());
     }
     return this.vectorsArrayCache;
+  }
+
+  /**
+   * Serialize every stored vector into a portable, versioned envelope that can
+   * live in the synced vault (so Obsidian Sync/backup restores it on a new
+   * device). Records are device-independent — no remapping needed on import.
+   */
+  async exportAll(): Promise<SerializedEmbeddingsIndex> {
+    const vectors = await this.getAllVectors();
+    return serializeEmbeddingsIndex(vectors, { createdAt: Date.now() });
+  }
+
+  /**
+   * Import a portable envelope into the store. Malformed records and unknown
+   * formats are dropped by the deserializer, so this never throws on a partially
+   * synced or corrupt snapshot.
+   */
+  async importAll(index: SerializedEmbeddingsIndex): Promise<{ imported: number }> {
+    const vectors = deserializeEmbeddingsIndex(index);
+    if (vectors.length === 0) return { imported: 0 };
+    await this.storeVectors(vectors);
+    return { imported: vectors.length };
   }
 
   async getVectorsByNamespacePrefix(prefix: string): Promise<EmbeddingVector[]> {

--- a/src/services/embeddings/storage/__tests__/EmbeddingsIndexFile.test.ts
+++ b/src/services/embeddings/storage/__tests__/EmbeddingsIndexFile.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { EmbeddingsIndexFile } from "../EmbeddingsIndexFile";
+import {
+  EMBEDDINGS_INDEX_FORMAT,
+  type SerializedEmbeddingsIndex,
+} from "../EmbeddingsIndexSerialization";
+
+function makeAdapter() {
+  const files = new Map<string, string>();
+  const dirs = new Set<string>();
+  return {
+    files,
+    dirs,
+    exists: jest.fn(async (p: string) => files.has(p) || dirs.has(p)),
+    read: jest.fn(async (p: string) => {
+      if (!files.has(p)) throw new Error(`ENOENT: ${p}`);
+      return files.get(p) as string;
+    }),
+    write: jest.fn(async (p: string, data: string) => {
+      files.set(p, data);
+    }),
+    mkdir: jest.fn(async (p: string) => {
+      dirs.add(p);
+    }),
+  };
+}
+
+function sampleIndex(): SerializedEmbeddingsIndex {
+  return {
+    format: EMBEDDINGS_INDEX_FORMAT,
+    createdAt: 1700000000000,
+    vectorCount: 1,
+    vectors: [
+      {
+        id: "ns::A.md#0",
+        path: "A.md",
+        chunkId: 0,
+        vector: "",
+        metadata: {
+          title: "A",
+          mtime: 1,
+          contentHash: "h",
+          provider: "systemsculpt",
+          model: "m",
+          dimension: 0,
+          createdAt: 1,
+          namespace: "ns",
+          isEmpty: true,
+        },
+      },
+    ],
+  };
+}
+
+describe("EmbeddingsIndexFile", () => {
+  it("writes then reads back the same envelope, creating the directory", async () => {
+    const adapter = makeAdapter();
+    const file = new EmbeddingsIndexFile(adapter as never);
+
+    await file.write(sampleIndex());
+
+    expect(adapter.mkdir).toHaveBeenCalledWith(".systemsculpt/embeddings");
+    expect(adapter.write).toHaveBeenCalledWith(
+      ".systemsculpt/embeddings/index.json",
+      expect.any(String),
+    );
+
+    const read = await file.read();
+    expect(read).toEqual(sampleIndex());
+  });
+
+  it("returns null when no snapshot exists", async () => {
+    const adapter = makeAdapter();
+    const file = new EmbeddingsIndexFile(adapter as never);
+
+    expect(await file.exists()).toBe(false);
+    expect(await file.read()).toBeNull();
+  });
+
+  it("returns null on a corrupt (unparseable) snapshot instead of throwing", async () => {
+    const adapter = makeAdapter();
+    adapter.files.set(".systemsculpt/embeddings/index.json", "{not json");
+    const file = new EmbeddingsIndexFile(adapter as never);
+
+    expect(await file.exists()).toBe(true);
+    await expect(file.read()).resolves.toBeNull();
+  });
+
+  it("does not call mkdir when the directory already exists", async () => {
+    const adapter = makeAdapter();
+    adapter.dirs.add(".systemsculpt/embeddings");
+    const file = new EmbeddingsIndexFile(adapter as never);
+
+    await file.write(sampleIndex());
+    expect(adapter.mkdir).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/embeddings/storage/__tests__/EmbeddingsIndexSerialization.test.ts
+++ b/src/services/embeddings/storage/__tests__/EmbeddingsIndexSerialization.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "@jest/globals";
+import type { EmbeddingVector } from "../../types";
+import { buildVectorId } from "../../utils/vectorId";
+import {
+  EMBEDDINGS_INDEX_FORMAT,
+  deserializeEmbeddingsIndex,
+  serializeEmbeddingsIndex,
+} from "../EmbeddingsIndexSerialization";
+
+function makeVector(
+  path: string,
+  values: number[],
+  overrides: Partial<EmbeddingVector["metadata"]> = {},
+): EmbeddingVector {
+  const namespace = `systemsculpt:openai/text-embedding-3-small:v2:${values.length}`;
+  return {
+    id: buildVectorId(namespace, path, 0),
+    path,
+    chunkId: 0,
+    vector: new Float32Array(values),
+    metadata: {
+      title: path.replace(/\.md$/, ""),
+      mtime: 1700000000000,
+      contentHash: `${path}-hash`,
+      provider: "systemsculpt",
+      model: "openai/text-embedding-3-small",
+      dimension: values.length,
+      createdAt: 1700000000000,
+      namespace,
+      ...overrides,
+    },
+  };
+}
+
+describe("EmbeddingsIndexSerialization", () => {
+  it("round-trips vectors through serialize -> deserialize with float32 fidelity", () => {
+    const vectors = [
+      makeVector("A.md", [0.1, 0.2, 0.3]),
+      makeVector("B.md", [-1, 0.5, 0.25]),
+    ];
+
+    const serialized = serializeEmbeddingsIndex(vectors, { createdAt: 123 });
+    expect(serialized.format).toBe(EMBEDDINGS_INDEX_FORMAT);
+    expect(serialized.vectorCount).toBe(2);
+    expect(serialized.createdAt).toBe(123);
+
+    const restored = deserializeEmbeddingsIndex(serialized);
+    expect(restored).toHaveLength(2);
+
+    const a = restored.find((v) => v.path === "A.md");
+    expect(a).toBeDefined();
+    expect(a!.id).toBe(vectors[0].id);
+    expect(a!.chunkId).toBe(0);
+    expect(a!.metadata.namespace).toBe(vectors[0].metadata.namespace);
+    expect(a!.metadata.contentHash).toBe("A.md-hash");
+    expect(a!.vector).toBeInstanceOf(Float32Array);
+    // float32 storage rounds the literals; the round-trip must reproduce the
+    // exact same 32-bit values, not the f64 originals.
+    expect(Array.from(a!.vector)).toEqual([
+      Math.fround(0.1),
+      Math.fround(0.2),
+      Math.fround(0.3),
+    ]);
+  });
+
+  it("preserves intentionally-empty vectors and metadata flags", () => {
+    const empty = makeVector("empty.md", [], {
+      isEmpty: true,
+      dimension: 0,
+      complete: true,
+      chunkCount: 0,
+    });
+
+    const restored = deserializeEmbeddingsIndex(serializeEmbeddingsIndex([empty]));
+    expect(restored).toHaveLength(1);
+    expect(restored[0].vector).toBeInstanceOf(Float32Array);
+    expect(restored[0].vector.length).toBe(0);
+    expect(restored[0].metadata.isEmpty).toBe(true);
+    expect(restored[0].metadata.complete).toBe(true);
+    expect(restored[0].metadata.chunkCount).toBe(0);
+  });
+
+  it("skips malformed records instead of throwing (corruption recovery)", () => {
+    const serialized = serializeEmbeddingsIndex([makeVector("ok.md", [1, 0, 0])]);
+    // Corrupt the payload with junk a hand-edited / partially-synced file might contain.
+    (serialized.vectors as unknown[]).push({ id: "x", path: "bad.md", vector: "%%%not-base64" });
+    (serialized.vectors as unknown[]).push(null);
+    (serialized.vectors as unknown[]).push({ path: "no-id.md" });
+
+    const restored = deserializeEmbeddingsIndex(serialized);
+    expect(restored.map((v) => v.path)).toEqual(["ok.md"]);
+  });
+
+  it("fails safe (empty array) on unknown format or junk envelopes", () => {
+    expect(deserializeEmbeddingsIndex({ format: 999, vectors: [] } as never)).toEqual([]);
+    expect(deserializeEmbeddingsIndex(null as never)).toEqual([]);
+    expect(deserializeEmbeddingsIndex({} as never)).toEqual([]);
+    expect(deserializeEmbeddingsIndex({ format: 1, vectors: "nope" } as never)).toEqual([]);
+  });
+});

--- a/src/services/embeddings/storage/__tests__/EmbeddingsPortableIndex.test.ts
+++ b/src/services/embeddings/storage/__tests__/EmbeddingsPortableIndex.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import {
+  restoreEmbeddingsIndexIfEmpty,
+  writeEmbeddingsIndexSnapshot,
+  type PortableIndexFile,
+  type PortableIndexStore,
+} from "../EmbeddingsPortableIndex";
+import {
+  EMBEDDINGS_INDEX_FORMAT,
+  type SerializedEmbeddingsIndex,
+} from "../EmbeddingsIndexSerialization";
+
+function index(vectorCount: number): SerializedEmbeddingsIndex {
+  return { format: EMBEDDINGS_INDEX_FORMAT, createdAt: 1, vectorCount, vectors: [] };
+}
+
+function makeStore(overrides: Partial<PortableIndexStore> = {}): jest.Mocked<PortableIndexStore> {
+  return {
+    countVectors: jest.fn(async () => 0),
+    exportAll: jest.fn(async () => index(0)),
+    importAll: jest.fn(async () => ({ imported: 0 })),
+    ...overrides,
+  } as jest.Mocked<PortableIndexStore>;
+}
+
+function makeFile(overrides: Partial<PortableIndexFile> = {}): jest.Mocked<PortableIndexFile> {
+  return {
+    read: jest.fn(async () => null),
+    write: jest.fn(async () => undefined),
+    ...overrides,
+  } as jest.Mocked<PortableIndexFile>;
+}
+
+describe("restoreEmbeddingsIndexIfEmpty", () => {
+  it("imports the snapshot when the local store is empty", async () => {
+    const snapshot = index(5);
+    const store = makeStore({
+      countVectors: jest.fn(async () => 0),
+      importAll: jest.fn(async () => ({ imported: 5 })),
+    });
+    const file = makeFile({ read: jest.fn(async () => snapshot) });
+
+    const result = await restoreEmbeddingsIndexIfEmpty({ store, file });
+
+    expect(file.read).toHaveBeenCalledTimes(1);
+    expect(store.importAll).toHaveBeenCalledWith(snapshot);
+    expect(result).toEqual({ restored: true, imported: 5, reason: "restored" });
+  });
+
+  it("skips entirely when the store already has vectors", async () => {
+    const store = makeStore({ countVectors: jest.fn(async () => 42) });
+    const file = makeFile({ read: jest.fn(async () => index(5)) });
+
+    const result = await restoreEmbeddingsIndexIfEmpty({ store, file });
+
+    expect(file.read).not.toHaveBeenCalled();
+    expect(store.importAll).not.toHaveBeenCalled();
+    expect(result).toEqual({ restored: false, imported: 0, reason: "store-not-empty" });
+  });
+
+  it("skips when no snapshot file is present", async () => {
+    const store = makeStore({ countVectors: jest.fn(async () => 0) });
+    const file = makeFile({ read: jest.fn(async () => null) });
+
+    const result = await restoreEmbeddingsIndexIfEmpty({ store, file });
+
+    expect(store.importAll).not.toHaveBeenCalled();
+    expect(result).toEqual({ restored: false, imported: 0, reason: "no-snapshot" });
+  });
+
+  it("reports an empty/unusable snapshot without claiming a restore", async () => {
+    const store = makeStore({
+      countVectors: jest.fn(async () => 0),
+      importAll: jest.fn(async () => ({ imported: 0 })),
+    });
+    const file = makeFile({ read: jest.fn(async () => index(0)) });
+
+    const result = await restoreEmbeddingsIndexIfEmpty({ store, file });
+    expect(result).toEqual({ restored: false, imported: 0, reason: "empty-snapshot" });
+  });
+});
+
+describe("writeEmbeddingsIndexSnapshot", () => {
+  it("writes the exported index when it has vectors", async () => {
+    const exported = index(7);
+    const store = makeStore({ exportAll: jest.fn(async () => exported) });
+    const file = makeFile();
+
+    const result = await writeEmbeddingsIndexSnapshot({ store, file });
+
+    expect(file.write).toHaveBeenCalledWith(exported);
+    expect(result).toEqual({ written: true, count: 7 });
+  });
+
+  it("does not write an empty index (nothing to snapshot)", async () => {
+    const store = makeStore({ exportAll: jest.fn(async () => index(0)) });
+    const file = makeFile();
+
+    const result = await writeEmbeddingsIndexSnapshot({ store, file });
+
+    expect(file.write).not.toHaveBeenCalled();
+    expect(result).toEqual({ written: false, count: 0 });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -411,6 +411,12 @@ export interface SystemSculptSettings {
   embeddingsRateLimitPerMinute?: number; // Maximum requests per minute
   /** Quiet period after edits before re-embedding on modify events (ms) */
   embeddingsQuietPeriodMs?: number;
+  /**
+   * When true (default), persist a portable copy of the embedding index into the
+   * synced vault (`.systemsculpt/embeddings/`) so Obsidian Sync/backup restores
+   * it on a new device instead of re-embedding the whole vault.
+   */
+  embeddingsPortableIndex?: boolean;
   // Embeddings search behavior settings removed; use internal defaults
   
   /**
@@ -663,6 +669,7 @@ Raw transcript:`,
   embeddingsBatchSize: 20, // Optimized batch size for parallel processing
   embeddingsRateLimitPerMinute: 50, // Default rate limiting
   embeddingsQuietPeriodMs: 1200,
+  embeddingsPortableIndex: true,
   // Search behavior defaults removed; handled internally
   
   /**


### PR DESCRIPTION
**Part 1 of 4 for #208** ("embeddings portability + provider error handling"). This slice delivers the headline goal: an embedding index that survives a device move.

## Problem
The index lives in per-device IndexedDB whose DB name is scoped to a random per-install `vaultInstanceId`. IndexedDB sits in Obsidian's app profile, *outside* the vault, so Obsidian Sync/backup never captures it — every new device re-embeds (and re-pays for) the whole vault from scratch (Feb-2026 contact-form report). There is currently no export/import path.

## Approach
Vector records are already device-independent — `id`/`namespace` encode `provider:model:vSchema:dimension` with no device identity — so a snapshot needs **no remapping** on import. The only missing piece is a transport the synced vault can carry.

- **`EmbeddingsIndexSerialization`** (pure) — a versioned envelope. Float32 vectors are encoded as explicit **little-endian** bytes + base64 so the snapshot round-trips byte-for-byte across platforms. Deserialize **fails safe**: unknown format / junk envelope → `[]` (caller re-embeds); individual malformed records are skipped, never thrown (a partially-synced or hand-edited file can't crash startup).
- **`EmbeddingsIndexFile`** — reads/writes `.systemsculpt/embeddings/index.json` via Obsidian's `DataAdapter` (the mobile-safe path; **no `node:fs`**), alongside the existing `.systemsculpt/diagnostics`.
- **`EmbeddingsStorage.exportAll/importAll`** — thin serialize/deserialize over `getAllVectors`/`storeVectors`.
- **`EmbeddingsPortableIndex`** — the restore/snapshot decision logic, dependency-light so it's unit-testable: restore **only** into an empty store (a populated store always wins, mirroring the existing legacy-DB import guard); never write an empty snapshot.
- **`EmbeddingsManager`** — restore on `initialize()` *before* the legacy-DB migration (a synced snapshot beats stale per-device legacy data), and a debounced snapshot write after a successful vault process. Best-effort throughout; timer cleared in `cleanup()` (#214 hygiene). Gated by a new `embeddingsPortableIndex` setting (**default on**).

No new services, no IndexedDB schema bump. The new modules stay within the embeddings tree's no-eager-node-import boundary.

## Tests (failing-first)
- `EmbeddingsIndexSerialization` — float32 round-trip fidelity, empty-vector preservation, malformed-record recovery, fail-safe on bad envelopes.
- `EmbeddingsIndexFile` — write/read round-trip + `mkdir`, null on missing, null on corrupt JSON.
- `EmbeddingsPortableIndex` — restore-when-empty / skip-when-populated / skip-when-absent; write-when-nonempty / skip-when-empty.
- `EmbeddingsStorage.portableIndex` — exportAll/importAll wiring.
- `EmbeddingsManager.portableIndex` — init restores when enabled, skips when the setting is off.

Local gates green: `check:plugin:fast`; `npm test` (404 suites / 5609); `test:embeddings` (19 / 229); `test:integration` (21/21, incl. `bundle-load.no-node` + `bundle-load.mobile` — confirms no Node creeps into the embeddings tree).

Follow-ups under #208: provider adapter layer + typed errors (#179/#153), adapter retry/backoff (#150), rate-limit-aware checkpoint/resume (#127).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added portable embeddings index that automatically syncs and restores embeddings across devices when switching devices. New `embeddingsPortableIndex` setting controls this feature (enabled by default).

* **Tests**
  * Added comprehensive test coverage for embeddings index export, import, and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->