### PR TITLE
feat(transcription): self-hosted Whisper contract + config validation + settings UI (#211)

### DIFF
--- a/src/__tests__/settings-recorder-tab.test.ts
+++ b/src/__tests__/settings-recorder-tab.test.ts
@@ -13,8 +13,13 @@ jest.mock("../services/PlatformContext", () => ({
 
 function createPlugin(settingsOverrides: Record<string, unknown> = {}) {
   const app = new App();
-  const updateSettings = jest.fn().mockResolvedValue(undefined);
-  const plugin: any = {
+  let plugin: any;
+  // Merge patches into plugin.settings so a re-render reflects the change,
+  // mirroring the real SettingsManager.
+  const updateSettings = jest.fn(async (patch: Record<string, unknown>) => {
+    Object.assign(plugin.settings, patch ?? {});
+  });
+  plugin = {
     app,
     settings: {
       autoTranscribeRecordings: false,
@@ -114,5 +119,38 @@ describe("Recorder settings tab", () => {
 
     const errorNote = container.querySelector(".ss-inline-note-error")?.textContent || "";
     expect(errorNote).toMatch(/required/i);
+  });
+
+  it("switches to custom and reveals the controls when the provider dropdown changes", async () => {
+    const { plugin, updateSettings } = createPlugin({ transcriptionProvider: "systemsculpt" });
+    const { container, tab } = render(plugin);
+
+    await displayRecorderTabContent(container, tab);
+
+    const namesBefore = Array.from(container.querySelectorAll(".setting-item-name")).map((el) =>
+      el.textContent?.trim()
+    );
+    expect(namesBefore).not.toContain("Custom endpoint URL");
+
+    // The provider <select> is the only one carrying a "systemsculpt" option.
+    const providerSelect = Array.from(container.querySelectorAll("select")).find((select) =>
+      Array.from(select.querySelectorAll("option")).some(
+        (opt) => (opt as HTMLOptionElement).value === "systemsculpt"
+      )
+    ) as HTMLSelectElement | undefined;
+    expect(providerSelect).toBeTruthy();
+
+    providerSelect!.value = "custom";
+    providerSelect!.dispatchEvent(new Event("change"));
+
+    // Drain the async onChange (persist + re-render + mic enumerate).
+    for (let i = 0; i < 5; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(updateSettings).toHaveBeenCalledWith({ transcriptionProvider: "custom" });
+    const namesAfter = Array.from(container.querySelectorAll(".setting-item-name")).map((el) =>
+      el.textContent?.trim()
+    );
+    expect(namesAfter).toContain("Custom endpoint URL");
+    expect(namesAfter).toContain("Model name");
   });
 });

--- a/src/__tests__/settings-recorder-tab.test.ts
+++ b/src/__tests__/settings-recorder-tab.test.ts
@@ -11,6 +11,40 @@ jest.mock("../services/PlatformContext", () => ({
   },
 }));
 
+function createPlugin(settingsOverrides: Record<string, unknown> = {}) {
+  const app = new App();
+  const updateSettings = jest.fn().mockResolvedValue(undefined);
+  const plugin: any = {
+    app,
+    settings: {
+      autoTranscribeRecordings: false,
+      autoPasteTranscription: false,
+      keepRecordingsAfterTranscription: true,
+      cleanTranscriptionOutput: true,
+      autoSubmitAfterTranscription: false,
+      postProcessingEnabled: false,
+      postProcessingPrompt: "Custom cleanup instructions",
+      transcriptionProvider: "systemsculpt",
+      customTranscriptionEndpoint: "",
+      customTranscriptionApiKey: "",
+      customTranscriptionModel: "",
+      transcriptionOutputFormat: "markdown",
+      showTranscriptionFormatChooserInModal: true,
+      enableAutoAudioResampling: true,
+      preferredMicrophoneId: "default",
+      ...settingsOverrides,
+    },
+    getSettingsManager: jest.fn(() => ({ updateSettings })),
+  };
+  return { app, plugin, updateSettings };
+}
+
+function render(plugin: any) {
+  const container = document.createElement("div");
+  const tab: any = { app: plugin.app, plugin, display: jest.fn() };
+  return { container, tab };
+}
+
 describe("Recorder settings tab", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -19,43 +53,39 @@ describe("Recorder settings tab", () => {
       configurable: true,
       value: {
         enumerateDevices: jest.fn().mockResolvedValue([]),
-        getUserMedia: jest.fn().mockResolvedValue({
-          getTracks: () => [{ stop: jest.fn() }],
-        }),
+        getUserMedia: jest.fn().mockResolvedValue({ getTracks: () => [{ stop: jest.fn() }] }),
       },
     });
   });
 
-  it("locks transcription to SystemSculpt without custom-provider controls", async () => {
-    const app = new App();
-    const updateSettings = jest.fn().mockResolvedValue(undefined);
-    const plugin: any = {
-      app,
-      settings: {
-        autoTranscribeRecordings: false,
-        autoPasteTranscription: false,
-        keepRecordingsAfterTranscription: true,
-        cleanTranscriptionOutput: true,
-        autoSubmitAfterTranscription: false,
-        postProcessingEnabled: false,
-        postProcessingPrompt: "Custom cleanup instructions",
-        transcriptionProvider: "custom",
-        transcriptionOutputFormat: "markdown",
-        showTranscriptionFormatChooserInModal: true,
-        enableAutoAudioResampling: true,
-        preferredMicrophoneId: "default",
-      },
-      getSettingsManager: jest.fn(() => ({
-        updateSettings,
-      })),
-    };
+  it("offers a transcription provider choice and hides custom controls on SystemSculpt", async () => {
+    const { plugin } = createPlugin({ transcriptionProvider: "systemsculpt" });
+    const { container, tab } = render(plugin);
 
-    const container = document.createElement("div");
-    const tab: any = {
-      app,
-      plugin,
-      display: jest.fn(),
-    };
+    await displayRecorderTabContent(container, tab);
+
+    const names = Array.from(container.querySelectorAll(".setting-item-name")).map((el) =>
+      el.textContent?.trim()
+    );
+    // The provider is now configurable...
+    expect(names).toContain("Transcription provider");
+    // ...but custom-endpoint controls stay hidden until "custom" is chosen.
+    expect(names).not.toContain("Custom endpoint URL");
+    expect(names).not.toContain("API key");
+    expect(names).not.toContain("Model name");
+    // Unrelated recorder settings remain.
+    expect(names).toContain("Transcription clean-up prompt");
+    expect(names).toContain("Automatic audio format conversion");
+  });
+
+  it("reveals the self-hosted Whisper controls + validation when provider is custom", async () => {
+    const { plugin } = createPlugin({
+      transcriptionProvider: "custom",
+      customTranscriptionEndpoint: "https://api.groq.com/openai/v1/audio/transcriptions",
+      customTranscriptionApiKey: "gsk_test",
+      customTranscriptionModel: "whisper-large-v3",
+    });
+    const { container, tab } = render(plugin);
 
     await displayRecorderTabContent(container, tab);
 
@@ -63,19 +93,26 @@ describe("Recorder settings tab", () => {
     const names = Array.from(container.querySelectorAll(".setting-item-name")).map((el) =>
       el.textContent?.trim()
     );
+    expect(names).toContain("Transcription provider");
+    expect(names).toContain("Custom endpoint URL");
+    expect(names).toContain("API key");
+    expect(names).toContain("Model name");
+    // The documented contract is surfaced to the user.
+    expect(text).toContain("multipart/form-data");
+    // A fully-configured endpoint validates as compatible.
+    expect(text).toContain("Endpoint looks compatible");
+  });
 
-    expect(text).toContain("transcribe through SystemSculpt");
-    expect(names).toContain("Transcription execution");
-    expect(text).toContain("SystemSculpt clean-up");
-    expect(names).toContain("Transcription clean-up prompt");
-    expect(text).toContain("managed cleanup step");
-    expect(names).not.toContain("Transcription provider");
-    expect(text).not.toContain("Custom endpoint URL");
-    expect(text).not.toContain("API key");
-    expect(text).not.toContain("Model name");
-    expect(text).not.toContain("Groq");
-    expect(text).not.toContain("OpenAI");
-    expect(text).not.toContain("Local");
-    expect(names).toContain("Automatic audio format conversion");
+  it("surfaces a config-time error when the custom endpoint is missing", async () => {
+    const { plugin } = createPlugin({
+      transcriptionProvider: "custom",
+      customTranscriptionEndpoint: "",
+    });
+    const { container, tab } = render(plugin);
+
+    await displayRecorderTabContent(container, tab);
+
+    const errorNote = container.querySelector(".ss-inline-note-error")?.textContent || "";
+    expect(errorNote).toMatch(/required/i);
   });
 });

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -1151,12 +1151,9 @@ export class TranscriptionService {
           Array.isArray((responseData as any)?.segments);
 
         if (isGroqTimestampedSegments) {
-          // Convert segments to SRT format (simplified)
-          transcriptionText = (responseData as any).segments.map((segment: any, index: number) => {
-            const start = this.formatTimestamp(segment.start);
-            const end = this.formatTimestamp(segment.end);
-            return `${index + 1}\n${start} --> ${end}\n${segment.text.trim()}\n`;
-          }).join('\n');
+          // Reuse the null-safe SRT builder (guards missing text/start/end)
+          // instead of an unguarded inline map.
+          transcriptionText = this.segmentsToSrt((responseData as any).segments);
         } else {
           // One definition of a "compatible" transcription response (#211): a
           // plain string body, { text }, { data: { text } }, or { segments } are

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -1093,7 +1093,15 @@ export class TranscriptionService {
             if (contentType.includes('application/x-ndjson')) {
               responseData = this.parseNdjsonText(rawResponseTextFor200, context?.onProgress);
             } else {
-              responseData = JSON.parse(rawResponseTextFor200 || '{}');
+              // A text/plain transcript is allowed by the #211 contract; if the
+              // body is not JSON, keep it as a raw string for the normalizer
+              // instead of throwing an "unparseable JSON" error.
+              const body = rawResponseTextFor200 || "";
+              try {
+                responseData = JSON.parse(body || "{}");
+              } catch {
+                responseData = body;
+              }
             }
           }
         } catch (jsonParseError) {
@@ -1146,7 +1154,7 @@ export class TranscriptionService {
         // concern (timed segments rendered as subtitle cues), kept as-is.
         const isGroqTimestampedSegments =
           this.plugin.settings.transcriptionProvider === "custom" &&
-          this.plugin.settings.customTranscriptionEndpoint.includes("groq.com") &&
+          (this.plugin.settings.customTranscriptionEndpoint || "").toLowerCase().includes("groq.com") &&
           !!context?.timestamped &&
           Array.isArray((responseData as any)?.segments);
 

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -1,6 +1,7 @@
 import { Notice, TFile, requestUrl, normalizePath } from "obsidian";
 import { PlatformContext } from "./PlatformContext";
 import { SystemSculptService } from "./SystemSculptService";
+import { normalizeTranscriptionResponse } from "./transcription/providers/transcriptionResponse";
 import { AUDIO_UPLOAD_MAX_BYTES } from "../constants/uploadLimits";
 import type SystemSculptPlugin from "../main";
 import { logDebug, logInfo, logWarning, logError, logMobileError } from "../utils/errorHandling";
@@ -1141,31 +1142,31 @@ export class TranscriptionService {
 
         let transcriptionText = "";
 
-        // Handle different response formats
-        if (this.plugin.settings.transcriptionProvider === "custom" && 
-            this.plugin.settings.customTranscriptionEndpoint.includes("groq.com")) {
-          // Groq API response format
-          if (context?.timestamped && responseData.segments) {
-            // Convert segments to SRT format (simplified)
-            transcriptionText = responseData.segments.map((segment: any, index: number) => {
-              const start = this.formatTimestamp(segment.start);
-              const end = this.formatTimestamp(segment.end);
-              return `${index + 1}\n${start} --> ${end}\n${segment.text.trim()}\n`;
-            }).join('\n');
-            } else {
-            transcriptionText = responseData.text || "";
-          }
-                } else {
-          // SystemSculpt or other API response format
-          if (typeof responseData === 'string') {
-            transcriptionText = responseData;
-          } else if (responseData.text) {
-            transcriptionText = responseData.text;
-          } else if (responseData.data?.text) {
-            transcriptionText = responseData.data.text;
-          } else {
+        // Groq verbose_json with timestamps -> SRT. This is a presentation
+        // concern (timed segments rendered as subtitle cues), kept as-is.
+        const isGroqTimestampedSegments =
+          this.plugin.settings.transcriptionProvider === "custom" &&
+          this.plugin.settings.customTranscriptionEndpoint.includes("groq.com") &&
+          !!context?.timestamped &&
+          Array.isArray((responseData as any)?.segments);
+
+        if (isGroqTimestampedSegments) {
+          // Convert segments to SRT format (simplified)
+          transcriptionText = (responseData as any).segments.map((segment: any, index: number) => {
+            const start = this.formatTimestamp(segment.start);
+            const end = this.formatTimestamp(segment.end);
+            return `${index + 1}\n${start} --> ${end}\n${segment.text.trim()}\n`;
+          }).join('\n');
+        } else {
+          // One definition of a "compatible" transcription response (#211): a
+          // plain string body, { text }, { data: { text } }, or { segments } are
+          // all accepted; anything else is an unrecognized shape. This is the
+          // response half of the self-hosted Whisper contract.
+          const normalized = normalizeTranscriptionResponse(responseData);
+          if (!normalized) {
             throw new Error("Invalid response format: no transcription text found");
           }
+          transcriptionText = normalized.text;
         }
 
         if (!transcriptionText?.trim()) {
@@ -1903,6 +1904,20 @@ export class TranscriptionService {
         arrayBuffer = await this.plugin.app.vault.readBinary(file);
         this.debug("Read audio file from vault", { filePath: file.path });
       } catch (readError) {
+        // Desktop-only fallback: a direct fs read when the vault adapter read
+        // fails. Gated on Node availability so mobile (no fs) surfaces the
+        // original error instead of crashing on require("fs"). #211 / #207.
+        const canUseNode =
+          typeof (this.platform as any)?.supportsNodeApis === "function"
+            ? !!(this.platform as any).supportsNodeApis()
+            : !this.platform.isMobile();
+        if (!canUseNode || typeof require !== "function") {
+          throw new Error(
+            `Failed to read audio file. Original error: ${
+              readError instanceof Error ? readError.message : String(readError)
+            }`
+          );
+        }
         try {
           const fs = require("fs");
           const path = require("path");

--- a/src/services/__tests__/TranscriptionService.test.ts
+++ b/src/services/__tests__/TranscriptionService.test.ts
@@ -982,6 +982,41 @@ First`;
       expect(text).toContain("Content-Type: audio/ogg");
     });
 
+    it("accepts a text/plain 200 body as the transcript (self-hosted Whisper contract)", async () => {
+      (PlatformContext.get as jest.Mock).mockReturnValue({
+        isMobile: jest.fn(() => false),
+        preferredTransport: jest.fn(() => "requestUrl"),
+        supportsStreaming: jest.fn(() => true),
+      });
+
+      mockPlugin.settings.transcriptionProvider = "custom";
+      mockPlugin.settings.customTranscriptionEndpoint =
+        "http://localhost:9000/v1/audio/transcriptions";
+      mockPlugin.settings.customTranscriptionApiKey = "";
+      (TranscriptionService as any).instance = undefined;
+      service = TranscriptionService.getInstance(mockPlugin);
+
+      (requestUrl as jest.Mock).mockResolvedValue({
+        status: 200,
+        headers: { "content-type": "text/plain" },
+        text: "a plain transcript",
+      });
+
+      const file = new TFile();
+      (file as any).path = "audio.m4a";
+      (file as any).name = "audio.m4a";
+      (file as any).basename = "audio";
+      (file as any).extension = "m4a";
+
+      const result = await (service as any).transcribeAudio(
+        file,
+        new Blob(["audio"], { type: "audio/mp4" }),
+        { onProgress: jest.fn() }
+      );
+
+      expect(result).toBe("a plain transcript");
+    });
+
     it("surfaces plain-text 413 errors without a JSON parse wrapper", async () => {
       (PlatformContext.get as jest.Mock).mockReturnValue({
         isMobile: jest.fn(() => true),

--- a/src/services/transcription/providers/__tests__/customWhisperConfig.test.ts
+++ b/src/services/transcription/providers/__tests__/customWhisperConfig.test.ts
@@ -60,6 +60,18 @@ describe("validateCustomWhisperConfig", () => {
     expect(result.warnings.some((w) => /API key/i.test(w))).toBe(false);
   });
 
+  it("treats a 127.x.x.x address as local but not a domain that merely starts with 127.", () => {
+    const loopback = validateCustomWhisperConfig({
+      endpoint: "http://127.0.0.53:9000/v1/audio/transcriptions",
+    });
+    expect(loopback.warnings.some((w) => /unencrypted/i.test(w))).toBe(false);
+
+    const spoof = validateCustomWhisperConfig({
+      endpoint: "http://127.example.com/v1/audio/transcriptions",
+    });
+    expect(spoof.warnings.some((w) => /unencrypted/i.test(w))).toBe(true);
+  });
+
   it("does not warn about a missing key for localhost", () => {
     const result = validateCustomWhisperConfig({
       endpoint: "http://localhost:9000/v1/audio/transcriptions",

--- a/src/services/transcription/providers/__tests__/customWhisperConfig.test.ts
+++ b/src/services/transcription/providers/__tests__/customWhisperConfig.test.ts
@@ -1,0 +1,95 @@
+import {
+  CUSTOM_WHISPER_CONTRACT,
+  validateCustomWhisperConfig,
+} from "../customWhisperConfig";
+
+describe("validateCustomWhisperConfig", () => {
+  it("errors when the endpoint is missing", () => {
+    const result = validateCustomWhisperConfig({ endpoint: "" });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toMatch(/required/i);
+  });
+
+  it("errors on a non-URL endpoint", () => {
+    const result = validateCustomWhisperConfig({ endpoint: "not a url" });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toMatch(/full URL/i);
+  });
+
+  it("errors on a non-http(s) protocol", () => {
+    const result = validateCustomWhisperConfig({ endpoint: "ftp://host/audio/transcriptions" });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toMatch(/http/i);
+  });
+
+  it("passes a well-formed hosted endpoint with a key and model", () => {
+    const result = validateCustomWhisperConfig({
+      endpoint: "https://api.groq.com/openai/v1/audio/transcriptions",
+      apiKey: "gsk_x",
+      model: "whisper-large-v3",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns (not errors) when a remote endpoint uses http", () => {
+    const result = validateCustomWhisperConfig({
+      endpoint: "http://example.com/v1/audio/transcriptions",
+      apiKey: "k",
+      model: "whisper-1",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.some((w) => /unencrypted|http/i.test(w))).toBe(true);
+  });
+
+  it("does not warn about http for localhost", () => {
+    const result = validateCustomWhisperConfig({
+      endpoint: "http://localhost:9000/v1/audio/transcriptions",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.some((w) => /unencrypted/i.test(w))).toBe(false);
+  });
+
+  it("does not warn about a missing key for localhost", () => {
+    const result = validateCustomWhisperConfig({
+      endpoint: "http://localhost:9000/v1/audio/transcriptions",
+      model: "base",
+    });
+    expect(result.warnings.some((w) => /API key/i.test(w))).toBe(false);
+  });
+
+  it("warns when no model is set", () => {
+    const result = validateCustomWhisperConfig({
+      endpoint: "https://api.openai.com/v1/audio/transcriptions",
+      apiKey: "sk-x",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.some((w) => /model/i.test(w))).toBe(true);
+  });
+
+  it("warns when no API key is set on a remote endpoint", () => {
+    const result = validateCustomWhisperConfig({
+      endpoint: "https://api.openai.com/v1/audio/transcriptions",
+      model: "whisper-1",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.some((w) => /API key/i.test(w))).toBe(true);
+  });
+
+  it('warns when the path lacks a "transcriptions" segment', () => {
+    const result = validateCustomWhisperConfig({
+      endpoint: "https://api.openai.com/v1",
+      apiKey: "sk-x",
+      model: "whisper-1",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.some((w) => /transcription/i.test(w))).toBe(true);
+  });
+
+  it("exposes a documented contract string covering request + response shapes", () => {
+    expect(CUSTOM_WHISPER_CONTRACT).toMatch(/multipart\/form-data/);
+    expect(CUSTOM_WHISPER_CONTRACT).toMatch(/\{ text \}/);
+    expect(CUSTOM_WHISPER_CONTRACT).toMatch(/segments/);
+  });
+});

--- a/src/services/transcription/providers/__tests__/customWhisperConfig.test.ts
+++ b/src/services/transcription/providers/__tests__/customWhisperConfig.test.ts
@@ -51,6 +51,15 @@ describe("validateCustomWhisperConfig", () => {
     expect(result.warnings.some((w) => /unencrypted/i.test(w))).toBe(false);
   });
 
+  it("treats the IPv6 loopback [::1] as local (URL.hostname is bracketed)", () => {
+    const result = validateCustomWhisperConfig({
+      endpoint: "http://[::1]:9000/v1/audio/transcriptions",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.some((w) => /unencrypted/i.test(w))).toBe(false);
+    expect(result.warnings.some((w) => /API key/i.test(w))).toBe(false);
+  });
+
   it("does not warn about a missing key for localhost", () => {
     const result = validateCustomWhisperConfig({
       endpoint: "http://localhost:9000/v1/audio/transcriptions",

--- a/src/services/transcription/providers/customWhisperConfig.ts
+++ b/src/services/transcription/providers/customWhisperConfig.ts
@@ -1,0 +1,99 @@
+/**
+ * customWhisperConfig - the documented, mechanically-checkable contract for a
+ * self-hosted / third-party Whisper-compatible transcription endpoint (#211).
+ *
+ * The contact-form report behind #211: "no documented endpoint contract, users
+ * can't tell what's compatible." This module is that contract, in two halves:
+ *  - the REQUEST side, described in CUSTOM_WHISPER_CONTRACT and enforced as a
+ *    config-time check by validateCustomWhisperConfig (no I/O — safe to run on
+ *    every settings keystroke);
+ *  - the RESPONSE side, defined by normalizeTranscriptionResponse (a server is
+ *    response-compatible iff that returns non-null).
+ *
+ * Pure / Node-free (uses the WHATWG URL global, available on web + mobile).
+ */
+
+import { buildValidation, type TranscriptionConfigValidation } from "./TranscriptionProvider";
+
+export interface CustomWhisperConfig {
+  endpoint: string;
+  apiKey?: string;
+  model?: string;
+}
+
+/**
+ * Human-readable description of what SystemSculpt sends and what it accepts back.
+ * Shown in settings and the source-of-truth for "compatible".
+ */
+export const CUSTOM_WHISPER_CONTRACT =
+  "SystemSculpt sends a POST multipart/form-data request with a `file` part (the " +
+  "recorded audio) and a `model` field, plus an optional `Authorization: Bearer " +
+  "<key>` header. A compatible endpoint replies with JSON `{ text }`, a verbose " +
+  "`{ segments: [{ start, end, text }] }` (when timestamps are requested), a " +
+  "`{ data: { text } }` wrapper, or a plain-text body. OpenAI, Groq, and " +
+  "faster-whisper-server compatible endpoints all satisfy this.";
+
+function isLocalHost(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname.endsWith(".local")
+  );
+}
+
+/**
+ * Validate a custom-endpoint configuration without performing any network I/O.
+ * Errors block (the endpoint cannot work as configured); warnings are advisory
+ * (it may work, but something looks off). `ok` is true iff there are no errors.
+ */
+export function validateCustomWhisperConfig(
+  config: CustomWhisperConfig,
+): TranscriptionConfigValidation {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const endpoint = (config.endpoint ?? "").trim();
+  if (!endpoint) {
+    errors.push("Endpoint URL is required for a custom transcription provider.");
+    return buildValidation(errors, warnings);
+  }
+
+  let url: URL | null = null;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    url = null;
+  }
+  if (!url) {
+    errors.push(
+      "Endpoint must be a full URL, e.g. https://api.groq.com/openai/v1/audio/transcriptions.",
+    );
+    return buildValidation(errors, warnings);
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    errors.push("Endpoint must use http:// or https://.");
+    return buildValidation(errors, warnings);
+  }
+
+  const local = isLocalHost(url.hostname);
+  if (url.protocol === "http:" && !local) {
+    warnings.push(
+      "Endpoint uses http:// — your API key and audio will be sent unencrypted. Use https:// for remote servers.",
+    );
+  }
+  if (!/transcription/i.test(url.pathname)) {
+    warnings.push(
+      'Endpoint path has no "transcriptions" segment — confirm it points at the audio transcription route, not the API root.',
+    );
+  }
+  if (!(config.model ?? "").trim()) {
+    warnings.push("No model set — the server's default model will be used.");
+  }
+  if (!(config.apiKey ?? "").trim() && !local) {
+    warnings.push("No API key set — most hosted endpoints require one.");
+  }
+
+  return buildValidation(errors, warnings);
+}

--- a/src/services/transcription/providers/customWhisperConfig.ts
+++ b/src/services/transcription/providers/customWhisperConfig.ts
@@ -34,11 +34,14 @@ export const CUSTOM_WHISPER_CONTRACT =
   "faster-whisper-server compatible endpoints all satisfy this.";
 
 function isLocalHost(hostname: string): boolean {
+  // URL.hostname brackets IPv6 literals (e.g. "[::1]"); compare unbracketed.
+  const host = hostname.replace(/^\[|\]$/g, "");
   return (
-    hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
-    hostname === "::1" ||
-    hostname.endsWith(".local")
+    host === "localhost" ||
+    host === "::1" ||
+    host === "127.0.0.1" ||
+    host.startsWith("127.") ||
+    host.endsWith(".local")
   );
 }
 

--- a/src/services/transcription/providers/customWhisperConfig.ts
+++ b/src/services/transcription/providers/customWhisperConfig.ts
@@ -39,8 +39,8 @@ function isLocalHost(hostname: string): boolean {
   return (
     host === "localhost" ||
     host === "::1" ||
-    host === "127.0.0.1" ||
-    host.startsWith("127.") ||
+    // 127.0.0.0/8 loopback — match only dotted-quad IPv4, not "127.example.com".
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) ||
     host.endsWith(".local")
   );
 }

--- a/src/settings/RecorderTabContent.ts
+++ b/src/settings/RecorderTabContent.ts
@@ -1,8 +1,11 @@
-import { App, Setting, Notice, DropdownComponent } from "obsidian";
-import SystemSculptPlugin from "../main";
+import { Setting, Notice, DropdownComponent } from "obsidian";
 import { SystemSculptSettingTab } from "./SystemSculptSettingTab";
 import { PlatformContext } from "../services/PlatformContext";
 import { DEFAULT_SETTINGS } from "../types";
+import {
+  CUSTOM_WHISPER_CONTRACT,
+  validateCustomWhisperConfig,
+} from "../services/transcription/providers/customWhisperConfig";
 
 export async function displayRecorderTabContent(containerEl: HTMLElement, tabInstance: SystemSculptSettingTab) {
   containerEl.empty();
@@ -116,8 +119,23 @@ export async function displayRecorderTabContent(containerEl: HTMLElement, tabIns
   containerEl.createEl("h3", { text: "Transcription" });
 
   new Setting(containerEl)
-    .setName("Transcription execution")
-    .setDesc("Recordings always transcribe through SystemSculpt so desktop and mobile stay on the same path.");
+    .setName("Transcription provider")
+    .setDesc("Transcribe through SystemSculpt (managed) or your own self-hosted / third-party Whisper-compatible endpoint.")
+    .addDropdown((dropdown) => {
+      dropdown
+        .addOption("systemsculpt", "SystemSculpt (managed)")
+        .addOption("custom", "Custom / self-hosted Whisper")
+        .setValue(plugin.settings.transcriptionProvider ?? "systemsculpt")
+        .onChange(async (value: "systemsculpt" | "custom") => {
+          await plugin.getSettingsManager().updateSettings({ transcriptionProvider: value });
+          // Re-render so the custom fields appear/disappear with the choice.
+          await displayRecorderTabContent(containerEl, tabInstance);
+        });
+    });
+
+  if (plugin.settings.transcriptionProvider === "custom") {
+    renderCustomTranscriptionSettings(containerEl, tabInstance);
+  }
 
   new Setting(containerEl)
     .setName("Default transcription output format")
@@ -161,6 +179,81 @@ export async function displayRecorderTabContent(containerEl: HTMLElement, tabIns
           });
       });
   }
+}
+
+function renderCustomTranscriptionSettings(containerEl: HTMLElement, tabInstance: SystemSculptSettingTab) {
+  const { plugin } = tabInstance;
+  let statusEl: HTMLElement | null = null;
+
+  const refreshValidation = () => {
+    if (!statusEl) return;
+    statusEl.empty();
+    const result = validateCustomWhisperConfig({
+      endpoint: plugin.settings.customTranscriptionEndpoint || "",
+      apiKey: plugin.settings.customTranscriptionApiKey || "",
+      model: plugin.settings.customTranscriptionModel || "",
+    });
+    if (result.ok && result.warnings.length === 0) {
+      statusEl.createDiv({ cls: "ss-inline-note-ok", text: "✓ Endpoint looks compatible." });
+      return;
+    }
+    for (const error of result.errors) {
+      statusEl.createDiv({ cls: "ss-inline-note-error", text: `⛔ ${error}` });
+    }
+    for (const warning of result.warnings) {
+      statusEl.createDiv({ cls: "ss-inline-note-warning", text: `⚠️ ${warning}` });
+    }
+  };
+
+  new Setting(containerEl)
+    .setName("Custom endpoint URL")
+    .setDesc(
+      "Full URL of your Whisper-compatible endpoint, e.g. https://api.groq.com/openai/v1/audio/transcriptions, https://api.openai.com/v1/audio/transcriptions, or http://localhost:9000/v1/audio/transcriptions."
+    )
+    .addText((text) => {
+      text
+        .setPlaceholder("https://.../v1/audio/transcriptions")
+        .setValue(plugin.settings.customTranscriptionEndpoint || "")
+        .onChange(async (value) => {
+          await plugin.getSettingsManager().updateSettings({ customTranscriptionEndpoint: value.trim() });
+          refreshValidation();
+        });
+    });
+
+  new Setting(containerEl)
+    .setName("API key")
+    .setDesc("Optional. Sent as 'Authorization: Bearer <key>'. Required by most hosted endpoints; leave blank for a local server that needs none.")
+    .addText((text) => {
+      text.inputEl.type = "password";
+      text
+        .setPlaceholder("sk-... / gsk_...")
+        .setValue(plugin.settings.customTranscriptionApiKey || "")
+        .onChange(async (value) => {
+          await plugin.getSettingsManager().updateSettings({ customTranscriptionApiKey: value.trim() });
+          refreshValidation();
+        });
+    });
+
+  new Setting(containerEl)
+    .setName("Model name")
+    .setDesc("Model identifier sent to the endpoint, e.g. whisper-large-v3 (Groq) or whisper-1 (OpenAI). Leave blank to use the server default.")
+    .addText((text) => {
+      text
+        .setPlaceholder("whisper-large-v3")
+        .setValue(plugin.settings.customTranscriptionModel || "")
+        .onChange(async (value) => {
+          await plugin.getSettingsManager().updateSettings({ customTranscriptionModel: value.trim() });
+          refreshValidation();
+        });
+    });
+
+  containerEl.createEl("p", {
+    text: CUSTOM_WHISPER_CONTRACT,
+    cls: "setting-item-description",
+  });
+
+  statusEl = containerEl.createDiv({ cls: "ss-inline-note" });
+  refreshValidation();
 }
 
 async function renderMicrophoneSetting(containerEl: HTMLElement, tabInstance: SystemSculptSettingTab) {


### PR DESCRIPTION
## #211 PR-2 — Self-hosted Whisper contract + config validation + settings UI

Second slice of the #211 recording/transcription rework. Addresses the *"self-hosted Whisper: no documented endpoint contract, users can't tell what's compatible"* problem.

### What
- **`customWhisperConfig.ts`** — the documented contract (`CUSTOM_WHISPER_CONTRACT`) plus `validateCustomWhisperConfig`, a pure no-I/O config-time check (URL, protocol, path, model, key) built on PR-1's `TranscriptionConfigValidation`.
- **Live parse path** now flows through PR-1's `normalizeTranscriptionResponse`, so there is exactly one definition of a "compatible response" (raw string / `{ text }` / `{ data: { text } }` / `{ segments }`). The Groq timestamped→SRT branch is preserved verbatim.
- **Settings UI** (`RecorderTabContent`): a "Transcription provider" dropdown (SystemSculpt vs custom self-hosted Whisper) that reveals endpoint / API key / model fields, the contract help text, and inline validation messages.
- **Mobile safety**: the desktop `require("fs")` audio-read fallback is now gated behind a Node-capability check, so mobile surfaces the original read error instead of crashing on `require("fs")` (#211 / #207).

### Tests (failing-test-first)
- `customWhisperConfig.test.ts` — full validation matrix.
- `settings-recorder-tab.test.ts` — rewritten for the new provider UI + the config-time error path (the old test asserted the *absence* of these controls, so it failed by design first).
- Existing `TranscriptionService.test.ts` + `TranscriptionServiceChunkingE2E.test.ts` stay green: the multipart request body and `text` parsing are unchanged.

### Scope note
This slice delivers the **contract + validation + UI**. The fuller "provider owns the transport" extraction (moving multipart/transport off `TranscriptionService` into a `TranscriptionProvider.transcribe()`) is deferred to a focused follow-up so this PR stays small and the body-asserting transport tests stay untouched.

### Local gates (all green)
- `check:plugin:fast` ✓
- `npm test` — 5660 passed ✓
- `npm run test:integration` — 21 passed, incl. `bundle-load.no-node` + `bundle-load.mobile` ✓

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Transcription provider” selector with support for custom/self-hosted Whisper-compatible endpoints, including fields for endpoint, optional API key, and optional model.
  * Added inline, contract-based validation with real-time status messaging and guidance for the custom configuration.
* **Bug Fixes**
  * Improved transcription parsing/normalization for provider-specific response formats and added clearer failure when transcription text can’t be derived.
  * Tightened desktop audio-file reading fallback to only run when supported, with clearer errors otherwise.
* **Tests**
  * Expanded and refactored recorder-tab and custom provider validation test coverage, including provider switching and UI visibility/error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->