### PR TITLE
fix(recorder): save captured audio when iOS interrupts recording (#211 PR-3, #162)

### DIFF
--- a/src/services/RecorderService.ts
+++ b/src/services/RecorderService.ts
@@ -260,12 +260,14 @@ export class RecorderService {
     this.storeRecordingInMemory(result);
     const stoppedFromBackground =
       result.stopReason === "background-hidden" || result.stopReason === "background-pagehide";
+    const stoppedByInterruption = result.stopReason === "interrupted";
+    const stoppedUnexpectedly = stoppedFromBackground || stoppedByInterruption;
 
     const fileName = result.filePath.split("/").pop();
     const autoTranscribe = this.plugin.settings.autoTranscribeRecordings;
     if (autoTranscribe) {
-      if (stoppedFromBackground) {
-        this.ui.setStatus("Saved after lock/background interruption. Transcribing captured audio…");
+      if (stoppedUnexpectedly) {
+        this.ui.setStatus("Saved after interruption. Transcribing captured audio…");
       } else {
         this.ui.setStatus("Saved. Transcribing…");
       }
@@ -275,6 +277,11 @@ export class RecorderService {
       if (stoppedFromBackground) {
         this.ui.linger(
           `${savedMessage} iOS stopped recording when the app locked/backgrounded; keep the app unlocked for continuous recording.`,
+          4200
+        );
+      } else if (stoppedByInterruption) {
+        this.ui.linger(
+          `${savedMessage} Recording was interrupted before you stopped it; saved what was captured.`,
           4200
         );
       } else {

--- a/src/services/recorder/MicrophoneRecorder.ts
+++ b/src/services/recorder/MicrophoneRecorder.ts
@@ -1,6 +1,11 @@
 import { App } from "obsidian";
+import { logError } from "../../utils/errorHandling";
 
-export type RecorderStopReason = "manual" | "background-hidden" | "background-pagehide";
+export type RecorderStopReason =
+  | "manual"
+  | "background-hidden"
+  | "background-pagehide"
+  | "interrupted";
 
 export interface MicrophoneRecorderOptions {
   mimeType: string;
@@ -33,6 +38,7 @@ export class MicrophoneRecorder {
   private micStream: MediaStream | null = null;
   private mediaRecorder: MediaRecorder | null = null;
   private chunks: Blob[] = [];
+  private outputPath: string | null = null;
 
   private deviceChangeListener: ((this: MediaDevices, ev: Event) => any) | null = null;
   private micTrackEndListener: (() => void) | null = null;
@@ -62,6 +68,7 @@ export class MicrophoneRecorder {
 
     this.state = "starting";
     this.chunks = [];
+    this.outputPath = outputPath;
     this.stopReason = "manual";
     this.wakeLockHintShown = false;
 
@@ -76,6 +83,20 @@ export class MicrophoneRecorder {
       };
       this.mediaRecorder.onstop = async () => {
         await this.finalizeRecording(outputPath);
+      };
+      this.mediaRecorder.onerror = (event: Event) => {
+        // iOS can revoke the mic track when the screen locks and surface it as a
+        // MediaRecorder "error" rather than a clean visibilitychange/onstop.
+        // Without this handler the in-progress recording is dropped silently
+        // (#162). Treat any error while recording as an interruption so the
+        // captured chunks are still flushed to disk.
+        if (this.state !== "recording") return;
+        logError(
+          "MicrophoneRecorder",
+          "Recording interrupted by MediaRecorder error",
+          (event as { error?: unknown })?.error ?? event
+        );
+        this.stop("interrupted");
       };
 
       this.mediaRecorder.start(800);
@@ -106,6 +127,8 @@ export class MicrophoneRecorder {
     this.stopReason = reason;
     if (reason === "manual") {
       this.onStatus("Processing recording...");
+    } else if (reason === "interrupted") {
+      this.onStatus("Recording interrupted. Saving captured audio...");
     } else {
       this.onStatus("App moved to background. Saving captured audio...");
     }
@@ -240,8 +263,19 @@ export class MicrophoneRecorder {
       this.swapMicStream(next);
       this.onStatus("Microphone reconnected");
     } catch (error) {
-      this.onError(new Error(`Microphone lost: ${error instanceof Error ? error.message : String(error)}`));
-      this.stop("manual");
+      // A lock/background transition can end the mic track and then block
+      // re-acquisition (getUserMedia is unavailable while the page is hidden).
+      // Preserve the background classification so the captured audio is saved
+      // and flagged, instead of being treated as a hard failure (#162).
+      const hiddenNow = typeof document !== "undefined" && document.hidden;
+      if (hiddenNow) {
+        this.stop("background-hidden");
+      } else {
+        this.onError(
+          new Error(`Microphone lost: ${error instanceof Error ? error.message : String(error)}`)
+        );
+        this.stop("manual");
+      }
     } finally {
       this.refreshingMic = false;
     }
@@ -360,6 +394,10 @@ export class MicrophoneRecorder {
   }
 
   private async finalizeRecording(outputPath?: string): Promise<void> {
+    // Fall back to the path captured at start() so paths that finalize without
+    // re-passing it (stop()'s already-inactive branch, the onerror path) still
+    // persist the buffered audio rather than silently dropping it (#162).
+    const targetPath = outputPath ?? this.outputPath ?? undefined;
     try {
       if (this.chunks.length === 0) {
         if (this.stopReason !== "manual") {
@@ -369,15 +407,17 @@ export class MicrophoneRecorder {
       }
 
       const blob = new Blob(this.chunks, { type: this.mimeType });
-      if (outputPath) {
+      if (targetPath) {
         const arrayBuffer = await blob.arrayBuffer();
-        await this.app.vault.adapter.writeBinary(outputPath, arrayBuffer);
+        await this.app.vault.adapter.writeBinary(targetPath, arrayBuffer);
         if (this.stopReason === "manual") {
           this.onStatus("Recording saved");
+        } else if (this.stopReason === "interrupted") {
+          this.onStatus("Recording saved after interruption");
         } else {
           this.onStatus("Recording saved after app lock/background");
         }
-        this.onComplete(outputPath, blob, this.stopReason);
+        this.onComplete(targetPath, blob, this.stopReason);
       }
     } catch (error) {
       this.onError(new Error(`Save failed: ${error instanceof Error ? error.message : String(error)}`));

--- a/src/services/recorder/MicrophoneRecorder.ts
+++ b/src/services/recorder/MicrophoneRecorder.ts
@@ -418,6 +418,14 @@ export class MicrophoneRecorder {
           this.onStatus("Recording saved after app lock/background");
         }
         this.onComplete(targetPath, blob, this.stopReason);
+      } else {
+        // Defensive: outputPath is set on start(), so this should be
+        // unreachable. Surface it rather than dropping captured audio silently.
+        logError(
+          "MicrophoneRecorder",
+          "finalizeRecording reached without a target path; captured audio not saved",
+          { stopReason: this.stopReason }
+        );
       }
     } catch (error) {
       this.onError(new Error(`Save failed: ${error instanceof Error ? error.message : String(error)}`));

--- a/src/services/recorder/__tests__/MicrophoneRecorder.test.ts
+++ b/src/services/recorder/__tests__/MicrophoneRecorder.test.ts
@@ -268,6 +268,7 @@ describe("MicrophoneRecorder", () => {
     await flushPromises();
     await flushPromises();
 
+    expect((app.vault.adapter as any).writeBinary).toHaveBeenCalled();
     expect(onComplete).toHaveBeenCalledWith(
       "SystemSculpt/Recordings/bg-miclost.webm",
       expect.any(Blob),

--- a/src/services/recorder/__tests__/MicrophoneRecorder.test.ts
+++ b/src/services/recorder/__tests__/MicrophoneRecorder.test.ts
@@ -18,10 +18,12 @@ const flushPromises = async (): Promise<void> => {
 
 class MockMediaRecorder {
   public static isTypeSupported = jest.fn(() => true);
+  public static instances: MockMediaRecorder[] = [];
 
   public state: "inactive" | "recording" = "inactive";
   public ondataavailable: ((event: { data: Blob }) => void) | null = null;
   public onstop: (() => void) | null = null;
+  public onerror: ((event: { error?: unknown }) => void) | null = null;
   public requestData = jest.fn(() => {
     if (this.state !== "recording") return;
     if (this.ondataavailable) {
@@ -38,7 +40,18 @@ class MockMediaRecorder {
     this.onstop?.();
   });
 
-  public constructor(_stream: MediaStream, _options?: { mimeType?: string }) {}
+  /**
+   * Simulate the device revoking the mic (e.g. iOS lock): a real MediaRecorder
+   * fires "error" and transitions to "inactive" without a clean onstop.
+   */
+  public emitError = (error?: unknown): void => {
+    this.state = "inactive";
+    this.onerror?.({ error });
+  };
+
+  public constructor(_stream: MediaStream, _options?: { mimeType?: string }) {
+    MockMediaRecorder.instances.push(this);
+  }
 }
 
 const createTrack = (): MockTrack => ({
@@ -64,6 +77,7 @@ describe("MicrophoneRecorder", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     hiddenValue = false;
+    MockMediaRecorder.instances = [];
     Object.defineProperty(document, "hidden", {
       configurable: true,
       get: () => hiddenValue,
@@ -167,6 +181,99 @@ describe("MicrophoneRecorder", () => {
       expect.any(Blob),
       "background-pagehide"
     );
+  });
+
+  it("flushes and saves captured audio when the recorder errors mid-recording (#162)", async () => {
+    const track = createTrack();
+    const stream = createStream(track);
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: jest.fn().mockResolvedValue(stream),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+    });
+
+    const app = new App();
+    (app.vault.adapter as any).writeBinary = jest.fn().mockResolvedValue(undefined);
+    const onComplete = jest.fn();
+    const onError = jest.fn();
+
+    const recorder = new MicrophoneRecorder(app, {
+      mimeType: "audio/webm;codecs=opus",
+      extension: "webm",
+      onError,
+      onStatus: jest.fn(),
+      onComplete,
+    });
+
+    await recorder.start("SystemSculpt/Recordings/interrupted.webm");
+
+    const instance = MockMediaRecorder.instances[MockMediaRecorder.instances.length - 1];
+    // A timeslice chunk lands before the interruption (start(800) on a device).
+    instance.requestData();
+    // iOS lock revokes the track: the recorder errors and goes inactive without
+    // a clean visibilitychange/onstop. The captured audio must still be saved.
+    instance.emitError(new Error("The operation could not be performed"));
+    await flushPromises();
+
+    expect((app.vault.adapter as any).writeBinary).toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledWith(
+      "SystemSculpt/Recordings/interrupted.webm",
+      expect.any(Blob),
+      "interrupted"
+    );
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("treats a mic loss while backgrounded as a background save, not a hard failure (#162)", async () => {
+    const track = createTrack();
+    const stream = createStream(track);
+    const getUserMedia = jest
+      .fn()
+      .mockResolvedValueOnce(stream)
+      .mockRejectedValue(new Error("NotAllowedError: getUserMedia blocked while hidden"));
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+    });
+
+    const app = new App();
+    (app.vault.adapter as any).writeBinary = jest.fn().mockResolvedValue(undefined);
+    const onComplete = jest.fn();
+    const onError = jest.fn();
+
+    const recorder = new MicrophoneRecorder(app, {
+      mimeType: "audio/webm;codecs=opus",
+      extension: "webm",
+      onError,
+      onStatus: jest.fn(),
+      onComplete,
+    });
+
+    await recorder.start("SystemSculpt/Recordings/bg-miclost.webm");
+    const instance = MockMediaRecorder.instances[MockMediaRecorder.instances.length - 1];
+    instance.requestData(); // buffer a chunk before the track ends
+
+    // Device locks: the track ends AND the page is hidden, so re-acquisition fails.
+    hiddenValue = true;
+    const endedCall = track.addEventListener.mock.calls.find(([event]) => event === "ended");
+    const endedHandler = endedCall?.[1] as () => void;
+    endedHandler();
+    await flushPromises();
+    await flushPromises();
+
+    expect(onComplete).toHaveBeenCalledWith(
+      "SystemSculpt/Recordings/bg-miclost.webm",
+      expect.any(Blob),
+      "background-hidden"
+    );
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("acquires wake lock while recording and releases it on cleanup", async () => {


### PR DESCRIPTION
## What & why

Addresses #162 (part of the #211 recording/transcription rework) — on iOS the screen lock can stop an in-progress recording and the captured audio was lost.

Root cause: `MicrophoneRecorder` already handles the *clean* lock paths (`visibilitychange`/`pagehide` → save partial + wakeLock), but on iOS the lock often **revokes the mic track via a `MediaRecorder` error** (or a track `ended` while the page is hidden) instead of a clean visibility transition. There was:
- **no `MediaRecorder.onerror` handler** → an errored recording was dropped silently, and
- a **latent no-save bug**: `stop()`'s already-inactive branch and any post-error path call `finalizeRecording()` with *no output path*, so even reaching finalize saved nothing.

## Changes
- **`MicrophoneRecorder`**
  - Add `MediaRecorder.onerror` → `stop("interrupted")`, flushing buffered chunks to disk.
  - Persist `outputPath` on `start()`; `finalizeRecording()` falls back to it (fixes the latent no-save).
  - A mic re-acquisition failure **while the page is hidden** is now classified as a background save (`background-hidden`) rather than a hard failure, so the lock-induced track-`ended` path also preserves + flags the audio.
  - New `"interrupted"` value in the `RecorderStopReason` union (propagates through `RecordingSession`'s `RecordingResult`).
- **`RecorderService`** — surfaces `"interrupted"` with a clear "saved what was captured" notice (auto-transcribe + manual paths).

## Tests (failing-test-first)
`src/services/recorder/__tests__/MicrophoneRecorder.test.ts` gains an `onerror` harness + two #162 regressions:
1. recorder errors mid-recording → `writeBinary` called + `onComplete(..., "interrupted")`, no `onError`.
2. mic loss while backgrounded → `onComplete(..., "background-hidden")`, no `onError`.

Both were red before the fix, green after.

## Scope note
Deliberately scoped to #162 (iOS interruption resilience). The Android format/decode issue (#169) and iOS-vs-Android platform detection are a separate follow-up PR (PR-4), where the format-selection branch actually needs the OS distinction. One issue per PR.

## Local gates (all green)
- `npm run check:plugin:fast` — PASS (tsc, bundle, script-tests, unit)
- `npm test` — 5666 passed, 1 skipped
- `npm run test:integration` — 21 passed (incl. `bundle-load.mobile` + `bundle-load.no-node`)

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio saving reliability when recordings are interrupted by errors, app backgrounding, or device lock.
  * Prevented audio from being silently lost when recording errors occur.

* **New Features**
  * Enhanced status messages to better distinguish between different interruption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->