### PR TITLE
test(recorder): lock one-tap stop so the modal can't need repeat taps (#148)

### DIFF
--- a/src/services/recorder/RecorderUIManager.ts
+++ b/src/services/recorder/RecorderUIManager.ts
@@ -211,6 +211,10 @@ export class RecorderUIManager {
     ]);
   }
 
+  // Stop must be one tap. The first tap latches `stopRequested` and disables
+  // the button; any further taps are ignored here so a laggy webview that
+  // delivers several taps before the disabled state paints can't fire stop
+  // more than once (#148). Reset by open(): the next recording stops in one tap.
   private requestStop(): void {
     if (this.stopRequested) return;
     this.stopRequested = true;

--- a/src/services/recorder/__tests__/RecorderUIManager.test.ts
+++ b/src/services/recorder/__tests__/RecorderUIManager.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock("../../../modals/RecorderAdvancedModal", () => ({
+  openRecorderAdvancedModal: jest.fn(),
+}));
+
+import { RecorderUIManager } from "../RecorderUIManager";
+
+const stopButtons = (): HTMLButtonElement[] =>
+  Array.from(document.querySelectorAll("button[data-action-id='stop']")) as HTMLButtonElement[];
+
+// The most recently rendered Stop button. open() leaves the previous shell in
+// the DOM for a short teardown delay, so the newest button is always last.
+const latestStopButton = (): HTMLButtonElement => {
+  const buttons = stopButtons();
+  return buttons[buttons.length - 1];
+};
+
+const createManager = (variant: "mobile" | "desktop" = "mobile"): RecorderUIManager =>
+  new RecorderUIManager({
+    app: {} as any,
+    plugin: {} as any,
+    platform: { uiVariant: () => variant } as any,
+  });
+
+describe("RecorderUIManager one-tap stop (#148)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    localStorage.clear();
+  });
+
+  it("ends the recording on a single tap of Stop", () => {
+    const onStop = jest.fn();
+    const ui = createManager();
+    ui.open(onStop);
+
+    const button = latestStopButton();
+    expect(button).toBeTruthy();
+    expect(button.disabled).toBe(false);
+
+    button.click();
+
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores repeated taps so 5 mashed taps still trigger exactly one stop (#148)", () => {
+    const onStop = jest.fn();
+    const ui = createManager();
+    ui.open(onStop);
+
+    // The reported bug: the first tap looked like it did nothing, so the user
+    // tapped Stop five times. Hold the original (enabled) button reference to
+    // mimic taps that land before the UI repaints the button as disabled — the
+    // exact race seen on the Android webview in #148. Each tap must be a no-op
+    // after the first, which relies on the idempotency guard, not just the
+    // disabled attribute.
+    const button = latestStopButton();
+    for (let i = 0; i < 5; i++) {
+      button.click();
+    }
+
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables and relabels Stop after the first tap", () => {
+    const onStop = jest.fn();
+    const ui = createManager();
+    ui.open(onStop);
+
+    latestStopButton().click();
+
+    const button = latestStopButton();
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toContain("Stopping");
+  });
+
+  it("resets to one-tap stop for the next recording", () => {
+    const ui = createManager();
+
+    const firstStop = jest.fn();
+    ui.open(firstStop);
+    latestStopButton().click();
+    expect(firstStop).toHaveBeenCalledTimes(1);
+
+    const secondStop = jest.fn();
+    ui.open(secondStop);
+
+    const button = latestStopButton();
+    expect(button.disabled).toBe(false);
+    expect(button.textContent).toContain("Stop");
+
+    button.click();
+
+    expect(secondStop).toHaveBeenCalledTimes(1);
+    expect(firstStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires one-tap stop the same way on desktop", () => {
+    const onStop = jest.fn();
+    const ui = createManager("desktop");
+    ui.open(onStop);
+
+    const button = latestStopButton();
+    button.click();
+    button.click();
+
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What & why

Closes #148 — the recorder modal was reported needing **~5 taps on Stop** before the recording ended (Android, v4.4.7).

The 5.x hover-shell recorder **already fixes this**: the first tap latches `stopRequested`, disables the Stop button, and fires the stop callback exactly once (`RecorderUIManager.requestStop`). But there was **no test guarding it** — and the recorder modal had no UI-layer coverage at all — so a future refactor could silently reintroduce the multi-tap bug.

This PR adds the permanent guard the **#211 epic** explicitly calls for:

> UI test: start/stop recording is one tap each.

## What's added

A `RecorderUIManager` suite that drives the **real** hover-shell Stop button (no mock of the shell) and asserts:

- A single tap stops the recording exactly once.
- **Five mashed taps still stop exactly once** — holding the original *enabled* button reference to mimic the Android-webview race where taps land before the disabled state repaints. This specifically exercises the `if (this.stopRequested) return;` idempotency guard, not just the `disabled` attribute.
- After the first tap the button relabels to **"Stopping…"** and is disabled.
- The latch resets on the next `open()`, so the next recording is one tap again.
- The same wiring holds with the desktop UI variant.

I also documented *why* the idempotency guard exists in `requestStop`, so it isn't stripped in a later cleanup.

## Guard has teeth

Verified by temporarily removing `if (this.stopRequested) return;` — the mashed-taps test goes red (5 calls instead of 1), then green once restored. This is a regression guard for an already-fixed, closed issue (same pattern as #201 → `provider-listing.test.ts`), so it's test-only with no behavioral change.

Local gates green: `check:plugin:fast`; `npm test` (413 suites, 5678 passed/1 skipped); `test:integration` (21 passed).

Part of the #211 recording/transcription rework (PR-5).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on stop button behavior to prevent multiple triggers in laggy webviews; the button latches on first tap and resets when a new recording starts.

* **Tests**
  * Added comprehensive test suite verifying one-tap stop functionality across various scenarios, including button state transitions and behavior reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->