### PR TITLE
feat(embeddings): resume an interrupted bulk rebuild when autoProcess is off (#208)

### DIFF
--- a/src/services/__tests__/EmbeddingsManager.rebuildResume.test.ts
+++ b/src/services/__tests__/EmbeddingsManager.rebuildResume.test.ts
@@ -1,0 +1,218 @@
+jest.mock("../embeddings/storage/EmbeddingsStorage", () => {
+  const storageMock = {
+    initialize: jest.fn(),
+    loadEmbeddings: jest.fn(),
+    clear: jest.fn(),
+    countVectors: jest.fn(async () => 0),
+    importFromLegacyGlobalDb: jest.fn(async () => ({ imported: 0, skipped: 0 })),
+    upgradeVectorsToCanonicalFormat: jest.fn(async () => ({ updated: 0, skipped: 0, removed: 0 })),
+    backfillRootCompleteness: jest.fn(async () => ({ updated: 0, skipped: 0 })),
+    getAllVectors: jest.fn(() => []),
+    size: jest.fn(() => 0),
+    storeVectors: jest.fn(),
+    purgeCorruptedVectors: jest.fn(() => ({
+      removedCount: 0,
+      correctedCount: 0,
+      removedPaths: [],
+      correctedPaths: [],
+    })),
+  };
+  const EmbeddingsStorage = jest.fn(() => storageMock);
+  (EmbeddingsStorage as any).buildDbName = jest.fn(() => "SystemSculptEmbeddings::test-vault");
+  return { EmbeddingsStorage };
+});
+
+jest.mock("../embeddings/processing/EmbeddingsProcessor", () => ({
+  EmbeddingsProcessor: jest.fn().mockImplementation(() => ({
+    processFiles: jest.fn(),
+    cancel: jest.fn(),
+    setProvider: jest.fn(),
+    setConfig: jest.fn(),
+    cleanup: jest.fn(),
+  })),
+}));
+
+jest.mock("../embeddings/storage/EmbeddingsPortableIndex", () => ({
+  restoreEmbeddingsIndexIfEmpty: jest.fn(async () => ({ restored: false, imported: 0, reason: "no-snapshot" })),
+  writeEmbeddingsIndexSnapshot: jest.fn(async () => ({ written: false, count: 0 })),
+}));
+
+jest.mock("../../core/ui/notifications", () => ({
+  showNoticeWhenReady: jest.fn(),
+}));
+
+import { TFile } from "obsidian";
+import { EmbeddingsManager } from "../embeddings/EmbeddingsManager";
+import { EmbeddingsProviderError } from "../embeddings/providers/ProviderError";
+
+function createPluginStub(settingsOverrides: Record<string, unknown> = {}) {
+  const settings: Record<string, any> = {
+    vaultInstanceId: "test-vault",
+    embeddingsVectorFormatVersion: 4,
+    embeddingsProvider: "systemsculpt",
+    embeddingsCustomEndpoint: "",
+    embeddingsCustomApiKey: "",
+    embeddingsCustomModel: "",
+    embeddingsModel: "",
+    embeddingsBatchSize: 8,
+    embeddingsAutoProcess: false,
+    embeddingsExclusions: {
+      folders: [],
+      patterns: [],
+      ignoreChatHistory: true,
+      respectObsidianExclusions: true,
+    },
+    embeddingsRateLimitPerMinute: 30,
+    embeddingsEnabled: true,
+    embeddingsQuietPeriodMs: 500,
+    embeddingsPortableIndex: false,
+    embeddingsRebuildPending: false,
+    embeddingsRebuildRetryAt: 0,
+    licenseKey: "fake-license",
+    licenseValid: true,
+    serverUrl: "https://api.systemsculpt.com/api/v1",
+    ...settingsOverrides,
+  };
+
+  // Mirror the real SettingsManager: merge the patch into the live settings.
+  const settingsManager = {
+    updateSettings: jest.fn(async (patch: Record<string, unknown>) => {
+      Object.assign(settings, patch);
+    }),
+  };
+
+  const vault = {
+    getMarkdownFiles: jest.fn(() => [new TFile({ path: "Note.md", name: "Note.md", extension: "md" })]),
+    getAbstractFileByPath: jest.fn(() => null),
+    read: jest.fn(),
+    on: jest.fn(() => jest.fn()),
+    offref: jest.fn(),
+    adapter: {
+      exists: jest.fn(async () => false),
+      read: jest.fn(),
+      write: jest.fn(),
+      mkdir: jest.fn(),
+    },
+  };
+
+  return {
+    app: { vault },
+    settings,
+    emitter: { emit: jest.fn(), on: jest.fn(() => jest.fn()) },
+    getSettingsManager: jest.fn(() => settingsManager),
+  };
+}
+
+function transientError(): EmbeddingsProviderError {
+  return new EmbeddingsProviderError("rate limited", {
+    code: "RATE_LIMITED",
+    transient: true,
+    status: 429,
+    retryInMs: 90_000,
+    providerId: "systemsculpt",
+  });
+}
+
+function licenseError(): EmbeddingsProviderError {
+  return new EmbeddingsProviderError("unauthorized", {
+    code: "LICENSE_INVALID",
+    transient: false,
+    status: 401,
+    licenseRelated: true,
+    providerId: "systemsculpt",
+  });
+}
+
+describe("EmbeddingsManager rebuild resume (#208/#127)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("force-resumes an interrupted rebuild on init when pending + autoProcess OFF", async () => {
+    const pluginStub = createPluginStub({
+      embeddingsAutoProcess: false,
+      embeddingsRebuildPending: true,
+      embeddingsRebuildRetryAt: 0,
+    });
+    const manager = new EmbeddingsManager(pluginStub.app as any, pluginStub as any);
+    const spy = jest.spyOn(manager as any, "scheduleVaultProcessing").mockImplementation(() => {});
+
+    await manager.initialize();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(expect.any(Number), { force: true });
+  });
+
+  it("does not resume on init when nothing is pending (autoProcess OFF)", async () => {
+    const pluginStub = createPluginStub({
+      embeddingsAutoProcess: false,
+      embeddingsRebuildPending: false,
+    });
+    const manager = new EmbeddingsManager(pluginStub.app as any, pluginStub as any);
+    const spy = jest.spyOn(manager as any, "scheduleVaultProcessing").mockImplementation(() => {});
+
+    await manager.initialize();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("defers to the normal autoProcess path (never force-schedules) when autoProcess ON", async () => {
+    const pluginStub = createPluginStub({
+      embeddingsAutoProcess: true,
+      embeddingsRebuildPending: true,
+    });
+    const manager = new EmbeddingsManager(pluginStub.app as any, pluginStub as any);
+    const spy = jest.spyOn(manager as any, "scheduleVaultProcessing").mockImplementation(() => {});
+
+    await manager.initialize();
+
+    // scheduleAutoProcessing still runs, but the resume path must not force.
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls.every((call) => (call[1] as any)?.force !== true)).toBe(true);
+  });
+
+  it("persists resume intent and force-reschedules on a non-license vault failure", async () => {
+    const pluginStub = createPluginStub();
+    const manager = new EmbeddingsManager(pluginStub.app as any, pluginStub as any);
+    const spy = jest.spyOn(manager as any, "scheduleVaultProcessing").mockImplementation(() => {});
+
+    await (manager as any).handleVaultFailure(transientError(), 3);
+
+    expect(pluginStub.settings.embeddingsRebuildPending).toBe(true);
+    expect(pluginStub.settings.embeddingsRebuildRetryAt).toBeGreaterThan(0);
+    expect(spy).toHaveBeenCalledWith(expect.any(Number), { force: true });
+  });
+
+  it("does NOT persist resume intent or reschedule on a license failure", async () => {
+    const pluginStub = createPluginStub();
+    const manager = new EmbeddingsManager(pluginStub.app as any, pluginStub as any);
+    const spy = jest.spyOn(manager as any, "scheduleVaultProcessing").mockImplementation(() => {});
+
+    await (manager as any).handleVaultFailure(licenseError(), 3);
+
+    expect(pluginStub.settings.embeddingsRebuildPending).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("clears resume intent on a clean vault completion", () => {
+    const pluginStub = createPluginStub({ embeddingsRebuildPending: true, embeddingsRebuildRetryAt: 12345 });
+    const manager = new EmbeddingsManager(pluginStub.app as any, pluginStub as any);
+
+    (manager as any).handleProcessingSuccess("vault");
+
+    expect(pluginStub.settings.embeddingsRebuildPending).toBe(false);
+    expect(pluginStub.settings.embeddingsRebuildRetryAt).toBe(0);
+  });
+
+  it("does not touch resume intent on a per-file success", () => {
+    const pluginStub = createPluginStub({ embeddingsRebuildPending: true, embeddingsRebuildRetryAt: 12345 });
+    const manager = new EmbeddingsManager(pluginStub.app as any, pluginStub as any);
+    const settingsManager = pluginStub.getSettingsManager();
+
+    (manager as any).handleProcessingSuccess("file");
+
+    // A single file finishing is not a completed rebuild.
+    expect(pluginStub.settings.embeddingsRebuildPending).toBe(true);
+    expect(settingsManager.updateSettings).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/embeddings/EmbeddingsManager.ts
+++ b/src/services/embeddings/EmbeddingsManager.ts
@@ -25,6 +25,7 @@ import { ContentPreprocessor } from './processing/ContentPreprocessor';
 import { VectorSearch } from './search/VectorSearch';
 import { EmbeddingsIndexFile } from './storage/EmbeddingsIndexFile';
 import { restoreEmbeddingsIndexIfEmpty, writeEmbeddingsIndexSnapshot } from './storage/EmbeddingsPortableIndex';
+import { computeRebuildResume } from './rebuildResume';
 import { buildNamespace, buildNamespacePrefix, namespaceMatchesCurrentVersion, parseNamespace, parseNamespaceDimension } from './utils/namespace';
 import { buildVectorId } from "./utils/vectorId";
 import { normalizeInPlace, toFloat32Array } from './utils/vector';
@@ -165,6 +166,11 @@ export class EmbeddingsManager {
         if (this.plugin.settings.embeddingsEnabled && this.config.autoProcess) {
           this.scheduleAutoProcessing();
         }
+
+        // Resume a rebuild interrupted by a non-license fatal error (e.g. a
+        // sustained rate limit). Covers the autoProcess-OFF case the line above
+        // does not — see #208 / #127.
+        this.resumeInterruptedRebuildIfNeeded();
 
         this.setupFileWatchers();
         this.initialized = true;
@@ -1323,6 +1329,10 @@ export class EmbeddingsManager {
     } else {
       this.vaultCooldownUntil = 0;
       this.cancelScheduledVaultProcessing();
+      // A completed vault run means any interrupted rebuild has finished.
+      if (scope === 'vault') {
+        this.clearRebuildResumeIntent();
+      }
     }
     this.healthMonitor.recordSuccess(scope);
   }
@@ -1384,12 +1394,60 @@ export class EmbeddingsManager {
 
     // Don't auto-reschedule on license errors - user action required
     if (!isLicenseError) {
-      this.scheduleVaultProcessing(retryMs);
+      // Persist resume intent so an interrupted rebuild survives a restart even
+      // when autoProcess is OFF (the in-memory timer below does not). #208/#127.
+      this.persistRebuildResumeIntent(this.vaultCooldownUntil);
+      // force: a manual rebuild (autoProcess OFF) must still retry in-session,
+      // not only after the next launch.
+      this.scheduleVaultProcessing(retryMs, { force: true });
     }
   }
 
-  private scheduleVaultProcessing(delayMs: number): void {
-    if (!this.config.autoProcess) return;
+  /**
+   * Persist that a bulk rebuild was interrupted and the earliest time to resume
+   * it. Read on the next load by resumeInterruptedRebuildIfNeeded. Mirrors the
+   * migration write at initialize() — settings flow through the SettingsManager.
+   */
+  private persistRebuildResumeIntent(retryAt: number): void {
+    void this.plugin.getSettingsManager().updateSettings({
+      embeddingsRebuildPending: true,
+      embeddingsRebuildRetryAt: Math.max(0, retryAt),
+    });
+  }
+
+  /** Clear the persisted resume intent once a rebuild completes cleanly. */
+  private clearRebuildResumeIntent(): void {
+    if (this.plugin.settings.embeddingsRebuildPending !== true) return;
+    void this.plugin.getSettingsManager().updateSettings({
+      embeddingsRebuildPending: false,
+      embeddingsRebuildRetryAt: 0,
+    });
+  }
+
+  /**
+   * Resume a rebuild interrupted by a non-license fatal error after a restart.
+   *
+   * When autoProcess is ON the normal startup scheduleAutoProcessing already
+   * resumes (the durable per-file completeness markers make the re-run skip
+   * finished files), so computeRebuildResume defers to it. When autoProcess is
+   * OFF — the gap behind #127 — this re-arms exactly one forced vault run,
+   * honoring the persisted retry-at so it waits out a server cooldown.
+   */
+  private resumeInterruptedRebuildIfNeeded(): void {
+    const decision = computeRebuildResume({
+      enabled: this.plugin.settings.embeddingsEnabled === true,
+      autoProcess: this.config.autoProcess === true,
+      rebuildPending: this.plugin.settings.embeddingsRebuildPending === true,
+      retryAt: this.plugin.settings.embeddingsRebuildRetryAt ?? 0,
+      now: Date.now(),
+    });
+    if (!decision.resume) return;
+    this.scheduleVaultProcessing(decision.delayMs, { force: true });
+  }
+
+  private scheduleVaultProcessing(delayMs: number, options: { force?: boolean } = {}): void {
+    const force = options.force === true;
+    if (!this.config.autoProcess && !force) return;
     if (!this.plugin.settings.embeddingsEnabled) return;
 
     const now = Date.now();
@@ -1418,13 +1476,13 @@ export class EmbeddingsManager {
       }
 
       if (!this.plugin.settings.embeddingsEnabled) return;
-      if (!this.config.autoProcess) return;
+      if (!this.config.autoProcess && !force) return;
       if (this.processingSuspended) return;
       if (!this.isProviderReady()) return;
 
       const now = Date.now();
       if (now < this.vaultCooldownUntil) {
-        this.scheduleVaultProcessing(this.vaultCooldownUntil - now);
+        this.scheduleVaultProcessing(this.vaultCooldownUntil - now, { force });
         return;
       }
 

--- a/src/services/embeddings/__tests__/rebuildResume.test.ts
+++ b/src/services/embeddings/__tests__/rebuildResume.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  MIN_REBUILD_RESUME_DELAY_MS,
+  computeRebuildResume,
+  type RebuildResumeState,
+} from "../rebuildResume";
+
+function state(overrides: Partial<RebuildResumeState> = {}): RebuildResumeState {
+  return {
+    enabled: true,
+    autoProcess: false,
+    rebuildPending: true,
+    retryAt: 0,
+    now: 1_000_000,
+    ...overrides,
+  };
+}
+
+describe("computeRebuildResume", () => {
+  it("does not resume when embeddings are disabled", () => {
+    expect(computeRebuildResume(state({ enabled: false }))).toEqual({
+      resume: false,
+      delayMs: 0,
+      reason: "disabled",
+    });
+  });
+
+  it("does not resume when no rebuild is pending", () => {
+    expect(computeRebuildResume(state({ rebuildPending: false }))).toEqual({
+      resume: false,
+      delayMs: 0,
+      reason: "not-pending",
+    });
+  });
+
+  it("defers to the normal startup path when autoProcess is ON (no double-schedule)", () => {
+    // autoProcess ON => scheduleAutoProcessing already resumes; forcing here
+    // would schedule a second, redundant vault run.
+    expect(computeRebuildResume(state({ autoProcess: true }))).toEqual({
+      resume: false,
+      delayMs: 0,
+      reason: "auto-process-covers",
+    });
+  });
+
+  it("resumes (the #127 gap) when pending + autoProcess OFF", () => {
+    const decision = computeRebuildResume(state({ autoProcess: false, retryAt: 0 }));
+    expect(decision.resume).toBe(true);
+    expect(decision.reason).toBe("resume");
+    // No specific cooldown -> the startup floor, never blocking init.
+    expect(decision.delayMs).toBe(MIN_REBUILD_RESUME_DELAY_MS);
+  });
+
+  it("honors a future retry-at (waits out the server cooldown)", () => {
+    const now = 1_000_000;
+    const decision = computeRebuildResume(state({ now, retryAt: now + 90_000 }));
+    expect(decision.resume).toBe(true);
+    expect(decision.delayMs).toBe(90_000);
+  });
+
+  it("floors a past or zero retry-at at the startup delay", () => {
+    const now = 1_000_000;
+    expect(computeRebuildResume(state({ now, retryAt: now - 50_000 })).delayMs).toBe(
+      MIN_REBUILD_RESUME_DELAY_MS,
+    );
+    expect(computeRebuildResume(state({ now, retryAt: 0 })).delayMs).toBe(
+      MIN_REBUILD_RESUME_DELAY_MS,
+    );
+  });
+
+  it("honors a custom minimum delay", () => {
+    const now = 1_000_000;
+    expect(computeRebuildResume(state({ now, retryAt: 0 }), 500).delayMs).toBe(500);
+    // A future cooldown still wins over the floor.
+    expect(computeRebuildResume(state({ now, retryAt: now + 10_000 }), 500).delayMs).toBe(10_000);
+  });
+
+  it("treats a non-finite retry-at as ASAP (floored)", () => {
+    const decision = computeRebuildResume(state({ retryAt: Number.NaN }));
+    expect(decision.resume).toBe(true);
+    expect(decision.delayMs).toBe(MIN_REBUILD_RESUME_DELAY_MS);
+  });
+});

--- a/src/services/embeddings/rebuildResume.ts
+++ b/src/services/embeddings/rebuildResume.ts
@@ -1,0 +1,75 @@
+/**
+ * rebuildResume - decide whether (and when) to resume a bulk embeddings rebuild
+ * that was interrupted by a non-license fatal error (e.g. a sustained rate
+ * limit). This is #208's final slice over #127.
+ *
+ * Most of "checkpoint/resume" already exists: the per-file `complete`/`mtime`/
+ * `contentHash` markers are durable (IndexedDB), PR-3 absorbs transient 429s with
+ * backoff, and any re-run skips already-embedded files — so a resumed run never
+ * restarts from ~0%. The one gap is that every auto-resume path is gated behind
+ * `autoProcess`: when autoProcess is OFF, a sustained-429 stop neither
+ * reschedules in-session nor survives a restart, so a manual rebuild silently
+ * stalls until the user notices.
+ *
+ * The manager persists a tiny intent (`embeddingsRebuildPending` +
+ * `embeddingsRebuildRetryAt`) when a rebuild is interrupted. On the next load it
+ * asks this pure function whether to re-arm one vault run. Keeping the decision
+ * pure (no timers, no `Date.now()`) makes the policy fully unit-testable.
+ */
+
+export interface RebuildResumeState {
+  /** Embeddings feature enabled. */
+  enabled: boolean;
+  /** Background auto-processing enabled. When true, the normal startup
+   *  scheduleAutoProcessing already resumes, so this defers to avoid double-run. */
+  autoProcess: boolean;
+  /** Persisted "a rebuild was interrupted" intent. */
+  rebuildPending: boolean;
+  /** Persisted earliest epoch-ms to resume (server cooldown). 0 = ASAP. */
+  retryAt: number;
+  /** Current epoch-ms. */
+  now: number;
+}
+
+export interface RebuildResumeDecision {
+  resume: boolean;
+  /** Delay before the resumed run, in ms (never below `minDelayMs`). */
+  delayMs: number;
+  reason: "disabled" | "not-pending" | "auto-process-covers" | "resume";
+}
+
+/**
+ * A small startup delay before the resumed run, matching scheduleAutoProcessing,
+ * so init is never blocked and the store is ready.
+ */
+export const MIN_REBUILD_RESUME_DELAY_MS = 3000;
+
+/**
+ * Decide whether to force-resume an interrupted rebuild on load.
+ *
+ *  - feature off / nothing pending          -> no resume.
+ *  - autoProcess on                          -> no resume here (the normal
+ *    startup path covers it; forcing would double-schedule).
+ *  - autoProcess off + pending               -> resume after
+ *    `max(minDelayMs, retryAt - now)`, so we wait out a server cooldown but
+ *    never block startup.
+ */
+export function computeRebuildResume(
+  state: RebuildResumeState,
+  minDelayMs: number = MIN_REBUILD_RESUME_DELAY_MS,
+): RebuildResumeDecision {
+  if (!state.enabled) {
+    return { resume: false, delayMs: 0, reason: "disabled" };
+  }
+  if (!state.rebuildPending) {
+    return { resume: false, delayMs: 0, reason: "not-pending" };
+  }
+  if (state.autoProcess) {
+    return { resume: false, delayMs: 0, reason: "auto-process-covers" };
+  }
+
+  const floor = Math.max(0, minDelayMs);
+  const wait = Number.isFinite(state.retryAt) ? state.retryAt - state.now : 0;
+  const delayMs = Math.max(floor, wait);
+  return { resume: true, delayMs, reason: "resume" };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -417,6 +417,20 @@ export interface SystemSculptSettings {
    * it on a new device instead of re-embedding the whole vault.
    */
   embeddingsPortableIndex?: boolean;
+  /**
+   * Set true when a bulk rebuild is interrupted by a non-license fatal error
+   * (e.g. a sustained rate limit). Persisted so the rebuild resumes on the next
+   * load even when autoProcess is OFF — the durable per-file completeness markers
+   * make the resumed run skip already-embedded files. Cleared on a clean vault
+   * completion. See #208 / #127.
+   */
+  embeddingsRebuildPending?: boolean;
+  /**
+   * Earliest epoch-ms at which an interrupted rebuild should resume, derived from
+   * the server's Retry-After cooldown. Honored on the next load so resume waits
+   * out the cooldown instead of immediately re-hitting the rate limit. 0 = ASAP.
+   */
+  embeddingsRebuildRetryAt?: number;
   // Embeddings search behavior settings removed; use internal defaults
   
   /**
@@ -670,6 +684,8 @@ Raw transcript:`,
   embeddingsRateLimitPerMinute: 50, // Default rate limiting
   embeddingsQuietPeriodMs: 1200,
   embeddingsPortableIndex: true,
+  embeddingsRebuildPending: false,
+  embeddingsRebuildRetryAt: 0,
   // Search behavior defaults removed; handled internally
   
   /**


### PR DESCRIPTION
**Part 4 of 4 — the final slice of #208** (over #127: a bulk rebuild stalls and never resumes after a sustained rate limit).

## What already works (PR-1 + PR-3 + durable markers)
Resume is *mostly* solved already, and this PR deliberately reuses it rather than rebuilding it:
- per-file `complete` / `mtime` / `contentHash` markers are durable in IndexedDB, so `evaluateFileProcessingState` makes any re-run **skip finished files** — a resumed run never restarts from ~0%;
- **PR-3** absorbs transient 429s with Retry-After backoff before they can stop the run;
- `handleVaultFailure` already auto-reschedules after a stop, honoring `retryInMs`.

## The genuine gap
Every one of those resume paths is **gated behind `autoProcess`**. With autoProcess **OFF**, a sustained-429 stop:
- does **not** reschedule in-session (`scheduleVaultProcessing` early-returns), and
- persists **nothing**, so a restart does not resume —

a user who manually triggered a rebuild is left with a silently stalled job until they notice and re-trigger.

## Fix — a tiny persisted intent + a forced resume
- **Settings** `embeddingsRebuildPending` + `embeddingsRebuildRetryAt`: set (through the `SettingsManager`, mirroring the migration write) when a **non-license** vault failure interrupts a run, recording the server cooldown as the earliest resume time; **cleared on a clean vault completion** (and never on a single-file success).
- **`scheduleVaultProcessing(delayMs, { force })`**: threads a `force` flag through all three autoProcess gates (early-return, fire-time check, cooldown re-schedule). `handleVaultFailure` now forces the reschedule, so a manual rebuild **retries in-session** too — not only on the next launch. Existing callers pass no option → behavior unchanged.
- **`computeRebuildResume`** (pure, timer-free) decides resume on `initialize()`: **defers** to the normal `scheduleAutoProcessing` path when autoProcess is ON (no double-schedule), otherwise re-arms exactly one forced run honoring `retryAt` so it **waits out the cooldown** instead of re-hitting the 429.

Re-architected toward the canonical shape used by PR-1/PR-3: the policy is a pure function, the manager just wires it — no new scheduler, no new work-list, no checkpoint file. It rides the existing incremental skip.

## Tests (failing-test-first)
- `rebuildResume` — decision matrix: disabled / not-pending / auto-process-covers / resume, plus delay flooring, future-cooldown honoring, and non-finite retryAt.
- `EmbeddingsManager.rebuildResume` — wiring: force-resume on init when pending+autoProcess-off; no resume when not pending; **no force** when autoProcess on; intent persisted on a non-license failure but **not** on a license failure; cleared on vault success but **not** on per-file success.
- `rebuildResume.ts` stays **Node-free** — `bundle-load.no-node` + `bundle-load.mobile` green.

## Gates
`check:plugin:fast`; `npm test` (408 suites / 5627); `test:embeddings` (25 / 275); `test:integration` (21/21, incl. no-node + mobile).

Closes the last item under #208 — after this merges, #208 (embeddings portability + provider error handling) is complete.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interrupted embeddings rebuilds now automatically resume on application restart, even when auto-processing is disabled.
  * Added intelligent retry handling for rebuild operations, respecting server cooldown periods and distinguishing between transient and permanent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->