### PR TITLE
feat(transcription): typed provider core — errors, normalizer, HTTP classifier, interface (#211)

### DIFF
--- a/src/services/transcription/providers/ProviderError.ts
+++ b/src/services/transcription/providers/ProviderError.ts
@@ -1,0 +1,65 @@
+/**
+ * Typed transcription provider errors — the transcription twin of the embeddings
+ * `EmbeddingsProviderError` (src/services/embeddings/providers/ProviderError.ts).
+ *
+ * Before #211 every transcription failure was a plain `new Error(message)` with
+ * an ad-hoc `additionalInfo` bag, and retry decisions were made by substring-
+ * matching the message ("is500Error"/"isNetworkError"). That makes it impossible
+ * to tell a transient 429/5xx from a permanent 400, or a license/auth failure
+ * from a malformed response, without parsing prose. This carries the same
+ * structured fields the embeddings rework standardized on, so callers (the retry
+ * layer, the recorder UX, config validation) can branch on typed fields.
+ */
+
+export type TranscriptionProviderErrorCode =
+  | "HOST_UNAVAILABLE"
+  | "HTTP_ERROR"
+  | "NETWORK_ERROR"
+  | "RATE_LIMITED"
+  | "LICENSE_INVALID"
+  | "UNEXPECTED_RESPONSE"
+  | "INVALID_RESPONSE";
+
+export interface TranscriptionProviderErrorOptions {
+  code: TranscriptionProviderErrorCode;
+  status?: number;
+  retryInMs?: number;
+  transient?: boolean;
+  licenseRelated?: boolean;
+  providerId?: string;
+  endpoint?: string;
+  details?: Record<string, unknown>;
+  cause?: unknown;
+}
+
+export class TranscriptionProviderError extends Error {
+  readonly code: TranscriptionProviderErrorCode;
+  readonly status?: number;
+  readonly retryInMs?: number;
+  readonly transient: boolean;
+  readonly licenseRelated: boolean;
+  readonly providerId?: string;
+  readonly endpoint?: string;
+  readonly details?: Record<string, unknown>;
+  readonly cause?: unknown;
+
+  constructor(message: string, options: TranscriptionProviderErrorOptions) {
+    super(message);
+    this.name = "TranscriptionProviderError";
+    this.code = options.code;
+    this.status = options.status;
+    this.retryInMs = options.retryInMs;
+    this.transient = options.transient ?? false;
+    this.licenseRelated = options.licenseRelated ?? false;
+    this.providerId = options.providerId;
+    this.endpoint = options.endpoint;
+    this.details = options.details;
+    this.cause = options.cause;
+  }
+}
+
+export function isTranscriptionProviderError(
+  error: unknown,
+): error is TranscriptionProviderError {
+  return error instanceof TranscriptionProviderError;
+}

--- a/src/services/transcription/providers/TranscriptionProvider.ts
+++ b/src/services/transcription/providers/TranscriptionProvider.ts
@@ -1,0 +1,77 @@
+/**
+ * TranscriptionProvider - the contract every transcription backend implements,
+ * the transcription twin of the embeddings `EmbeddingsProvider` interface.
+ *
+ * Today provider choice is two inline branches on
+ * `settings.transcriptionProvider === "custom"` buried inside the 2k-line
+ * `TranscriptionService`. This interface is the seam the #211 rework introduces:
+ * the managed SystemSculpt backend and a self-hosted Whisper backend (PR-2) both
+ * implement it, `TranscriptionService` becomes thin wiring, and the self-hosted
+ * Whisper *contract* becomes a concrete `validateConfiguration()` instead of
+ * undocumented tribal knowledge.
+ *
+ * Kept Node-free: the audio payload is described with web types
+ * (Blob/ArrayBuffer/Uint8Array), never a Node Buffer or fs handle, so the whole
+ * provider layer stays in the mobile bundle (bundle-load.no-node / .mobile).
+ */
+
+import type { TranscriptionResult } from "./transcriptionResponse";
+
+export type { TranscriptionResult, TranscriptionSegment } from "./transcriptionResponse";
+
+/** The audio to transcribe, as already-captured bytes plus naming metadata. */
+export interface TranscriptionAudio {
+  /** Raw audio bytes. A Blob on web; ArrayBuffer/Uint8Array when read directly. */
+  data: Blob | ArrayBuffer | Uint8Array;
+  /** File name with extension, e.g. "recording.m4a". */
+  fileName: string;
+  /** MIME type, e.g. "audio/mp4". */
+  mimeType: string;
+}
+
+export interface TranscriptionRequest {
+  audio: TranscriptionAudio;
+  /** Optional language hint (ISO-639-1), when the user/endpoint supports it. */
+  language?: string;
+  /** Request timed segments (SRT/verbose output) rather than plain text. */
+  timestamped?: boolean;
+  /** Correlation id for progress/cancellation/server logs. */
+  requestId?: string;
+  /** Progress callback in [0,100] with an optional status message. */
+  onProgress?: (percent: number, message?: string) => void;
+  /** Cooperative cancellation. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Result of `validateConfiguration()` — config-time compatibility check for a
+ * provider (used to surface clear "your Whisper endpoint isn't compatible"
+ * errors in settings before the user records anything). `ok` is true only when
+ * `errors` is empty; `warnings` are non-fatal advisories.
+ */
+export interface TranscriptionConfigValidation {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface TranscriptionProvider {
+  /** Stable id, e.g. "systemsculpt" | "custom". */
+  readonly id: string;
+  /**
+   * Validate the provider's current configuration without performing I/O
+   * (URL/protocol/model presence checks). Cheap enough to call on settings
+   * change.
+   */
+  validateConfiguration(): TranscriptionConfigValidation;
+  /** Transcribe one audio payload, returning the normalized result. */
+  transcribe(request: TranscriptionRequest): Promise<TranscriptionResult>;
+}
+
+/** Convenience constructor for a passing/with-warnings/failing validation. */
+export function buildValidation(
+  errors: string[] = [],
+  warnings: string[] = [],
+): TranscriptionConfigValidation {
+  return { ok: errors.length === 0, errors, warnings };
+}

--- a/src/services/transcription/providers/__tests__/ProviderError.test.ts
+++ b/src/services/transcription/providers/__tests__/ProviderError.test.ts
@@ -1,0 +1,58 @@
+import {
+  TranscriptionProviderError,
+  isTranscriptionProviderError,
+} from "../ProviderError";
+import { buildValidation } from "../TranscriptionProvider";
+
+describe("TranscriptionProviderError", () => {
+  it("captures the typed fields and defaults transient/licenseRelated to false", () => {
+    const error = new TranscriptionProviderError("boom", {
+      code: "HTTP_ERROR",
+      status: 400,
+      providerId: "custom",
+      endpoint: "https://x",
+    });
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("TranscriptionProviderError");
+    expect(error.message).toBe("boom");
+    expect(error.code).toBe("HTTP_ERROR");
+    expect(error.status).toBe(400);
+    expect(error.transient).toBe(false);
+    expect(error.licenseRelated).toBe(false);
+    expect(error.providerId).toBe("custom");
+  });
+
+  it("preserves explicit transient / retryInMs / licenseRelated", () => {
+    const error = new TranscriptionProviderError("rate limited", {
+      code: "RATE_LIMITED",
+      status: 429,
+      transient: true,
+      retryInMs: 5_000,
+    });
+    expect(error.transient).toBe(true);
+    expect(error.retryInMs).toBe(5_000);
+
+    const license = new TranscriptionProviderError("unauthorized", {
+      code: "LICENSE_INVALID",
+      status: 401,
+      licenseRelated: true,
+    });
+    expect(license.licenseRelated).toBe(true);
+  });
+
+  it("is recognized by the type guard and rejects other values", () => {
+    const error = new TranscriptionProviderError("x", { code: "NETWORK_ERROR" });
+    expect(isTranscriptionProviderError(error)).toBe(true);
+    expect(isTranscriptionProviderError(new Error("plain"))).toBe(false);
+    expect(isTranscriptionProviderError(null)).toBe(false);
+    expect(isTranscriptionProviderError({ code: "NETWORK_ERROR" })).toBe(false);
+  });
+});
+
+describe("buildValidation", () => {
+  it("is ok only when there are no errors", () => {
+    expect(buildValidation()).toEqual({ ok: true, errors: [], warnings: [] });
+    expect(buildValidation([], ["heads up"])).toEqual({ ok: true, errors: [], warnings: ["heads up"] });
+    expect(buildValidation(["bad url"])).toEqual({ ok: false, errors: ["bad url"], warnings: [] });
+  });
+});

--- a/src/services/transcription/providers/__tests__/providerHttpErrors.test.ts
+++ b/src/services/transcription/providers/__tests__/providerHttpErrors.test.ts
@@ -1,0 +1,78 @@
+import {
+  buildTranscriptionHttpErrorOptions,
+  classifyTranscriptionHttpStatus,
+  parseRetryAfterMs,
+} from "../providerHttpErrors";
+
+describe("parseRetryAfterMs", () => {
+  it("parses integer seconds case-insensitively into ms", () => {
+    expect(parseRetryAfterMs({ "Retry-After": "30" })).toBe(30_000);
+    expect(parseRetryAfterMs({ "retry-after": "1" })).toBe(1_000);
+    expect(parseRetryAfterMs({ "RETRY-AFTER": " 2 " })).toBe(2_000);
+  });
+
+  it("returns undefined for missing / non-numeric / negative / HTTP-date values", () => {
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs({})).toBeUndefined();
+    expect(parseRetryAfterMs({ "retry-after": "soon" })).toBeUndefined();
+    expect(parseRetryAfterMs({ "retry-after": "-5" })).toBeUndefined();
+    expect(parseRetryAfterMs({ "retry-after": "Wed, 21 Oct 2026 07:28:00 GMT" })).toBeUndefined();
+  });
+});
+
+describe("classifyTranscriptionHttpStatus", () => {
+  it("classifies 429 as transient RATE_LIMITED with Retry-After", () => {
+    expect(classifyTranscriptionHttpStatus(429, { "retry-after": "12" })).toEqual({
+      code: "RATE_LIMITED",
+      transient: true,
+      retryInMs: 12_000,
+    });
+  });
+
+  it("classifies 408 and 5xx and unknown-transport as transient HTTP_ERROR", () => {
+    expect(classifyTranscriptionHttpStatus(408)).toEqual({ code: "HTTP_ERROR", transient: true });
+    expect(classifyTranscriptionHttpStatus(500)).toEqual({ code: "HTTP_ERROR", transient: true });
+    expect(classifyTranscriptionHttpStatus(503)).toEqual({ code: "HTTP_ERROR", transient: true });
+    expect(classifyTranscriptionHttpStatus(0)).toEqual({ code: "HTTP_ERROR", transient: true });
+    expect(classifyTranscriptionHttpStatus(-1)).toEqual({ code: "HTTP_ERROR", transient: true });
+  });
+
+  it("classifies other 4xx as permanent HTTP_ERROR", () => {
+    expect(classifyTranscriptionHttpStatus(400)).toEqual({ code: "HTTP_ERROR", transient: false });
+    expect(classifyTranscriptionHttpStatus(401)).toEqual({ code: "HTTP_ERROR", transient: false });
+    expect(classifyTranscriptionHttpStatus(404)).toEqual({ code: "HTTP_ERROR", transient: false });
+    expect(classifyTranscriptionHttpStatus(422)).toEqual({ code: "HTTP_ERROR", transient: false });
+  });
+});
+
+describe("buildTranscriptionHttpErrorOptions", () => {
+  it("merges the classification with provider/endpoint context", () => {
+    const options = buildTranscriptionHttpErrorOptions({
+      status: 429,
+      headers: { "retry-after": "5" },
+      providerId: "custom",
+      endpoint: "https://whisper.example.com/v1/audio/transcriptions",
+      details: { requestId: "req-1" },
+    });
+    expect(options).toEqual({
+      code: "RATE_LIMITED",
+      status: 429,
+      transient: true,
+      retryInMs: 5_000,
+      providerId: "custom",
+      endpoint: "https://whisper.example.com/v1/audio/transcriptions",
+      details: { requestId: "req-1" },
+    });
+  });
+
+  it("carries a permanent 400 through with no retryInMs", () => {
+    const options = buildTranscriptionHttpErrorOptions({
+      status: 400,
+      providerId: "custom",
+      endpoint: "https://whisper.example.com",
+    });
+    expect(options.code).toBe("HTTP_ERROR");
+    expect(options.transient).toBe(false);
+    expect(options.retryInMs).toBeUndefined();
+  });
+});

--- a/src/services/transcription/providers/__tests__/transcriptionResponse.test.ts
+++ b/src/services/transcription/providers/__tests__/transcriptionResponse.test.ts
@@ -1,0 +1,92 @@
+import { normalizeTranscriptionResponse } from "../transcriptionResponse";
+
+describe("normalizeTranscriptionResponse", () => {
+  it("accepts a raw string body (text/plain self-hosted servers)", () => {
+    expect(normalizeTranscriptionResponse("  hello world  ")).toEqual({
+      text: "hello world",
+      raw: "  hello world  ",
+    });
+  });
+
+  it("accepts top-level { text } (OpenAI json)", () => {
+    const data = { text: "a transcript" };
+    expect(normalizeTranscriptionResponse(data)).toMatchObject({ text: "a transcript" });
+  });
+
+  it("accepts nested { data: { text } } (managed SystemSculpt wrapper)", () => {
+    const data = { data: { text: "wrapped transcript" } };
+    expect(normalizeTranscriptionResponse(data)).toMatchObject({ text: "wrapped transcript" });
+  });
+
+  it("captures segments alongside top-level text (verbose_json)", () => {
+    const data = {
+      text: "one two",
+      language: "en",
+      segments: [
+        { start: 0, end: 1.5, text: "one" },
+        { start: 1.5, end: 2.5, text: "two" },
+      ],
+    };
+    expect(normalizeTranscriptionResponse(data)).toEqual({
+      text: "one two",
+      language: "en",
+      segments: [
+        { text: "one", start: 0, end: 1.5 },
+        { text: "two", start: 1.5, end: 2.5 },
+      ],
+      raw: data,
+    });
+  });
+
+  it("joins a segments-only payload into text (Groq verbose without top-level text)", () => {
+    const data = {
+      segments: [
+        { start: 0, end: 1, text: " Hello " },
+        { start: 1, end: 2, text: "there" },
+      ],
+    };
+    const result = normalizeTranscriptionResponse(data);
+    expect(result?.text).toBe("Hello there");
+    expect(result?.segments).toHaveLength(2);
+  });
+
+  it("ignores malformed segment entries but keeps valid ones", () => {
+    const data = {
+      segments: [
+        { start: 0, end: 1, text: "kept" },
+        { start: 1, end: 2 }, // no text -> dropped
+        null, // not an object -> dropped
+        { start: "x", end: "y", text: "timings-dropped" }, // bad timings, text kept
+      ],
+    };
+    const result = normalizeTranscriptionResponse(data);
+    expect(result?.text).toBe("kept timings-dropped");
+    expect(result?.segments).toEqual([
+      { text: "kept", start: 0, end: 1 },
+      { text: "timings-dropped" },
+    ]);
+  });
+
+  it("treats empty / whitespace-only transcripts as no result (null)", () => {
+    expect(normalizeTranscriptionResponse("")).toBeNull();
+    expect(normalizeTranscriptionResponse("   ")).toBeNull();
+    expect(normalizeTranscriptionResponse({ text: "   " })).toBeNull();
+    expect(normalizeTranscriptionResponse({ data: { text: "" } })).toBeNull();
+    expect(normalizeTranscriptionResponse({ segments: [{ text: "   " }] })).toBeNull();
+  });
+
+  it("returns null for unrecognized shapes", () => {
+    expect(normalizeTranscriptionResponse(null)).toBeNull();
+    expect(normalizeTranscriptionResponse(undefined)).toBeNull();
+    expect(normalizeTranscriptionResponse(42)).toBeNull();
+    expect(normalizeTranscriptionResponse({ unexpected: true })).toBeNull();
+    expect(normalizeTranscriptionResponse({ text: 123 })).toBeNull();
+    expect(normalizeTranscriptionResponse({ data: { notText: "x" } })).toBeNull();
+    expect(normalizeTranscriptionResponse([])).toBeNull();
+  });
+
+  it("prefers top-level text over nested data.text", () => {
+    const data = { text: "top", data: { text: "nested" } };
+    expect(normalizeTranscriptionResponse(data)?.text).toBe("top");
+  });
+});

--- a/src/services/transcription/providers/providerHttpErrors.ts
+++ b/src/services/transcription/providers/providerHttpErrors.ts
@@ -1,0 +1,91 @@
+/**
+ * providerHttpErrors - pure classification of an HTTP failure from a transcription
+ * endpoint into the typed `TranscriptionProviderError` shape. The transcription
+ * twin of the embeddings `providerHttpErrors`.
+ *
+ * The current code decides retries by substring-matching error messages
+ * ("is500Error", "isNetworkError"). This maps a status code to
+ * {code, transient, retryInMs} so the retry layer and the recorder UX can act on
+ * typed fields, and so the self-hosted Whisper contract has a single definition
+ * of which failures are retryable.
+ */
+
+import type {
+  TranscriptionProviderErrorCode,
+  TranscriptionProviderErrorOptions,
+} from "./ProviderError";
+
+export interface TranscriptionHttpClassification {
+  code: TranscriptionProviderErrorCode;
+  transient: boolean;
+  retryInMs?: number;
+}
+
+/**
+ * Parse a `Retry-After` header (case-insensitive) into milliseconds. Whisper
+ * endpoints send integer seconds; the HTTP-date form is not parsed here (kept
+ * pure / Date-free) and yields undefined.
+ */
+export function parseRetryAfterMs(
+  headers?: Record<string, string>,
+): number | undefined {
+  if (!headers) return undefined;
+  let raw: string | undefined;
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === "retry-after") {
+      raw = value;
+      break;
+    }
+  }
+  if (raw == null) return undefined;
+  const seconds = Number(String(raw).trim());
+  if (!Number.isFinite(seconds) || seconds < 0) return undefined;
+  return Math.round(seconds * 1000);
+}
+
+/**
+ * Classify an HTTP status (and optional headers) from a transcription endpoint.
+ *  - 429            -> RATE_LIMITED, transient, retryInMs from Retry-After
+ *  - 408 / >= 500   -> HTTP_ERROR, transient (timeouts and server faults retry)
+ *  - <= 0           -> HTTP_ERROR, transient (no usable status from transport)
+ *  - other          -> HTTP_ERROR, permanent (4xx client errors do not retry)
+ */
+export function classifyTranscriptionHttpStatus(
+  status: number,
+  headers?: Record<string, string>,
+): TranscriptionHttpClassification {
+  if (status === 429) {
+    return {
+      code: "RATE_LIMITED",
+      transient: true,
+      retryInMs: parseRetryAfterMs(headers),
+    };
+  }
+  if (status <= 0 || status === 408 || status >= 500) {
+    return { code: "HTTP_ERROR", transient: true };
+  }
+  return { code: "HTTP_ERROR", transient: false };
+}
+
+/**
+ * Build the `TranscriptionProviderError` options for a failed transcription HTTP
+ * call, merging the status classification with provider/endpoint context.
+ */
+export function buildTranscriptionHttpErrorOptions(args: {
+  status: number;
+  headers?: Record<string, string>;
+  providerId: string;
+  endpoint: string;
+  details?: Record<string, unknown>;
+}): TranscriptionProviderErrorOptions {
+  const classification = classifyTranscriptionHttpStatus(args.status, args.headers);
+  return {
+    code: classification.code,
+    status: args.status,
+    transient: classification.transient,
+    retryInMs: classification.retryInMs,
+    providerId: args.providerId,
+    endpoint: args.endpoint,
+    details: args.details,
+  };
+}

