### PR TITLE
feat(embeddings): typed provider errors + robust response parsing (#208)

### DIFF
--- a/jest.embeddings.config.cjs
+++ b/jest.embeddings.config.cjs
@@ -10,7 +10,10 @@ module.exports = {
 	roots: ['<rootDir>/src'],
 	testMatch: [
 		'**/__tests__/**/Embeddings*.test.ts',
-		'services/embeddings/**/__tests__/**/*.test.ts'
+		// Match the whole embeddings tree by path (not just `Embeddings*`-named
+		// files). The previous glob lacked a `<rootDir>` anchor, so it silently
+		// matched nothing and tests like providers/__tests__ went unrun.
+		'<rootDir>/src/services/embeddings/**/__tests__/**/*.test.ts'
 	],
 	moduleNameMapper: {
 		'^obsidian$': '<rootDir>/src/tests/mocks/obsidian.js',

--- a/src/services/__tests__/CustomProvider.typedErrors.test.ts
+++ b/src/services/__tests__/CustomProvider.typedErrors.test.ts
@@ -1,0 +1,147 @@
+jest.mock("../../utils/httpClient", () => ({
+  httpRequest: jest.fn(),
+}));
+
+const { httpRequest } = require("../../utils/httpClient") as {
+  httpRequest: jest.Mock;
+};
+
+import { CustomProvider } from "../embeddings/providers/CustomProvider";
+import {
+  EmbeddingsProviderError,
+  isEmbeddingsProviderError,
+} from "../embeddings/providers/ProviderError";
+
+const ENDPOINT = "http://localhost:1234/v1/embeddings";
+
+function provider() {
+  return new CustomProvider({
+    endpoint: ENDPOINT,
+    apiKey: "",
+    model: "text-embedding-3-small",
+  });
+}
+
+async function capture(p: Promise<unknown>): Promise<EmbeddingsProviderError> {
+  try {
+    await p;
+  } catch (error) {
+    if (isEmbeddingsProviderError(error)) return error;
+    throw new Error(`expected EmbeddingsProviderError, got: ${String(error)}`);
+  }
+  throw new Error("expected the call to reject");
+}
+
+describe("CustomProvider — response-shape coverage (#153)", () => {
+  beforeEach(() => httpRequest.mockReset());
+
+  it("accepts LM Studio's top-level singular `{embedding: [...]}`", async () => {
+    httpRequest.mockResolvedValue({
+      status: 200,
+      text: JSON.stringify({ embedding: [0.1, 0.2, 0.3] }),
+    });
+
+    const result = await provider().generateEmbeddings(["hello"]);
+    expect(result).toEqual([[0.1, 0.2, 0.3]]);
+  });
+
+  it("accepts a top-level plural `{embeddings: [[...]]}`", async () => {
+    httpRequest.mockResolvedValue({
+      status: 200,
+      text: JSON.stringify({
+        embeddings: [
+          [0.1, 0.2],
+          [0.3, 0.4],
+        ],
+      }),
+    });
+
+    const result = await provider().generateEmbeddings(["a", "b"]);
+    expect(result).toEqual([
+      [0.1, 0.2],
+      [0.3, 0.4],
+    ]);
+  });
+
+  it("throws a typed UNEXPECTED_RESPONSE on an unrecognized 200 body", async () => {
+    httpRequest.mockResolvedValue({
+      status: 200,
+      text: JSON.stringify({ unexpected: "format" }),
+    });
+
+    const err = await capture(provider().generateEmbeddings(["hello"]));
+    expect(err.code).toBe("UNEXPECTED_RESPONSE");
+    // Preserve the legacy message so the original suite stays green.
+    expect(err.message).toContain("Unsupported response format from custom endpoint");
+  });
+});
+
+describe("CustomProvider — typed HTTP errors", () => {
+  beforeEach(() => httpRequest.mockReset());
+
+  it("classifies 429 as transient RATE_LIMITED with Retry-After", async () => {
+    httpRequest.mockResolvedValue({
+      status: 429,
+      text: JSON.stringify({ error: { message: "slow down" } }),
+      headers: { "retry-after": "3" },
+    });
+
+    const err = await capture(provider().generateEmbeddings(["hello"]));
+    expect(err.code).toBe("RATE_LIMITED");
+    expect(err.transient).toBe(true);
+    expect(err.status).toBe(429);
+    expect(err.retryInMs).toBe(3000);
+    // Legacy message format preserved.
+    expect(err.message).toContain("Custom API error 429: slow down");
+  });
+
+  it("classifies 5xx as transient HTTP_ERROR", async () => {
+    httpRequest.mockResolvedValue({
+      status: 503,
+      text: "Service temporarily unavailable",
+    });
+
+    const err = await capture(provider().generateEmbeddings(["hello"]));
+    expect(err.code).toBe("HTTP_ERROR");
+    expect(err.transient).toBe(true);
+    expect(err.status).toBe(503);
+  });
+
+  it("classifies other 4xx as permanent HTTP_ERROR", async () => {
+    httpRequest.mockResolvedValue({
+      status: 400,
+      text: JSON.stringify({ error: { message: "bad request" } }),
+    });
+
+    const err = await capture(provider().generateEmbeddings(["hello"]));
+    expect(err.code).toBe("HTTP_ERROR");
+    expect(err.transient).toBe(false);
+    expect(err.status).toBe(400);
+  });
+
+  it("wraps a transport failure as a transient NETWORK_ERROR", async () => {
+    httpRequest.mockRejectedValue(new Error("Connection refused"));
+
+    const err = await capture(provider().generateEmbeddings(["hello"]));
+    expect(err.code).toBe("NETWORK_ERROR");
+    expect(err.transient).toBe(true);
+    expect(err.message).toContain("Connection refused");
+  });
+
+  it("does not double-wrap an EmbeddingsProviderError thrown from the Ollama path", async () => {
+    // /api/embeddings -> Ollama path; an unrecognized body must surface as a
+    // typed error, not be re-wrapped as NETWORK_ERROR by the outer catch.
+    httpRequest.mockResolvedValue({
+      status: 200,
+      text: JSON.stringify({ nope: true }),
+    });
+    const ollama = new CustomProvider({
+      endpoint: "http://localhost:11434/api/embeddings",
+      apiKey: "",
+      model: "nomic-embed-text",
+    });
+
+    const err = await capture(ollama.generateEmbeddings(["hello"]));
+    expect(err.code).toBe("UNEXPECTED_RESPONSE");
+  });
+});

--- a/src/services/__tests__/SystemSculptProvider.modelParam.test.ts
+++ b/src/services/__tests__/SystemSculptProvider.modelParam.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression guard for #179: the SystemSculpt managed embeddings endpoint runs
+ * server-controlled inference and rejects a client-supplied `model` with
+ * "API error 400 ... unsupported parameter model". The provider must therefore
+ * send only the supported contract fields (`texts`, `inputType`) and never a
+ * `model` in the request body.
+ */
+jest.mock("../../utils/httpClient", () => ({
+  httpRequest: jest.fn(),
+  isHostTemporarilyDisabled: jest.fn(() => ({ disabled: false, retryInMs: 0 })),
+}));
+
+jest.mock("../../utils/errorLogger", () => ({
+  errorLogger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const { httpRequest } = require("../../utils/httpClient") as {
+  httpRequest: jest.Mock;
+};
+
+import { SystemSculptProvider } from "../embeddings/providers/SystemSculptProvider";
+
+describe("SystemSculptProvider request body (#179 guard)", () => {
+  beforeEach(() => httpRequest.mockReset());
+
+  it("never sends a `model` field to the managed endpoint", async () => {
+    httpRequest.mockResolvedValue({
+      status: 200,
+      text: JSON.stringify({ embeddings: [[0.1, 0.2, 0.3]] }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const provider = new SystemSculptProvider("test-license");
+    await provider.generateEmbeddings(["hello world"]);
+
+    expect(httpRequest).toHaveBeenCalled();
+    const body = JSON.parse(httpRequest.mock.calls[0][0].body);
+    expect(body).not.toHaveProperty("model");
+    expect(body.texts).toEqual(["hello world"]);
+    expect(body.inputType).toBe("document");
+  });
+});

--- a/src/services/embeddings/providers/CustomProvider.ts
+++ b/src/services/embeddings/providers/CustomProvider.ts
@@ -1,15 +1,24 @@
 /**
  * CustomProvider - User-configurable embeddings provider
- * 
+ *
  * Supports any OpenAI-compatible embeddings API:
  * - OpenAI API
  * - Azure OpenAI
- * - Local embeddings servers
+ * - Local embeddings servers (LM Studio, Ollama, ...)
  * - Other compatible providers
+ *
+ * Response parsing is delegated to the shared `normalizeEmbeddingsResponse` so
+ * every server shape (OpenAI `data[]`, top-level `{embedding}`/`{embeddings}`,
+ * raw arrays) is handled in one tested place (#153), and every failure is raised
+ * as a typed `EmbeddingsProviderError` so callers can tell a transient 429/5xx
+ * apart from a permanent 4xx (#150, and the retry/backoff slice that follows).
  */
 
 import { httpRequest } from '../../../utils/httpClient';
 import { EmbeddingsProvider, EmbeddingsGenerateOptions } from '../types';
+import { normalizeEmbeddingsResponse } from './embeddingResponse';
+import { EmbeddingsProviderError, isEmbeddingsProviderError } from './ProviderError';
+import { buildHttpErrorOptions } from './providerHttpErrors';
 
 export interface CustomProviderConfig {
   endpoint: string;
@@ -25,7 +34,7 @@ export class CustomProvider implements EmbeddingsProvider {
   readonly supportsModels = true;
   public readonly model: string | undefined;
   public expectedDimension: number | undefined;
-  
+
   private readonly maxBatchSize: number;
   private readonly headers: Record<string, string>;
   private readonly isOllamaStyle: boolean;
@@ -36,7 +45,7 @@ export class CustomProvider implements EmbeddingsProvider {
       'Content-Type': 'application/json',
       ...config.headers
     };
-    
+
     if (config.apiKey) {
       this.headers['Authorization'] = `Bearer ${config.apiKey}`;
     }
@@ -65,59 +74,10 @@ export class CustomProvider implements EmbeddingsProvider {
       return this.generateEmbeddingsInBatches(texts, options?.inputType);
     }
 
-    try {
-      if (this.isOllamaStyle) {
-        return this.processOllamaParallel(texts, endpoint, model, options);
-      } else {
-        // OpenAI-compatible batch embeddings
-        const response = await httpRequest({
-          url: endpoint,
-          method: 'POST',
-          headers: this.headers,
-          body: JSON.stringify({
-            input: texts,
-            model,
-            encoding_format: 'float',
-            input_type: options?.inputType === 'query' ? 'query' : 'document'
-          })
-        });
-
-        if (!response.status || response.status !== 200) {
-          const errorMessage = await this.parseErrorResponse(response as any);
-          throw new Error(`Custom API error ${response.status}: ${errorMessage}`);
-        }
-
-        const data = response.json ?? JSON.parse(response.text || '{}');
-        
-        // Handle OpenAI-style response
-        if (data.data && Array.isArray(data.data)) {
-          const embeddings = data.data
-            .sort((a: any, b: any) => a.index - b.index)
-            .map((item: any) => item.embedding);
-          
-          const sample = embeddings[0];
-          const dim = Array.isArray(sample) ? sample.length : undefined;
-          if (typeof dim === 'number' && dim > 0) {
-            this.expectedDimension = dim;
-          }
-          
-          return embeddings;
-        }
-        
-        // Handle direct array response
-        if (Array.isArray(data) && data.length > 0 && Array.isArray(data[0])) {
-          const dim = data[0].length;
-          if (typeof dim === 'number' && dim > 0) {
-            this.expectedDimension = dim;
-          }
-          return data;
-        }
-
-        throw new Error('Unsupported response format from custom endpoint');
-      }
-    } catch (error) {
-      throw error;
+    if (this.isOllamaStyle) {
+      return this.processOllamaParallel(texts, endpoint, model, options);
     }
+    return this.processOpenAiBatch(texts, endpoint, model, options);
   }
 
   async validateConfiguration(): Promise<boolean> {
@@ -148,16 +108,59 @@ export class CustomProvider implements EmbeddingsProvider {
       'text-embedding-004',
       'text-embedding-004-multilingual'
     ];
-    
+
     if (this.config.model && !commonModels.includes(this.config.model)) {
       return [this.config.model, ...commonModels];
     }
-    
+
     return commonModels;
   }
 
   getMaxBatchSize(): number {
     return this.maxBatchSize;
+  }
+
+  /** OpenAI-compatible batch embeddings (one request for the whole batch). */
+  private async processOpenAiBatch(
+    texts: string[],
+    endpoint: string,
+    model: string,
+    options?: EmbeddingsGenerateOptions
+  ): Promise<number[][]> {
+    let response;
+    try {
+      response = await httpRequest({
+        url: endpoint,
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify({
+          input: texts,
+          model,
+          encoding_format: 'float',
+          input_type: options?.inputType === 'query' ? 'query' : 'document'
+        })
+      });
+    } catch (error) {
+      throw this.toNetworkError(error, endpoint);
+    }
+
+    if (!response.status || response.status !== 200) {
+      throw await this.toHttpError(response, endpoint);
+    }
+
+    const data = response.json ?? this.safeParseJson(response.text);
+    const vectors = normalizeEmbeddingsResponse(data);
+    if (!vectors) {
+      throw new EmbeddingsProviderError('Unsupported response format from custom endpoint', {
+        code: 'UNEXPECTED_RESPONSE',
+        providerId: this.id,
+        endpoint,
+        details: { shape: this.describeShape(data) }
+      });
+    }
+
+    this.recordDimension(vectors);
+    return vectors;
   }
 
   private async generateEmbeddingsInBatches(texts: string[], inputType?: 'document' | 'query'): Promise<number[][]> {
@@ -185,33 +188,37 @@ export class CustomProvider implements EmbeddingsProvider {
     let firstError: Error | null = null;
 
     const processOne = async (index: number, text: string): Promise<void> => {
-      const response = await httpRequest({
-        url: endpoint,
-        method: 'POST',
-        headers: this.headers,
-        body: JSON.stringify({
-          model,
-          prompt: text,
-          task_type: options?.inputType === 'query' ? 'retrieval_query' : 'retrieval_document'
-        })
-      });
+      let response;
+      try {
+        response = await httpRequest({
+          url: endpoint,
+          method: 'POST',
+          headers: this.headers,
+          body: JSON.stringify({
+            model,
+            prompt: text,
+            task_type: options?.inputType === 'query' ? 'retrieval_query' : 'retrieval_document'
+          })
+        });
+      } catch (error) {
+        throw this.toNetworkError(error, endpoint);
+      }
 
       if (!response.status || response.status !== 200) {
-        const errorMessage = await this.parseErrorResponse(response as any);
-        throw new Error(`Custom API error ${response.status}: ${errorMessage}`);
+        throw await this.toHttpError(response, endpoint);
       }
 
-      const data = response.json ?? JSON.parse(response.text || '{}');
-      let embedding: number[] | undefined;
-
-      if (Array.isArray(data?.embedding)) {
-        embedding = data.embedding;
-      } else if (Array.isArray(data?.data) && Array.isArray(data.data[0]?.embedding)) {
-        embedding = data.data[0].embedding;
-      }
+      const data = response.json ?? this.safeParseJson(response.text);
+      const vectors = normalizeEmbeddingsResponse(data);
+      const embedding = vectors?.[0];
 
       if (!embedding) {
-        throw new Error('Unsupported response format from Ollama endpoint');
+        throw new EmbeddingsProviderError('Unsupported response format from Ollama endpoint', {
+          code: 'UNEXPECTED_RESPONSE',
+          providerId: this.id,
+          endpoint,
+          details: { shape: this.describeShape(data) }
+        });
       }
 
       if (!this.expectedDimension && embedding.length > 0) {
@@ -244,15 +251,69 @@ export class CustomProvider implements EmbeddingsProvider {
     return results.sort((a, b) => a.index - b.index).map(r => r.embedding);
   }
 
+  /** Adopt the observed dimension from the first vector for downstream validation. */
+  private recordDimension(vectors: number[][]): void {
+    const dim = vectors[0]?.length;
+    if (typeof dim === 'number' && dim > 0) {
+      this.expectedDimension = dim;
+    }
+  }
+
+  /** Build a typed error for a non-200 HTTP response, preserving the legacy message. */
+  private async toHttpError(response: any, endpoint: string): Promise<EmbeddingsProviderError> {
+    const errorMessage = await this.parseErrorResponse(response);
+    return new EmbeddingsProviderError(
+      `Custom API error ${response.status}: ${errorMessage}`,
+      buildHttpErrorOptions({
+        status: response.status || 0,
+        headers: response.headers,
+        providerId: this.id,
+        endpoint,
+        details: { body: errorMessage.slice(0, 500) }
+      })
+    );
+  }
+
+  /** Wrap a transport-level failure as a transient NETWORK_ERROR (never double-wrap). */
+  private toNetworkError(error: unknown, endpoint: string): EmbeddingsProviderError {
+    if (isEmbeddingsProviderError(error)) {
+      return error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return new EmbeddingsProviderError(message, {
+      code: 'NETWORK_ERROR',
+      transient: true,
+      providerId: this.id,
+      endpoint,
+      cause: error
+    });
+  }
+
+  private safeParseJson(text?: string): unknown {
+    try {
+      return JSON.parse(text || '{}');
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** A compact, non-sensitive description of a response shape for error diagnostics. */
+  private describeShape(data: unknown): string {
+    if (data == null) return String(data);
+    if (Array.isArray(data)) return `array[${data.length}]`;
+    if (typeof data === 'object') return `object{${Object.keys(data as object).join(',')}}`;
+    return typeof data;
+  }
+
   private async parseErrorResponse(response: any): Promise<string> {
     try {
       const errorData = JSON.parse(response.text);
-      
+
       // Common error formats
       if (errorData.error?.message) return errorData.error.message;
       if (errorData.message) return errorData.message;
       if (errorData.detail) return errorData.detail;
-      
+
       return response.text;
     } catch {
       return response.text || 'Unknown error';

--- a/src/services/embeddings/providers/__tests__/embeddingResponse.test.ts
+++ b/src/services/embeddings/providers/__tests__/embeddingResponse.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "@jest/globals";
+import { normalizeEmbeddingsResponse } from "../embeddingResponse";
+
+describe("normalizeEmbeddingsResponse", () => {
+  it("reads the OpenAI/LM Studio `data: [{embedding,index}]` batch shape", () => {
+    const out = normalizeEmbeddingsResponse({
+      data: [
+        { index: 0, embedding: [0.1, 0.2] },
+        { index: 1, embedding: [0.3, 0.4] },
+      ],
+    });
+    expect(out).toEqual([
+      [0.1, 0.2],
+      [0.3, 0.4],
+    ]);
+  });
+
+  it("sorts the `data[]` shape by index when every item is indexed", () => {
+    const out = normalizeEmbeddingsResponse({
+      data: [
+        { index: 2, embedding: [3] },
+        { index: 0, embedding: [1] },
+        { index: 1, embedding: [2] },
+      ],
+    });
+    expect(out).toEqual([[1], [2], [3]]);
+  });
+
+  it("preserves order for the `data[]` shape when index is absent", () => {
+    const out = normalizeEmbeddingsResponse({
+      data: [{ embedding: [1] }, { embedding: [2] }],
+    });
+    expect(out).toEqual([[1], [2]]);
+  });
+
+  it("reads a top-level singular `{embedding: [...]}` (LM Studio single -> #153)", () => {
+    const out = normalizeEmbeddingsResponse({ embedding: [0.5, 0.6, 0.7] });
+    expect(out).toEqual([[0.5, 0.6, 0.7]]);
+  });
+
+  it("reads a top-level plural `{embeddings: [[...]]}`", () => {
+    const out = normalizeEmbeddingsResponse({
+      embeddings: [
+        [1, 2],
+        [3, 4],
+      ],
+    });
+    expect(out).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it("reads a raw 2D array response", () => {
+    const out = normalizeEmbeddingsResponse([
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(out).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it("wraps a raw single vector `[...]` into a 2D array", () => {
+    expect(normalizeEmbeddingsResponse([1, 2, 3])).toEqual([[1, 2, 3]]);
+  });
+
+  it("returns null for unrecognized shapes (caller throws UNEXPECTED_RESPONSE)", () => {
+    expect(normalizeEmbeddingsResponse({ unexpected: "format" })).toBeNull();
+    expect(normalizeEmbeddingsResponse(null)).toBeNull();
+    expect(normalizeEmbeddingsResponse("nope")).toBeNull();
+    expect(normalizeEmbeddingsResponse({ data: [] })).toBeNull();
+    expect(normalizeEmbeddingsResponse({ embedding: "%%%" })).toBeNull();
+    // A base64 embedding payload is not a number[] -> unrecognized (out of scope).
+    expect(
+      normalizeEmbeddingsResponse({ data: [{ index: 0, embedding: "AACAPw==" }] }),
+    ).toBeNull();
+  });
+
+  it("rejects non-finite values rather than emitting NaN vectors", () => {
+    expect(
+      normalizeEmbeddingsResponse({ data: [{ index: 0, embedding: [1, NaN] }] }),
+    ).toBeNull();
+  });
+});

--- a/src/services/embeddings/providers/__tests__/providerHttpErrors.test.ts
+++ b/src/services/embeddings/providers/__tests__/providerHttpErrors.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  buildHttpErrorOptions,
+  classifyEmbeddingsHttpStatus,
+  parseRetryAfterMs,
+} from "../providerHttpErrors";
+
+describe("classifyEmbeddingsHttpStatus", () => {
+  it("classifies 429 as a transient rate-limit", () => {
+    const c = classifyEmbeddingsHttpStatus(429);
+    expect(c.code).toBe("RATE_LIMITED");
+    expect(c.transient).toBe(true);
+  });
+
+  it("carries Retry-After (seconds) into retryInMs for a 429", () => {
+    const c = classifyEmbeddingsHttpStatus(429, { "retry-after": "2" });
+    expect(c.retryInMs).toBe(2000);
+  });
+
+  it("classifies 5xx and 408 as transient HTTP errors", () => {
+    expect(classifyEmbeddingsHttpStatus(500)).toMatchObject({
+      code: "HTTP_ERROR",
+      transient: true,
+    });
+    expect(classifyEmbeddingsHttpStatus(503).transient).toBe(true);
+    expect(classifyEmbeddingsHttpStatus(408).transient).toBe(true);
+  });
+
+  it("treats a missing/zero status as transient (no usable response)", () => {
+    expect(classifyEmbeddingsHttpStatus(0)).toMatchObject({
+      code: "HTTP_ERROR",
+      transient: true,
+    });
+  });
+
+  it("classifies other 4xx as permanent HTTP errors", () => {
+    expect(classifyEmbeddingsHttpStatus(400)).toMatchObject({
+      code: "HTTP_ERROR",
+      transient: false,
+    });
+    expect(classifyEmbeddingsHttpStatus(401).transient).toBe(false);
+    expect(classifyEmbeddingsHttpStatus(422).transient).toBe(false);
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  it("parses integer seconds (case-insensitive header key)", () => {
+    expect(parseRetryAfterMs({ "Retry-After": "5" })).toBe(5000);
+    expect(parseRetryAfterMs({ "retry-after": "0" })).toBe(0);
+  });
+
+  it("returns undefined for missing / non-numeric / negative values", () => {
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs({})).toBeUndefined();
+    expect(parseRetryAfterMs({ "retry-after": "Wed, 21 Oct 2026 07:28:00 GMT" })).toBeUndefined();
+    expect(parseRetryAfterMs({ "retry-after": "-3" })).toBeUndefined();
+  });
+});
+
+describe("buildHttpErrorOptions", () => {
+  it("merges classification with provider/endpoint context", () => {
+    const opts = buildHttpErrorOptions({
+      status: 429,
+      headers: { "retry-after": "1" },
+      providerId: "custom",
+      endpoint: "http://host/v1/embeddings",
+      details: { sample: "x" },
+    });
+    expect(opts).toMatchObject({
+      code: "RATE_LIMITED",
+      status: 429,
+      transient: true,
+      retryInMs: 1000,
+      providerId: "custom",
+      endpoint: "http://host/v1/embeddings",
+      details: { sample: "x" },
+    });
+  });
+});

--- a/src/services/embeddings/providers/embeddingResponse.ts
+++ b/src/services/embeddings/providers/embeddingResponse.ts
@@ -1,0 +1,92 @@
+/**
+ * embeddingResponse - a single, robust normalizer for the many shapes that
+ * OpenAI-compatible (and not-quite-compatible) embedding endpoints return.
+ *
+ * Different servers wrap embeddings differently, and the divergence is the root
+ * cause of #153 (LM Studio "Unsupported response format"): LM Studio's
+ * `/v1/embeddings` can answer with a top-level `{ embedding: [...] }` /
+ * `{ embeddings: [...] }` instead of OpenAI's `{ data: [{ embedding }] }`, and
+ * the old inline parser only recognized the `data[]` and raw-2D-array shapes.
+ *
+ * Centralizing the shape handling here (pure, no I/O) means every provider gets
+ * the same coverage and new shapes are added in one tested place rather than
+ * re-discovered per endpoint.
+ *
+ * Returns a 2D number array (one vector per input, in order) or `null` when the
+ * payload matches no known shape — the caller turns `null` into a typed
+ * UNEXPECTED_RESPONSE error so the failure is classifiable rather than silent.
+ */
+
+/** True when `value` is a non-empty array whose every element is a finite number. */
+function isNumberVector(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((n) => typeof n === "number" && Number.isFinite(n))
+  );
+}
+
+/** Extract the `data: [{ embedding, index }]` (OpenAI / LM Studio batch) shape. */
+function fromOpenAiList(data: Record<string, unknown>): number[][] | null {
+  const list = data.data;
+  if (!Array.isArray(list) || list.length === 0) return null;
+
+  const items = list as Array<Record<string, unknown>>;
+  // Only trust `index` for ordering when every item carries a numeric one;
+  // some servers omit it, and a partial sort would scramble the results.
+  const allIndexed = items.every((item) => typeof item.index === "number");
+  const ordered = allIndexed
+    ? [...items].sort((a, b) => (a.index as number) - (b.index as number))
+    : items;
+
+  const vectors: number[][] = [];
+  for (const item of ordered) {
+    if (!isNumberVector(item.embedding)) return null;
+    vectors.push(item.embedding);
+  }
+  return vectors;
+}
+
+/**
+ * Normalize an embeddings response body into a 2D array of vectors, or `null`
+ * when the shape is unrecognized. Handles, in order:
+ *  - OpenAI / LM Studio batch:   `{ data: [{ embedding, index }] }`
+ *  - top-level plural:           `{ embeddings: [[...], ...] }`
+ *  - top-level singular:         `{ embedding: [...] }`              (LM Studio / Ollama single)
+ *  - raw 2D array:               `[[...], [...]]`
+ *  - raw single vector:          `[...]`
+ */
+export function normalizeEmbeddingsResponse(data: unknown): number[][] | null {
+  if (data == null) return null;
+
+  if (typeof data === "object" && !Array.isArray(data)) {
+    const obj = data as Record<string, unknown>;
+
+    const fromList = fromOpenAiList(obj);
+    if (fromList) return fromList;
+
+    // `{ embeddings: [[...]] }` — plural top-level (some OpenAI-compatible
+    // servers, and the SystemSculpt managed contract).
+    if (Array.isArray(obj.embeddings)) {
+      const rows = obj.embeddings as unknown[];
+      if (rows.length > 0 && rows.every(isNumberVector)) return rows as number[][];
+      return null;
+    }
+
+    // `{ embedding: [...] }` — singular top-level (LM Studio / Ollama single
+    // input). This is the shape the old parser missed -> #153.
+    if (isNumberVector(obj.embedding)) return [obj.embedding];
+
+    return null;
+  }
+
+  if (Array.isArray(data)) {
+    // Raw 2D array: `[[...], [...]]`.
+    if (data.length > 0 && data.every(isNumberVector)) return data as number[][];
+    // Raw single vector: `[...]` of numbers.
+    if (isNumberVector(data)) return [data];
+    return null;
+  }
+
+  return null;
+}

--- a/src/services/embeddings/providers/providerHttpErrors.ts
+++ b/src/services/embeddings/providers/providerHttpErrors.ts
@@ -1,0 +1,92 @@
+/**
+ * providerHttpErrors - pure classification of an HTTP failure from a custom
+ * embeddings endpoint into the typed `EmbeddingsProviderError` shape.
+ *
+ * Before #208 the CustomProvider threw plain `Error("Custom API error 429: ...")`
+ * strings, so the manager (and the retry/backoff work in the next slice) could
+ * not tell a transient 429/503 apart from a permanent 400 — every failure looked
+ * the same. This maps a status code to {code, transient, retryInMs} so callers
+ * can decide whether to retry, and how long to wait, from typed fields instead
+ * of regex-matching messages.
+ */
+
+import type {
+  EmbeddingsProviderErrorCode,
+  EmbeddingsProviderErrorOptions,
+} from "./ProviderError";
+
+export interface EmbeddingsHttpClassification {
+  code: EmbeddingsProviderErrorCode;
+  transient: boolean;
+  retryInMs?: number;
+}
+
+/**
+ * Parse a `Retry-After` header value (case-insensitive lookup by the caller)
+ * into milliseconds. Embedding APIs send integer seconds; the HTTP-date form is
+ * not parsed here (kept pure / Date-free) and yields `undefined`.
+ */
+export function parseRetryAfterMs(
+  headers?: Record<string, string>,
+): number | undefined {
+  if (!headers) return undefined;
+  let raw: string | undefined;
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === "retry-after") {
+      raw = value;
+      break;
+    }
+  }
+  if (raw == null) return undefined;
+  const seconds = Number(String(raw).trim());
+  if (!Number.isFinite(seconds) || seconds < 0) return undefined;
+  return Math.round(seconds * 1000);
+}
+
+/**
+ * Classify an HTTP status (and optional headers) from a custom endpoint.
+ *  - 429            -> RATE_LIMITED, transient, retryInMs from Retry-After
+ *  - 408 / >= 500   -> HTTP_ERROR, transient (timeouts and server faults retry)
+ *  - other          -> HTTP_ERROR, permanent (4xx client errors do not retry)
+ */
+export function classifyEmbeddingsHttpStatus(
+  status: number,
+  headers?: Record<string, string>,
+): EmbeddingsHttpClassification {
+  if (status === 429) {
+    return {
+      code: "RATE_LIMITED",
+      transient: true,
+      retryInMs: parseRetryAfterMs(headers),
+    };
+  }
+  // <= 0 means the transport gave us no usable status (treat as retryable);
+  // 408 (timeout) and 5xx (server fault) are transient too.
+  if (status <= 0 || status === 408 || status >= 500) {
+    return { code: "HTTP_ERROR", transient: true };
+  }
+  return { code: "HTTP_ERROR", transient: false };
+}
+
+/**
+ * Build the `EmbeddingsProviderError` options for a failed custom-endpoint HTTP
+ * call, merging the status classification with provider/endpoint context.
+ */
+export function buildHttpErrorOptions(args: {
+  status: number;
+  headers?: Record<string, string>;
+  providerId: string;
+  endpoint: string;
+  details?: Record<string, unknown>;
+}): EmbeddingsProviderErrorOptions {
+  const classification = classifyEmbeddingsHttpStatus(args.status, args.headers);
+  return {
+    code: classification.code,
+    status: args.status,
+    transient: classification.transient,
+    retryInMs: classification.retryInMs,
+    providerId: args.providerId,
+    endpoint: args.endpoint,
+    details: args.details,
+  };
+}


### PR DESCRIPTION
**Part 2 of 4 for #208** — the provider error/response layer. (Part 1 #261 made the index portable.)

## Problem
The managed `SystemSculptProvider` was already canonical (typed `EmbeddingsProviderError`, retry-aware, server-controlled model). The user-configurable `CustomProvider` lagged and owned two reported failures:

- **#153** (LM Studio *"Unsupported response format"*): the inline parser recognized only OpenAI's `{ data: [{ embedding }] }` and a raw 2D array. LM Studio's `/v1/embeddings` can answer with a **top-level `{ embedding: [...] }` / `{ embeddings: [...] }`**, which fell straight through to the error.
- **#150 / #127** (rate-limit & transient handling): `CustomProvider` threw plain `Error("Custom API error 429: …")` strings, so the manager — and the retry/backoff slice that follows — couldn't tell a transient 429/5xx from a permanent 4xx. Every failure looked identical.

## Approach — two shared, pure, tested modules
Rather than re-derive response shapes per endpoint, the providers now share:

- **`embeddingResponse.normalizeEmbeddingsResponse(data)`** → one normalizer for every known shape (OpenAI `data[]` with/without `index`, top-level `{embedding}`/`{embeddings}`, raw 2D array, raw single vector) → `number[][]` or `null`. Fixes **#153**.
- **`providerHttpErrors`** → `classifyEmbeddingsHttpStatus` / `parseRetryAfterMs` / `buildHttpErrorOptions`: map an HTTP status (+ `Retry-After`) to the typed error fields. `429 → RATE_LIMITED` transient with `retryInMs`; `408/<=0/5xx → HTTP_ERROR` transient; other `4xx → HTTP_ERROR` permanent. Unblocks **#150** and the retry slice (PR-3).

`CustomProvider` routes all parsing through the normalizer and raises typed `EmbeddingsProviderError` on every failure path (HTTP; transport → `NETWORK_ERROR` without double-wrapping; unrecognized body → `UNEXPECTED_RESPONSE`). **User-facing messages are preserved verbatim** (`Custom API error <status>: …`, `Unsupported response format …`) so the existing 30+ `CustomProvider` tests stay green while the errors gain classification. `SystemSculptProvider` is untouched (already conformant).

## Guards (failing-test-first)
- **#179 regression guard** — `SystemSculptProvider` must never send `model` to the managed (server-controlled) endpoint. The fix already shipped; this locks it permanently (`SystemSculptProvider.modelParam.test.ts`).
- New unit coverage for both pure modules, incl. the LM Studio singular-shape case (#153) and the `429`/`Retry-After` path.
- Also repaired a **latent `jest.embeddings.config.cjs` bug**: the second `testMatch` glob lacked a `<rootDir>` anchor and silently matched nothing, so embeddings tests not named `Embeddings*` (e.g. `providers/__tests__`) went unrun. Anchored it — the embeddings lane now covers the whole tree by path (19→21 suites).

## Gates
`check:plugin:fast`; `npm test` (406 suites / 5618); `test:embeddings` (21 / 246); `test:integration` (21/21, incl. `bundle-load.no-node` + `.mobile` — the new modules stay Node-free).

Follow-ups under #208: adapter-level retry/backoff for transient + 429 (PR-3, #150), rate-limit-aware checkpoint/resume (PR-4, #127).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed embeddings test discovery pattern to ensure all provider tests execute correctly.
  * Enhanced error classification for embeddings providers with proper handling of rate-limit responses and HTTP failures.

* **Improvements**
  * Improved embeddings response parsing to support multiple response formats from different providers.
  * Added retry-after header support for rate-limited requests.

* **Tests**
  * Added comprehensive test coverage for embeddings provider error handling and response normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->