### PR TITLE
feat(embeddings): retry transient provider errors with backoff (#208)

### DIFF
--- a/src/services/__tests__/EmbeddingsProcessor.retry.test.ts
+++ b/src/services/__tests__/EmbeddingsProcessor.retry.test.ts
@@ -1,0 +1,82 @@
+import { EmbeddingsProcessor } from "../embeddings/processing/EmbeddingsProcessor";
+import { ContentPreprocessor } from "../embeddings/processing/ContentPreprocessor";
+import { EmbeddingsProviderError } from "../embeddings/providers/ProviderError";
+
+/**
+ * #127 / #150: a 429 used to cancel the whole embedding run on the first hit
+ * (handleBatchError treats RATE_LIMITED as a global-backoff stop). The provider
+ * call is now wrapped in withProviderRetry, so a transient rate limit is retried
+ * with backoff before it can reach that stop logic.
+ */
+function makeProcessor(provider: any) {
+  const storage = {
+    storeVectors: jest.fn(),
+    getVectorSync: jest.fn(),
+    removeByPathExceptIds: jest.fn(),
+  } as any;
+
+  return new EmbeddingsProcessor(provider, storage, new ContentPreprocessor(), {
+    batchSize: 1,
+    maxConcurrency: 1,
+    // Instant, deterministic retries — no real timers in the test.
+    retryDeps: { sleep: jest.fn(async () => undefined), random: () => 1, onRetry: jest.fn() },
+  });
+}
+
+const batch = [
+  { file: { path: "a.md" } as any, content: "hello", hash: "h", chunkId: 0, length: 5 },
+];
+
+describe("EmbeddingsProcessor retry wiring (#127/#150)", () => {
+  it("retries a transient 429 and returns the embeddings instead of stopping", async () => {
+    const provider = {
+      id: "custom",
+      getMaxBatchSize: () => 25,
+      generateEmbeddings: jest
+        .fn()
+        .mockRejectedValueOnce(
+          new EmbeddingsProviderError("rate limited", {
+            code: "RATE_LIMITED",
+            transient: true,
+            retryInMs: 5,
+            providerId: "custom",
+          })
+        )
+        .mockResolvedValueOnce([[0.1, 0.2, 0.3]]),
+    } as any;
+
+    const processor = makeProcessor(provider);
+    const result = await (processor as any).generateEmbeddingsWithHtmlForbiddenIsolation(
+      batch,
+      ["hello"],
+      { batchIndex: 0 }
+    );
+
+    expect(result).toEqual([[0.1, 0.2, 0.3]]);
+    expect(provider.generateEmbeddings).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a permanent (non-transient) error", async () => {
+    const provider = {
+      id: "custom",
+      getMaxBatchSize: () => 25,
+      generateEmbeddings: jest.fn().mockRejectedValue(
+        new EmbeddingsProviderError("bad request", {
+          code: "HTTP_ERROR",
+          transient: false,
+          status: 400,
+          providerId: "custom",
+        })
+      ),
+    } as any;
+
+    const processor = makeProcessor(provider);
+
+    await expect(
+      (processor as any).generateEmbeddingsWithHtmlForbiddenIsolation(batch, ["hello"], {
+        batchIndex: 0,
+      })
+    ).rejects.toMatchObject({ code: "HTTP_ERROR" });
+    expect(provider.generateEmbeddings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/embeddings/processing/EmbeddingsProcessor.ts
+++ b/src/services/embeddings/processing/EmbeddingsProcessor.ts
@@ -23,6 +23,11 @@ import { buildVectorId } from "../utils/vectorId";
 import { normalizeInPlace, toFloat32Array } from '../utils/vector';
 import { DEFAULT_EMBEDDING_DIMENSION } from '../../../constants/embeddings';
 import { ContentPreprocessor, PreparedChunk } from "./ContentPreprocessor";
+import {
+  withProviderRetry,
+  type EmbeddingsRetryOptions,
+  type EmbeddingsRetryDeps,
+} from "./embeddingsRetry";
 import { tokenCounter } from '../../../utils/TokenCounter';
 import { errorLogger } from '../../../utils/errorLogger';
 import { EmbeddingsProviderError, isEmbeddingsProviderError } from '../providers/ProviderError';
@@ -31,6 +36,10 @@ export interface ProcessorConfig {
   batchSize: number;
   maxConcurrency: number;
   rateLimitPerMinute?: number;
+  /** Backoff policy for retrying transient provider errors (defaults applied if omitted). */
+  retry?: EmbeddingsRetryOptions;
+  /** Injected retry dependencies (sleep/random/onRetry) — primarily for tests. */
+  retryDeps?: EmbeddingsRetryDeps;
 }
 
 type PendingChunkWork = {
@@ -714,7 +723,33 @@ export class EmbeddingsProcessor {
     if (this.cancelled) return texts.map(() => null);
 
     try {
-      const embeddings = await this.provider.generateEmbeddings(texts, { inputType: "document", batchMetadata: metadata });
+      // Retry transient provider errors (notably 429 rate limits, which neither
+      // provider retries) with backoff before letting the error reach
+      // handleBatchError — which would otherwise cancel the whole run on the
+      // first 429 (the #127 "bulk rebuild stalls on rate limit" behavior).
+      const embeddings = await withProviderRetry(
+        () => this.provider.generateEmbeddings(texts, { inputType: "document", batchMetadata: metadata }),
+        this.config.retry,
+        {
+          ...this.config.retryDeps,
+          onRetry: this.config.retryDeps?.onRetry ?? ((info) => {
+            errorLogger.warn(
+              `Embeddings request ${info.error.code}; retry ${info.attempt} in ${info.delayMs}ms`,
+              {
+                source: "EmbeddingsProcessor",
+                method: "generateEmbeddingsWithHtmlForbiddenIsolation",
+                providerId: this.provider.id,
+                metadata: {
+                  attempt: info.attempt,
+                  delayMs: info.delayMs,
+                  code: info.error.code,
+                  status: info.error.status,
+                },
+              }
+            );
+          }),
+        }
+      );
       if (embeddings.length !== texts.length) {
         throw new Error(`Embedding count mismatch: expected ${texts.length}, got ${embeddings.length}`);
       }

--- a/src/services/embeddings/processing/__tests__/embeddingsRetry.test.ts
+++ b/src/services/embeddings/processing/__tests__/embeddingsRetry.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { EmbeddingsProviderError } from "../../providers/ProviderError";
+import {
+  computeBackoffMs,
+  isRetriableEmbeddingsError,
+  withProviderRetry,
+} from "../embeddingsRetry";
+
+function providerError(
+  overrides: Partial<ConstructorParameters<typeof EmbeddingsProviderError>[1]> = {},
+): EmbeddingsProviderError {
+  return new EmbeddingsProviderError("boom", {
+    code: "RATE_LIMITED",
+    transient: true,
+    ...overrides,
+  });
+}
+
+describe("isRetriableEmbeddingsError", () => {
+  it("is true only for transient, non-license provider errors", () => {
+    expect(isRetriableEmbeddingsError(providerError({ transient: true }))).toBe(true);
+    expect(isRetriableEmbeddingsError(providerError({ transient: false }))).toBe(false);
+    expect(
+      isRetriableEmbeddingsError(
+        providerError({ transient: true, licenseRelated: true, code: "LICENSE_INVALID" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("never retries HOST_UNAVAILABLE (host cooldown / WAF has its own handling)", () => {
+    expect(
+      isRetriableEmbeddingsError(providerError({ transient: true, code: "HOST_UNAVAILABLE" })),
+    ).toBe(false);
+  });
+
+  it("is false for plain errors and non-errors", () => {
+    expect(isRetriableEmbeddingsError(new Error("nope"))).toBe(false);
+    expect(isRetriableEmbeddingsError(null)).toBe(false);
+    expect(isRetriableEmbeddingsError("429")).toBe(false);
+  });
+});
+
+describe("computeBackoffMs", () => {
+  it("honors a server retryInMs, capped at maxDelayMs", () => {
+    expect(computeBackoffMs(1, { maxDelayMs: 30_000 }, 2_000)).toBe(2_000);
+    expect(computeBackoffMs(1, { maxDelayMs: 5_000 }, 60_000)).toBe(5_000);
+  });
+
+  it("grows exponentially from the base when no retryInMs is given", () => {
+    // randomFraction=1 -> full (100%) of the capped exponential, no reduction.
+    expect(computeBackoffMs(1, { baseDelayMs: 1_000 }, undefined, 1)).toBe(1_000);
+    expect(computeBackoffMs(2, { baseDelayMs: 1_000 }, undefined, 1)).toBe(2_000);
+    expect(computeBackoffMs(3, { baseDelayMs: 1_000 }, undefined, 1)).toBe(4_000);
+  });
+
+  it("applies half-jitter into [50%, 100%] of the capped delay", () => {
+    expect(computeBackoffMs(1, { baseDelayMs: 1_000 }, undefined, 0)).toBe(500);
+    expect(computeBackoffMs(1, { baseDelayMs: 1_000 }, undefined, 1)).toBe(1_000);
+  });
+
+  it("caps the exponential growth at maxDelayMs", () => {
+    expect(computeBackoffMs(20, { baseDelayMs: 1_000, maxDelayMs: 30_000 }, undefined, 1)).toBe(30_000);
+  });
+});
+
+describe("withProviderRetry", () => {
+  const noSleep = { sleep: jest.fn(async () => undefined), random: () => 1 };
+
+  it("returns immediately on success without sleeping", async () => {
+    const sleep = jest.fn(async () => undefined);
+    const op = jest.fn(async () => "ok");
+
+    const result = await withProviderRetry(op, {}, { sleep, random: () => 1 });
+
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries a transient error then succeeds", async () => {
+    const op = jest
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(providerError({ code: "RATE_LIMITED", retryInMs: 1_500 }))
+      .mockResolvedValueOnce("recovered");
+    const sleep = jest.fn(async () => undefined);
+
+    const result = await withProviderRetry(op, {}, { sleep, random: () => 1 });
+
+    expect(result).toBe("recovered");
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(1_500); // honored Retry-After
+  });
+
+  it("does not retry a non-transient error", async () => {
+    const op = jest
+      .fn<() => Promise<string>>()
+      .mockRejectedValue(providerError({ code: "HTTP_ERROR", transient: false }));
+
+    await expect(withProviderRetry(op, {}, noSleep)).rejects.toMatchObject({
+      code: "HTTP_ERROR",
+    });
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after maxRetries and rethrows the last typed error", async () => {
+    const op = jest
+      .fn<() => Promise<string>>()
+      .mockRejectedValue(providerError({ code: "RATE_LIMITED", transient: true }));
+    const sleep = jest.fn(async () => undefined);
+
+    await expect(
+      withProviderRetry(op, { maxRetries: 2 }, { sleep, random: () => 1 }),
+    ).rejects.toMatchObject({ code: "RATE_LIMITED" });
+
+    expect(op).toHaveBeenCalledTimes(3); // first try + 2 retries
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports each retry via onRetry", async () => {
+    const op = jest
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(providerError({ retryInMs: 1_000 }))
+      .mockResolvedValueOnce("ok");
+    const onRetry = jest.fn();
+
+    await withProviderRetry(op, {}, { sleep: jest.fn(async () => undefined), random: () => 1, onRetry });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ attempt: 1, delayMs: 1_000 }),
+    );
+  });
+});

--- a/src/services/embeddings/processing/embeddingsRetry.ts
+++ b/src/services/embeddings/processing/embeddingsRetry.ts
@@ -1,0 +1,128 @@
+/**
+ * embeddingsRetry - a single retry/backoff layer for embedding provider calls.
+ *
+ * The providers raise typed `EmbeddingsProviderError`s with `transient` and
+ * `retryInMs` (see #208 PR-2), but nothing retries a rate limit: the managed
+ * SystemSculptProvider deliberately *stops* on 429 ("no point retrying" at the
+ * request level), and the CustomProvider has no retry at all. That is the gap
+ * behind #127 (bulk rebuild stalls at 0.2% on a 429) and #150 (429 handling).
+ *
+ * This wrapper owns that retry. It retries only transient, non-license errors,
+ * honors a server-provided `retryInMs` (Retry-After) when present, and otherwise
+ * backs off exponentially with half-jitter up to a cap. It composes with the
+ * managed provider's internal 5xx fast-path rather than replacing it: SS still
+ * retries a flaky 5xx within a single request, while this layer adds the
+ * rate-limit/backoff retry across the batch that neither provider performs.
+ *
+ * `sleep` and `random` are injectable so the policy is unit-testable without
+ * real timers or nondeterminism.
+ */
+
+import { EmbeddingsProviderError, isEmbeddingsProviderError } from "../providers/ProviderError";
+
+export interface EmbeddingsRetryOptions {
+  /** Maximum retry attempts AFTER the first try (so total attempts = maxRetries + 1). */
+  maxRetries?: number;
+  /** Base delay for exponential backoff, in ms. */
+  baseDelayMs?: number;
+  /** Upper bound for any single backoff wait, in ms. */
+  maxDelayMs?: number;
+}
+
+export interface EmbeddingsRetryDeps {
+  sleep?: (ms: number) => Promise<void>;
+  /** Returns a value in [0, 1) for jitter. */
+  random?: () => number;
+  onRetry?: (info: { attempt: number; delayMs: number; error: EmbeddingsProviderError }) => void;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 1000;
+const DEFAULT_MAX_DELAY_MS = 30_000;
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Only *locally* recoverable transient errors are worth retrying in place — a
+ * rate limit (429), a transient 5xx, a transport blip — where waiting briefly
+ * and re-issuing the same batch can succeed.
+ *
+ * Excluded:
+ *  - permanent errors (non-transient 4xx, malformed response): retrying wastes calls.
+ *  - license/auth errors: retrying can deepen a lockout.
+ *  - HOST_UNAVAILABLE: a whole-host cooldown / WAF block with its own dedicated
+ *    handling (global backoff + per-chunk HTML-403 isolation in the processor).
+ *    A local retry would fight that design and block on a long cooldown.
+ */
+export function isRetriableEmbeddingsError(error: unknown): error is EmbeddingsProviderError {
+  return (
+    isEmbeddingsProviderError(error) &&
+    error.transient === true &&
+    error.licenseRelated !== true &&
+    error.code !== "HOST_UNAVAILABLE"
+  );
+}
+
+/**
+ * Compute the wait before retry `attempt` (1-based). A server-provided
+ * `retryInMs` (Retry-After) wins, capped at `maxDelayMs`. Otherwise: exponential
+ * backoff `base * 2^(attempt-1)`, capped, then half-jittered into
+ * `[50%, 100%]` of the cap using `randomFraction` (in [0, 1)).
+ */
+export function computeBackoffMs(
+  attempt: number,
+  options: EmbeddingsRetryOptions = {},
+  retryInMs?: number,
+  randomFraction = 0,
+): number {
+  const base = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const cap = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+
+  if (typeof retryInMs === "number" && Number.isFinite(retryInMs) && retryInMs >= 0) {
+    return Math.min(retryInMs, cap);
+  }
+
+  const exponential = base * 2 ** Math.max(0, attempt - 1);
+  const capped = Math.min(exponential, cap);
+  const jittered = capped * (0.5 + 0.5 * clamp01(randomFraction));
+  return Math.round(jittered);
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `operation`, retrying transient provider errors with backoff. Non-retriable
+ * errors propagate immediately; after `maxRetries` exhausted retries the last
+ * error is rethrown unchanged (so the caller still sees a typed error).
+ */
+export async function withProviderRetry<T>(
+  operation: () => Promise<T>,
+  options: EmbeddingsRetryOptions = {},
+  deps: EmbeddingsRetryDeps = {},
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const sleep = deps.sleep ?? defaultSleep;
+  const random = deps.random ?? Math.random;
+
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await operation();
+    } catch (error) {
+      attempt++;
+      if (attempt > maxRetries || !isRetriableEmbeddingsError(error)) {
+        throw error;
+      }
+      const delayMs = computeBackoffMs(attempt, options, error.retryInMs, random());
+      deps.onRetry?.({ attempt, delayMs, error });
+      await sleep(delayMs);
+    }
+  }
+}


### PR DESCRIPTION
**Part 3 of 4 for #208.** PR-1 made the index portable; PR-2 gave providers typed `transient`/`retryInMs` errors. This slice acts on them.

## Problem
Nothing retries a rate limit:
- the managed provider deliberately **stops** on 429 at the request level,
- the custom provider has **no retry** at all,
- and `EmbeddingsProcessor.handleBatchError` treats a 429 as a global-backoff **stop** — so a single 429 cancels the whole run.

That is **#127** (bulk rebuild stalls at 0.2% on a 429) and **#150** (429 handling).

## Approach — one retry/backoff layer
- **`embeddingsRetry.withProviderRetry(operation, options, deps)`** retries only *locally recoverable* transient errors, honoring a server `retryInMs` (Retry-After) else exponential backoff with half-jitter, capped, bounded by `maxRetries`. `sleep`/`random` are injected so the policy is unit-tested without real timers or nondeterminism.
- **`isRetriableEmbeddingsError`**: transient + non-license, and explicitly **not** `HOST_UNAVAILABLE` — a whole-host cooldown / WAF block keeps its dedicated handling (global backoff + per-chunk HTML-403 isolation). A local retry would fight that design and block on a long cooldown.

Wired into `EmbeddingsProcessor` around the single batch provider call, **before** `handleBatchError` sees the error: a transient 429 is retried with backoff and only stops the run if it is *still* failing after the retries are spent (then the manager reschedules, as before). It composes with the managed provider's internal 5xx fast-path rather than replacing it. Policy/deps are exposed on `ProcessorConfig` (defaults applied) — tunable and injectable.

## Tests (failing-test-first)
- `embeddingsRetry`: retriable classification (incl. `HOST_UNAVAILABLE` excluded), backoff math (retryInMs honored + capped, exponential, half-jitter, cap), retry-then-succeed, no-retry-on-permanent, give-up-after-maxRetries, `onRetry`.
- `EmbeddingsProcessor.retry`: a transient 429 is retried and returns embeddings (not a cancelled run); a permanent error is not retried. The existing `HOST_UNAVAILABLE` cooldown + HTML-403 isolation batch tests **still pass**, proving those paths are untouched.

## Gates
`check:plugin:fast`; `npm test` (407 suites / 5620); `test:embeddings` (23 / 260); `test:integration` (21/21, incl. `bundle-load.no-node` + `.mobile` — the retry module stays Node-free).

Final follow-up under #208: rate-limit-aware checkpoint/resume so a run that *does* exhaust retries resumes seamlessly instead of restarting (PR-4, #127).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embeddings now automatically retry on transient provider errors with configurable exponential backoff and jitter.

* **Tests**
  * Added comprehensive test coverage for retry logic, error classification, and backoff delay computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->