--- a/src/services/transcription/providers/transcriptionResponse.ts
+++ b/src/services/transcription/providers/transcriptionResponse.ts
@@ -1,0 +1,131 @@
+/**
+ * normalizeTranscriptionResponse - one pure parser for the many shapes a Whisper-
+ * compatible endpoint can return, the transcription twin of the embeddings
+ * `normalizeEmbeddingsResponse`.
+ *
+ * Today `TranscriptionService.transcribeAudio` reparses these inline at every
+ * call site (a Groq `segments` branch, a `string` body, `.text`, `.data.text`,
+ * plus a separate NDJSON path), each throwing its own ad-hoc error. Centralizing
+ * the shape handling here means there is exactly one definition of "a compatible
+ * response", which is also what makes the self-hosted Whisper contract (#211)
+ * mechanically checkable: a server is compatible iff this returns non-null.
+ *
+ * Recognized shapes (verbatim from the current code + the OpenAI/Groq specs):
+ *  - a raw string body (some self-hosted servers return text/plain);
+ *  - `{ text }` (OpenAI `response_format=json`);
+ *  - `{ data: { text } }` (the managed SystemSculpt wrapper);
+ *  - `{ segments: [{ start, end, text }] }` (Groq / verbose_json) — joined into
+ *    `text` while preserving the timed segments for SRT output.
+ * Returns null for anything unrecognized so callers can raise a typed
+ * UNEXPECTED_RESPONSE instead of guessing.
+ */
+
+export interface TranscriptionSegment {
+  text: string;
+  /** Segment start, in seconds (when the endpoint reports timings). */
+  start?: number;
+  /** Segment end, in seconds. */
+  end?: number;
+}
+
+export interface TranscriptionResult {
+  text: string;
+  /** Timed segments, when the endpoint returns verbose/timestamped output. */
+  segments?: TranscriptionSegment[];
+  /** Detected/declared language, when reported. */
+  language?: string;
+  /** The original payload, for diagnostics. */
+  raw?: unknown;
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function pickLanguage(obj: Record<string, unknown>): string | undefined {
+  return isString(obj.language) ? obj.language : undefined;
+}
+
+function normalizeSegments(value: unknown): TranscriptionSegment[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const segments: TranscriptionSegment[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Record<string, unknown>;
+    if (!isString(record.text)) continue;
+    const segment: TranscriptionSegment = { text: record.text };
+    if (typeof record.start === "number" && Number.isFinite(record.start)) {
+      segment.start = record.start;
+    }
+    if (typeof record.end === "number" && Number.isFinite(record.end)) {
+      segment.end = record.end;
+    }
+    segments.push(segment);
+  }
+  return segments.length > 0 ? segments : undefined;
+}
+
+function joinSegments(segments: TranscriptionSegment[]): string {
+  return segments
+    .map((segment) => segment.text.trim())
+    .filter((text) => text.length > 0)
+    .join(" ")
+    .trim();
+}
+
+/**
+ * Normalize a raw transcription payload into `{ text, segments?, language? }`,
+ * or null when no recognized transcript shape is present. An empty/whitespace-only
+ * transcript is treated as "no usable result" (null) so the caller surfaces a
+ * single consistent error rather than persisting a blank note.
+ */
+export function normalizeTranscriptionResponse(
+  data: unknown,
+): TranscriptionResult | null {
+  // 1. Raw string body.
+  if (isString(data)) {
+    const text = data.trim();
+    return text.length > 0 ? { text, raw: data } : null;
+  }
+
+  if (!data || typeof data !== "object") return null;
+  const obj = data as Record<string, unknown>;
+
+  // 2. Top-level { text } (+ optional segments/language).
+  if (isString(obj.text)) {
+    const text = obj.text.trim();
+    if (text.length === 0) return null;
+    return {
+      text,
+      segments: normalizeSegments(obj.segments),
+      language: pickLanguage(obj),
+      raw: data,
+    };
+  }
+
+  // 3. Nested { data: { text } } — the managed SystemSculpt wrapper.
+  const nested = obj.data;
+  if (nested && typeof nested === "object") {
+    const nestedRecord = nested as Record<string, unknown>;
+    if (isString(nestedRecord.text)) {
+      const text = nestedRecord.text.trim();
+      if (text.length === 0) return null;
+      return {
+        text,
+        segments: normalizeSegments(nestedRecord.segments) ?? normalizeSegments(obj.segments),
+        language: pickLanguage(nestedRecord) ?? pickLanguage(obj),
+        raw: data,
+      };
+    }
+  }
+
+  // 4. Segments only (Groq verbose_json without a top-level text).
+  const segments = normalizeSegments(obj.segments);
+  if (segments) {
+    const text = joinSegments(segments);
+    if (text.length === 0) return null;
+    return { text, segments, language: pickLanguage(obj), raw: data };
+  }
+
+  return null;
+}


### PR DESCRIPTION
**Part 1 of the #211 recording/transcription rework.** A pure, fully-tested provider core — the foundation PR-2 (self-hosted Whisper contract + providers) and PR-6 (YouTube typed errors) build on.

## Why
Transcription today has **no provider abstraction**: provider choice is two inline branches on `settings.transcriptionProvider === "custom"` buried inside the ~2,250-line `TranscriptionService`; the response is reparsed at every call site (a Groq `segments` branch, a `string` body, `.text`, `.data.text`, plus a separate NDJSON path); and retry/abort decisions are made by **substring-matching error messages** (`is500Error`/`isNetworkError`). The embeddings rework (#208) already established the canonical shape — this brings the same one to transcription, with **zero I/O** so it's testable at the cheapest layer.

## What (all new, under `src/services/transcription/providers/`, all Node-free — web types only)
- **`ProviderError.ts`** — `TranscriptionProviderError` (`code` / `status` / `transient` / `retryInMs` / `licenseRelated` / `providerId` / `endpoint` / `details` / `cause`) + `isTranscriptionProviderError`, mirroring `EmbeddingsProviderError`.
- **`transcriptionResponse.ts`** — `normalizeTranscriptionResponse(data)`: one pure parser for **every shape the current code handles inline** — a raw string body, `{ text }`, `{ data: { text } }` (managed wrapper), and Groq/verbose `{ segments:[{start,end,text}] }` (joined into `text` while preserving timed segments for SRT). Returns `null` for empty/unrecognized payloads, so a server is **"compatible" iff this returns non-null** — the mechanical definition the self-hosted Whisper contract needs.
- **`providerHttpErrors.ts`** — `classifyTranscriptionHttpStatus` / `parseRetryAfterMs` / `buildTranscriptionHttpErrorOptions` (429 → RATE_LIMITED transient w/ Retry-After; 408/5xx/no-status → transient HTTP_ERROR; other 4xx → permanent).
- **`TranscriptionProvider.ts`** — the interface (`id`, `validateConfiguration`, `transcribe`) + request/audio/validation types that PR-2's managed + self-hosted Whisper backends implement.

## Tests (failing-test-first, pure unit — the cheapest layer)
`transcriptionResponse` (every shape + empty/unrecognized rejections + top-level-wins precedence), `providerHttpErrors` (status matrix + Retry-After case-insensitivity / non-numeric / HTTP-date), `ProviderError` (typed fields + defaults + guard + validation builder). 20 tests.

No production code imports these yet — PR-2 routes `TranscriptionService` through them, and the `bundle-load.no-node` guard then covers them in the shipped bundle.

## Gates
`check:plugin:fast`; `npm test` (411 suites / 5647); `test:integration` (21/21, incl. `bundle-load.no-node` + `.mobile`).

Part of #211. Next: PR-2 — implement the managed + self-hosted Whisper providers against this interface, document the endpoint contract, add config-time validation + the missing settings UI.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM