### PR TITLE
feat(recorder): configurable post-processing model (#97)

### DIFF
--- a/src/modals/PostProcessingModelPromptModal.ts
+++ b/src/modals/PostProcessingModelPromptModal.ts
@@ -5,6 +5,13 @@ import { StandardModal } from "../core/ui/modals/standard/StandardModal";
 interface PostProcessingModelPromptOptions {
   missingModelId: string;
   reason: string;
+  /**
+   * Whether the unavailable model is the managed SystemSculpt model. Managed
+   * problems are about licensing/availability (fix in Account); a user-chosen
+   * (BYOK) model is about provider config or picking another model (fix in
+   * Recording settings). Defaults to managed for back-compat. (#97)
+   */
+  isManaged?: boolean;
   onClose?: () => void;
 }
 
@@ -27,10 +34,19 @@ export class PostProcessingModelPromptModal extends StandardModal {
     this.options.onClose?.();
   }
 
+  private isManaged(): boolean {
+    // Back-compat: callers that don't specify treat the model as managed.
+    return this.options.isManaged !== false;
+  }
+
   private render(): void {
+    const managed = this.isManaged();
+
     this.addTitle(
       "Transcription clean-up unavailable",
-      "SystemSculpt transcription clean-up is unavailable right now."
+      managed
+        ? "SystemSculpt transcription clean-up is unavailable right now."
+        : "The post-processing model is unavailable right now."
     );
 
     const container = this.contentEl.createDiv({ cls: "ss-modal__stack" });
@@ -38,11 +54,15 @@ export class PostProcessingModelPromptModal extends StandardModal {
 
     const details = container.createEl("div", { cls: "ss-modal__callout" });
     details.createEl("p", {
-      text: "SystemSculpt still handles transcription clean-up automatically, but you can change the clean-up prompt in Recording settings.",
+      text: managed
+        ? "SystemSculpt still handles transcription clean-up automatically, but you can change the clean-up prompt in Recording settings."
+        : "Pick a different post-processing model, or fix the selected model's provider, in Recording settings.",
     });
 
     container.createEl("p", {
-      text: "Open Account to fix license or availability problems, open Recording settings to adjust the prompt, or disable post-processing until SystemSculpt is available again.",
+      text: managed
+        ? "Open Account to fix license or availability problems, open Recording settings to adjust the prompt, or disable post-processing until SystemSculpt is available again."
+        : "Open Recording settings to choose another model or fix the provider, or disable post-processing for now.",
       cls: "ss-modal__muted",
     });
 
@@ -50,17 +70,24 @@ export class PostProcessingModelPromptModal extends StandardModal {
   }
 
   private renderActions(): void {
-    this.addActionButton(
-      "Open Account",
-      () => this.openAccountSetup(),
-      true,
-      "settings"
-    );
+    const managed = this.isManaged();
+
+    // For the managed model, licensing/availability is the likely fix, so
+    // Account leads. For a user-chosen (BYOK) model, the model/provider lives in
+    // Recording settings, so that leads and Account is irrelevant (#97).
+    if (managed) {
+      this.addActionButton(
+        "Open Account",
+        () => this.openAccountSetup(),
+        true,
+        "settings"
+      );
+    }
 
     this.addActionButton(
       "Open Recording Settings",
       () => this.openRecordingSettings(),
-      false,
+      !managed,
       "mic"
     );
 

--- a/src/modals/__tests__/PostProcessingModelPromptModal.test.ts
+++ b/src/modals/__tests__/PostProcessingModelPromptModal.test.ts
@@ -4,19 +4,24 @@ import { App } from "obsidian";
 import { PostProcessingModelPromptModal } from "../PostProcessingModelPromptModal";
 
 describe("PostProcessingModelPromptModal", () => {
-  it("frames the issue as SystemSculpt availability without exposing raw model ids", () => {
+  const createPlugin = () => {
     const app = new App();
-    const plugin: any = {
+    return {
       app,
       openSettingsTab: jest.fn(),
       getSettingsManager: jest.fn(() => ({
         updateSettings: jest.fn().mockResolvedValue(undefined),
       })),
-    };
+    } as any;
+  };
+
+  it("frames the issue as SystemSculpt availability without exposing raw model ids", () => {
+    const plugin = createPlugin();
 
     const modal = new PostProcessingModelPromptModal(plugin, {
       missingModelId: "systemsculpt@@systemsculpt/ai-agent",
       reason: "SystemSculpt transcription clean-up is temporarily unavailable.",
+      isManaged: true,
     });
 
     modal.onOpen();
@@ -26,5 +31,25 @@ describe("PostProcessingModelPromptModal", () => {
     expect(text).toContain("SystemSculpt");
     expect(text).not.toContain("Model id:");
     expect(text).not.toContain("systemsculpt@@systemsculpt/ai-agent");
+  });
+
+  it("frames a BYOK model problem around the model/provider, not SystemSculpt licensing", () => {
+    const plugin = createPlugin();
+
+    const modal = new PostProcessingModelPromptModal(plugin, {
+      missingModelId: "openai@@gpt-4",
+      reason: "The post-processing model (openai@@gpt-4) is unavailable right now.",
+      isManaged: false,
+    });
+
+    modal.onOpen();
+
+    const text = modal.contentEl.textContent || "";
+    // The fix for a user-chosen model is in Recording settings, not licensing.
+    expect(text).toContain("Recording settings");
+    expect(text).toMatch(/different (post-processing )?model|another model/i);
+    // Must not imply SystemSculpt is silently running clean-up for them.
+    expect(text).not.toContain("SystemSculpt still handles transcription clean-up automatically");
+    expect(text).not.toContain("Model id:");
   });
 });

--- a/src/modals/__tests__/PostProcessingModelPromptModal.test.ts
+++ b/src/modals/__tests__/PostProcessingModelPromptModal.test.ts
@@ -15,6 +15,11 @@ describe("PostProcessingModelPromptModal", () => {
     } as any;
   };
 
+  const footerButtons = (modal: any): HTMLButtonElement[] =>
+    Array.from(modal.modalEl.querySelectorAll("button.ss-button")) as HTMLButtonElement[];
+  const buttonByText = (modal: any, label: string): HTMLButtonElement | undefined =>
+    footerButtons(modal).find((b) => (b.textContent || "").includes(label));
+
   it("frames the issue as SystemSculpt availability without exposing raw model ids", () => {
     const plugin = createPlugin();
 
@@ -31,6 +36,11 @@ describe("PostProcessingModelPromptModal", () => {
     expect(text).toContain("SystemSculpt");
     expect(text).not.toContain("Model id:");
     expect(text).not.toContain("systemsculpt@@systemsculpt/ai-agent");
+
+    // Managed recovery leads with the licensing/account fix.
+    const account = buttonByText(modal, "Open Account");
+    expect(account).toBeTruthy();
+    expect(account?.classList.contains("ss-button--primary")).toBe(true);
   });
 
   it("frames a BYOK model problem around the model/provider, not SystemSculpt licensing", () => {
@@ -51,5 +61,12 @@ describe("PostProcessingModelPromptModal", () => {
     // Must not imply SystemSculpt is silently running clean-up for them.
     expect(text).not.toContain("SystemSculpt still handles transcription clean-up automatically");
     expect(text).not.toContain("Model id:");
+
+    // BYOK recovery leads with Recording settings; the managed account/licensing
+    // path must be absent so a renderActions() regression is caught.
+    const recording = buttonByText(modal, "Open Recording Settings");
+    expect(recording).toBeTruthy();
+    expect(recording?.classList.contains("ss-button--primary")).toBe(true);
+    expect(buttonByText(modal, "Open Account")).toBeUndefined();
   });
 });

--- a/src/services/PostProcessingService.ts
+++ b/src/services/PostProcessingService.ts
@@ -2,6 +2,7 @@ import { SystemSculptService } from "./SystemSculptService";
 import {
   getManagedSystemSculptModelId,
   hasManagedSystemSculptAccess,
+  isManagedSystemSculptModelId,
 } from "./systemsculpt/ManagedSystemSculptModel";
 import type SystemSculptPlugin from "../main";
 
@@ -27,11 +28,27 @@ export class PostProcessingService {
   }
 
   /**
-   * Get the model ID to use for post-processing
+   * Resolve the model ID to use for post-processing.
+   *
+   * #97: post-processing has its own model so users can run clean-up on a
+   * fast/cheap model while keeping a stronger model for chat. Resolution order:
+   *   1. `postProcessingModelId` — the dedicated model the user picked.
+   *   2. `selectedModelId` — the active chat model, so post-processing "just
+   *      works" for BYOK users (and matches the model they already see) when no
+   *      dedicated model is chosen.
+   *   3. the managed SystemSculpt model — last resort for a fresh install that
+   *      has no chat model selected yet.
+   *
    * @returns The canonical model ID
    */
   private getPostProcessingModelId(): string {
-    return getManagedSystemSculptModelId();
+    const configured = String(this.plugin.settings.postProcessingModelId || "").trim();
+    if (configured) {
+      return configured;
+    }
+
+    const chatModel = String(this.plugin.settings.selectedModelId || "").trim();
+    return chatModel || getManagedSystemSculptModelId();
   }
 
   async processTranscription(text: string): Promise<string> {
@@ -41,7 +58,11 @@ export class PostProcessingService {
 
     try {
       const modelId = this.getPostProcessingModelId();
-      if (!hasManagedSystemSculptAccess(this.plugin)) {
+      // Only the managed SystemSculpt model is gated behind a SystemSculpt
+      // license. A BYOK model routes through the same provider runtime the chat
+      // uses, so it must never be blocked behind managed access (#97) — let
+      // availability validation handle a misconfigured BYOK provider instead.
+      if (isManagedSystemSculptModelId(modelId) && !hasManagedSystemSculptAccess(this.plugin)) {
         await this.promptPostProcessingModelFix(modelId);
         return text;
       }
@@ -135,12 +156,18 @@ export class PostProcessingService {
   }
 
   private buildModelUnavailableReason(modelId: string): string {
+    // A user-chosen (BYOK) post-processing model fails for provider/config
+    // reasons, not licensing — keep this guidance model-agnostic (#97).
+    if (!isManagedSystemSculptModelId(modelId)) {
+      return `The post-processing model (${modelId}) is unavailable right now. Make sure its provider is configured in Setup, pick a different post-processing model in the Recorder settings, or disable post-processing for now.`;
+    }
+
     if (!this.plugin.settings.licenseKey?.trim()) {
-      return "Post-processing now runs only through SystemSculpt, but no license key is configured. Add your license in Setup to continue.";
+      return "Post-processing is set to the managed SystemSculpt model, but no license key is configured. Add your license in Setup, or choose your own post-processing model in the Recorder settings.";
     }
 
     if (this.plugin.settings.licenseValid !== true) {
-      return "Post-processing now runs only through SystemSculpt, but the current license has not been validated yet. Validate it in Setup to continue.";
+      return "Post-processing is set to the managed SystemSculpt model, but the current license has not been validated yet. Validate it in Setup, or choose your own post-processing model in the Recorder settings.";
     }
 
     return `The managed SystemSculpt post-processing model (${modelId}) is unavailable right now. Check Setup and your connection, or disable post-processing for now.`;

--- a/src/services/PostProcessingService.ts
+++ b/src/services/PostProcessingService.ts
@@ -139,6 +139,7 @@ export class PostProcessingService {
     const modal = new PostProcessingModelPromptModal(this.plugin, {
       missingModelId: modelId,
       reason,
+      isManaged: isManagedSystemSculptModelId(modelId),
       onClose: () => {
         PostProcessingService.promptVisible = false;
       },

--- a/src/services/__tests__/PostProcessingService.test.ts
+++ b/src/services/__tests__/PostProcessingService.test.ts
@@ -366,9 +366,14 @@ describe("PostProcessingService", () => {
       const service = PostProcessingService.getInstance(mockPlugin);
       const reason = (service as any).buildModelUnavailableReason(CONFIGURED_MODEL_ID);
 
+      // Names the offending model and points at the provider/model controls.
       expect(reason).toContain(CONFIGURED_MODEL_ID);
-      // The whole point of #97 is that post-processing is no longer SystemSculpt-only.
-      expect(reason).not.toContain("only through SystemSculpt");
+      expect(reason).toMatch(/provider/i);
+      expect(reason).toMatch(/Recorder settings|different post-processing model/i);
+      // A BYOK failure must never be framed as a SystemSculpt licensing problem,
+      // under any wording (#97) — guard the whole concept, not one stale phrase.
+      expect(reason).not.toMatch(/license/i);
+      expect(reason).not.toMatch(/SystemSculpt/i);
     });
 
     it("explains when the license key is missing for the managed model", () => {

--- a/src/services/__tests__/PostProcessingService.test.ts
+++ b/src/services/__tests__/PostProcessingService.test.ts
@@ -2,7 +2,15 @@ import { PostProcessingService } from "../PostProcessingService";
 import { SystemSculptError } from "../../utils/errors";
 import { DEFAULT_SETTINGS } from "../../types";
 
+// The canonical managed SystemSculpt model id. getPostProcessingModelId() only
+// resolves to this as a last-resort fallback now (#97) — it is no longer the
+// hardcoded post-processing model.
 const MANAGED_MODEL_ID = "systemsculpt@@systemsculpt/ai-agent";
+// A BYOK model the user explicitly chose for post-processing.
+const CONFIGURED_MODEL_ID = "openai@@gpt-4";
+// The active chat model (selectedModelId) — the fallback when no dedicated
+// post-processing model is set.
+const CHAT_MODEL_ID = "anthropic@@claude-sonnet-4";
 
 const createMockSculptService = () => ({
   streamMessage: jest.fn(),
@@ -26,9 +34,10 @@ const createMockPlugin = () => ({
   settings: {
     postProcessingEnabled: true,
     postProcessingPrompt: "Process this text",
-    postProcessingModelId: "openai@@gpt-4",
+    // By default the user has chosen a dedicated BYOK post-processing model.
+    postProcessingModelId: CONFIGURED_MODEL_ID,
     postProcessingProviderId: "openai",
-    selectedModelId: "anthropic@@claude-sonnet-4",
+    selectedModelId: CHAT_MODEL_ID,
     useLatestModelEverywhere: false,
     settingsMode: "advanced",
     licenseKey: "valid-license",
@@ -61,17 +70,34 @@ describe("PostProcessingService", () => {
   });
 
   describe("getPostProcessingModelId (private)", () => {
-    it("always returns the managed SystemSculpt model", () => {
+    it("uses the dedicated post-processing model when one is configured (#97)", () => {
       const service = PostProcessingService.getInstance(mockPlugin);
       const modelId = (service as any).getPostProcessingModelId();
 
-      expect(modelId).toBe(MANAGED_MODEL_ID);
+      expect(modelId).toBe(CONFIGURED_MODEL_ID);
     });
 
-    it("ignores legacy post-processing model settings", () => {
-      mockPlugin.settings.postProcessingModelId = "custom-provider@@custom-model";
-      mockPlugin.settings.postProcessingProviderId = "custom-provider";
-      mockPlugin.settings.selectedModelId = "openai@@gpt-4.1";
+    it("falls back to the active chat model when no post-processing model is set", () => {
+      mockPlugin.settings.postProcessingModelId = "";
+
+      const service = PostProcessingService.getInstance(mockPlugin);
+      const modelId = (service as any).getPostProcessingModelId();
+
+      expect(modelId).toBe(CHAT_MODEL_ID);
+    });
+
+    it("treats a blank/whitespace post-processing model as unset", () => {
+      mockPlugin.settings.postProcessingModelId = "   ";
+
+      const service = PostProcessingService.getInstance(mockPlugin);
+      const modelId = (service as any).getPostProcessingModelId();
+
+      expect(modelId).toBe(CHAT_MODEL_ID);
+    });
+
+    it("falls back to the managed model only when neither a post-processing nor chat model exists", () => {
+      mockPlugin.settings.postProcessingModelId = "";
+      mockPlugin.settings.selectedModelId = "";
 
       const service = PostProcessingService.getInstance(mockPlugin);
       const modelId = (service as any).getPostProcessingModelId();
@@ -93,8 +119,32 @@ describe("PostProcessingService", () => {
       expect(mockSculptService.streamMessage).not.toHaveBeenCalled();
     });
 
-    it("returns the original text and opens recovery guidance when managed access is missing", async () => {
+    it("post-processes through a BYOK model without a SystemSculpt license (#97)", async () => {
       const { PostProcessingModelPromptModal } = require("../../modals/PostProcessingModelPromptModal");
+      // BYOK user: no managed access at all.
+      mockPlugin.settings.licenseKey = "";
+      mockPlugin.settings.licenseValid = false;
+      mockSculptService.streamMessage.mockReturnValue(
+        (async function* () {
+          yield { type: "content", text: "clean text" };
+        })()
+      );
+
+      const service = PostProcessingService.getInstance(mockPlugin);
+      await expect(service.processTranscription("raw text")).resolves.toBe("clean text");
+
+      // The dedicated BYOK model routes through the same provider runtime the
+      // chat uses — it must not be blocked behind a managed license.
+      expect(mockSculptService.streamMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ model: CONFIGURED_MODEL_ID })
+      );
+      expect(PostProcessingModelPromptModal).not.toHaveBeenCalled();
+    });
+
+    it("returns the original text and opens recovery guidance only when the managed model is selected without access", async () => {
+      const { PostProcessingModelPromptModal } = require("../../modals/PostProcessingModelPromptModal");
+      // The managed model is selected, but there is no valid license.
+      mockPlugin.settings.postProcessingModelId = MANAGED_MODEL_ID;
       mockPlugin.settings.licenseKey = "";
       mockPlugin.settings.licenseValid = false;
 
@@ -110,7 +160,7 @@ describe("PostProcessingService", () => {
       );
     });
 
-    it("processes text through the managed SystemSculpt model", async () => {
+    it("processes text through the configured post-processing model (#97)", async () => {
       mockSculptService.streamMessage.mockReturnValue(
         (async function* () {
           yield { type: "content", text: "Processed " };
@@ -122,7 +172,7 @@ describe("PostProcessingService", () => {
       await expect(service.processTranscription("original text")).resolves.toBe("Processed text");
       expect(mockSculptService.streamMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: MANAGED_MODEL_ID,
+          model: CONFIGURED_MODEL_ID,
           messages: expect.arrayContaining([
             expect.objectContaining({
               role: "system",
@@ -134,6 +184,21 @@ describe("PostProcessingService", () => {
             }),
           ]),
         })
+      );
+    });
+
+    it("falls back to the chat model when no post-processing model is set", async () => {
+      mockPlugin.settings.postProcessingModelId = "";
+      mockSculptService.streamMessage.mockReturnValue(
+        (async function* () {
+          yield { type: "content", text: "done" };
+        })()
+      );
+
+      const service = PostProcessingService.getInstance(mockPlugin);
+      await expect(service.processTranscription("text")).resolves.toBe("done");
+      expect(mockSculptService.streamMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ model: CHAT_MODEL_ID })
       );
     });
 
@@ -159,7 +224,7 @@ describe("PostProcessingService", () => {
       );
     });
 
-    it("returns the original text when validation says the managed model is unavailable", async () => {
+    it("returns the original text when validation says the model is unavailable", async () => {
       mockPlugin.modelService.validateSpecificModel.mockResolvedValueOnce({
         isAvailable: false,
       });
@@ -236,15 +301,15 @@ describe("PostProcessingService", () => {
   });
 
   describe("ensurePostProcessingModelAvailability (private)", () => {
-    it("resolves when the managed model is available", async () => {
+    it("resolves when the model is available", async () => {
       const service = PostProcessingService.getInstance(mockPlugin);
 
       await expect(
-        (service as any).ensurePostProcessingModelAvailability(MANAGED_MODEL_ID)
+        (service as any).ensurePostProcessingModelAvailability(CONFIGURED_MODEL_ID)
       ).resolves.not.toThrow();
     });
 
-    it("throws a SystemSculptError when the managed model is unavailable", async () => {
+    it("throws a SystemSculptError when the model is unavailable", async () => {
       mockPlugin.modelService.validateSpecificModel.mockResolvedValueOnce({
         isAvailable: false,
       });
@@ -252,11 +317,11 @@ describe("PostProcessingService", () => {
       const service = PostProcessingService.getInstance(mockPlugin);
 
       await expect(
-        (service as any).ensurePostProcessingModelAvailability(MANAGED_MODEL_ID)
+        (service as any).ensurePostProcessingModelAvailability(CONFIGURED_MODEL_ID)
       ).rejects.toThrow(SystemSculptError);
     });
 
-    it("includes the managed model id in error metadata", async () => {
+    it("includes the model id in error metadata", async () => {
       mockPlugin.modelService.validateSpecificModel.mockResolvedValueOnce({
         isAvailable: false,
       });
@@ -264,11 +329,11 @@ describe("PostProcessingService", () => {
       const service = PostProcessingService.getInstance(mockPlugin);
 
       try {
-        await (service as any).ensurePostProcessingModelAvailability(MANAGED_MODEL_ID);
+        await (service as any).ensurePostProcessingModelAvailability(CONFIGURED_MODEL_ID);
         fail("Expected error");
       } catch (error) {
         expect(error).toBeInstanceOf(SystemSculptError);
-        expect((error as SystemSculptError).metadata?.model).toBe(MANAGED_MODEL_ID);
+        expect((error as SystemSculptError).metadata?.model).toBe(CONFIGURED_MODEL_ID);
       }
     });
 
@@ -279,11 +344,11 @@ describe("PostProcessingService", () => {
       const service = PostProcessingService.getInstance(mockPlugin);
 
       await expect(
-        (service as any).ensurePostProcessingModelAvailability(MANAGED_MODEL_ID)
+        (service as any).ensurePostProcessingModelAvailability(CONFIGURED_MODEL_ID)
       ).rejects.toBe(originalError);
     });
 
-    it("wraps validation failures as managed-model unavailability", async () => {
+    it("wraps validation failures as model unavailability", async () => {
       mockPlugin.modelService.validateSpecificModel.mockRejectedValueOnce(
         new Error("Validation failed")
       );
@@ -291,13 +356,22 @@ describe("PostProcessingService", () => {
       const service = PostProcessingService.getInstance(mockPlugin);
 
       await expect(
-        (service as any).ensurePostProcessingModelAvailability(MANAGED_MODEL_ID)
+        (service as any).ensurePostProcessingModelAvailability(CONFIGURED_MODEL_ID)
       ).rejects.toThrow(SystemSculptError);
     });
   });
 
   describe("buildModelUnavailableReason (private)", () => {
-    it("explains when the license key is missing", () => {
+    it("gives model-agnostic guidance for a non-managed (BYOK) model", () => {
+      const service = PostProcessingService.getInstance(mockPlugin);
+      const reason = (service as any).buildModelUnavailableReason(CONFIGURED_MODEL_ID);
+
+      expect(reason).toContain(CONFIGURED_MODEL_ID);
+      // The whole point of #97 is that post-processing is no longer SystemSculpt-only.
+      expect(reason).not.toContain("only through SystemSculpt");
+    });
+
+    it("explains when the license key is missing for the managed model", () => {
       mockPlugin.settings.licenseKey = "";
 
       const service = PostProcessingService.getInstance(mockPlugin);
@@ -307,7 +381,7 @@ describe("PostProcessingService", () => {
       expect(reason).toContain("SystemSculpt");
     });
 
-    it("explains when the license has not been validated", () => {
+    it("explains when the managed license has not been validated", () => {
       mockPlugin.settings.licenseKey = "valid";
       mockPlugin.settings.licenseValid = false;
 
@@ -318,7 +392,7 @@ describe("PostProcessingService", () => {
       expect(reason).toContain("Setup");
     });
 
-    it("returns a generic managed-service reason for runtime failures", () => {
+    it("returns a generic managed-service reason for managed runtime failures", () => {
       const service = PostProcessingService.getInstance(mockPlugin);
       const reason = (service as any).buildModelUnavailableReason(MANAGED_MODEL_ID);
 

--- a/src/settings/RecorderTabContent.ts
+++ b/src/settings/RecorderTabContent.ts
@@ -76,7 +76,7 @@ export async function displayRecorderTabContent(containerEl: HTMLElement, tabIns
 
   new Setting(containerEl)
     .setName("Enable post-processing")
-    .setDesc("Apply SystemSculpt clean-up after transcription completes.")
+    .setDesc("Clean up the transcription with an LLM after it completes.")
     .addToggle((toggle) => {
       toggle
         .setValue(plugin.settings.postProcessingEnabled)
@@ -85,10 +85,43 @@ export async function displayRecorderTabContent(containerEl: HTMLElement, tabIns
         });
     });
 
+  // #97: a dedicated post-processing model. Clean-up is a cheap, mechanical
+  // task, so users want to run it on a fast/cheap model while keeping a stronger
+  // model for chat. Empty value = "use the chat model" (the PostProcessingService
+  // fallback), which keeps the default behavior and works for BYOK users.
+  new Setting(containerEl)
+    .setName("Post-processing model")
+    .setDesc(
+      "Model used for transcription clean-up. Defaults to your chat model — pick a faster or cheaper model here to keep chat on a stronger one."
+    )
+    .addDropdown((dropdown) => {
+      dropdown.addOption("", "Use chat model (default)");
+      dropdown.setValue(plugin.settings.postProcessingModelId || "");
+      dropdown.onChange(async (value) => {
+        await plugin.getSettingsManager().updateSettings({ postProcessingModelId: value });
+      });
+      // Populate the model list asynchronously. The dropdown stays usable with
+      // the default option while models load, and failures degrade gracefully
+      // (clean-up still runs via the chat model).
+      void (async () => {
+        try {
+          const models = await plugin.modelService.getModels();
+          for (const model of models) {
+            const label = String(model.name || model.id || "").trim() || model.id;
+            dropdown.addOption(model.id, label);
+          }
+          // Re-apply the stored selection now that its option exists.
+          dropdown.setValue(plugin.settings.postProcessingModelId || "");
+        } catch {
+          // Leave the default-only dropdown in place.
+        }
+      })();
+    });
+
   let postProcessingPromptText: HTMLTextAreaElement | null = null;
   new Setting(containerEl)
     .setName("Transcription clean-up prompt")
-    .setDesc("Optional. Adjust the clean-up instructions while SystemSculpt continues to run the managed cleanup step.")
+    .setDesc("Optional. Adjust the instructions used for the transcription clean-up step.")
     .addTextArea((text) => {
       postProcessingPromptText = text.inputEl;
       text

--- a/src/settings/RecorderTabContent.ts
+++ b/src/settings/RecorderTabContent.ts
@@ -95,9 +95,13 @@ export async function displayRecorderTabContent(containerEl: HTMLElement, tabIns
       "Model used for transcription clean-up. Defaults to your chat model — pick a faster or cheaper model here to keep chat on a stronger one."
     )
     .addDropdown((dropdown) => {
+      // Guards the late re-apply below: if the user picks a value while the
+      // model list is still loading, don't clobber their choice.
+      let userSelected = false;
       dropdown.addOption("", "Use chat model (default)");
       dropdown.setValue(plugin.settings.postProcessingModelId || "");
       dropdown.onChange(async (value) => {
+        userSelected = true;
         await plugin.getSettingsManager().updateSettings({ postProcessingModelId: value });
       });
       // Populate the model list asynchronously. The dropdown stays usable with
@@ -110,8 +114,11 @@ export async function displayRecorderTabContent(containerEl: HTMLElement, tabIns
             const label = String(model.name || model.id || "").trim() || model.id;
             dropdown.addOption(model.id, label);
           }
-          // Re-apply the stored selection now that its option exists.
-          dropdown.setValue(plugin.settings.postProcessingModelId || "");
+          // Re-apply the stored selection now that its option exists — unless the
+          // user already chose something while the list was loading.
+          if (!userSelected) {
+            dropdown.setValue(plugin.settings.postProcessingModelId || "");
+          }
         } catch {
           // Leave the default-only dropdown in place.
         }


### PR DESCRIPTION
## Summary

Closes #97. Part of the #211 recording/transcription rework (PR-6).

Post-processing (transcription clean-up) was **hardcoded to the managed SystemSculpt model** and gated behind a SystemSculpt license — it ignored the long-orphaned `postProcessingModelId` / `postProcessingProviderId` settings, whose own default comment in `types.ts` already promised *"logic should handle fallback if unset."* That meant:

- No way to run clean-up on a cheaper/faster model (exactly what #97 asks for: *"a fast, cheap LLM for the post-processing, but ... something much more complex for my chat model"*).
- BYOK users (no SystemSculpt license) **could not post-process at all** — the managed-access gate blocked them.

## What changed

**`PostProcessingService` — canonical model resolution** (`getPostProcessingModelId`):
1. `postProcessingModelId` — the dedicated model the user picks.
2. `selectedModelId` — the active chat model (BYOK-aware) when no dedicated model is set. Matches #97's expected default and restores BYOK post-processing.
3. the managed SystemSculpt model — last resort for a fresh install with no chat model chosen.

**License gate, scoped correctly:** the managed-access check now fires *only* when the resolved model is actually the managed SystemSculpt model (`isManagedSystemSculptModelId`). BYOK models route through the same provider runtime the chat uses (`SystemSculptService.streamMessage`) and are validated via `modelService.validateSpecificModel`, exactly like chat — no license wall (aligns with #209).

**Model-aware guidance:** `buildModelUnavailableReason` gives provider/config guidance for a BYOK model and license guidance for the managed model (no more "post-processing now runs only through SystemSculpt").

**Settings UI:** a new **"Post-processing model"** dropdown in the Recorder tab (empty = *"Use chat model (default)"*), populated from `modelService.getModels()` with graceful degradation if the list fails to load.

## Re-architecture note (per AGENTS.md)

This supersedes the managed-only slop rather than patching around it — the orphaned settings + their own "fallback if unset" comment show this was the original intent that an earlier rewrite left unwired.

## Tests (failing-test-first)

`PostProcessingService.test.ts` rewritten to encode the new contract — verified red against the old hardcoded code first, then green:
- resolves the configured model; falls back to chat model; managed only as last resort
- **BYOK model post-processes without a SystemSculpt license** (the key regression guard)
- managed-model-without-access still shows recovery guidance
- model-agnostic unavailable reason for BYOK models

Local gates green: `check:plugin:fast`, full unit (413 suites / 5683 passed), `test:integration` (6 suites / 21).

## Deferred

Temperature (a *"maybe"* in #97) is out of scope: the plugin has **no temperature concept anywhere** today, so it would require threading a new parameter through the entire `streamMessage` → provider-executor chain. Left for a focused follow-up.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added post-processing model selection dropdown in recording settings, enabling users to choose a dedicated model for transcription clean-up instead of using the chat model by default.

* **Improvements**
  * Updated modal messaging to distinguish between managed and unmanaged post-processing models with context-specific guidance.
  * Refined wording in recording settings to clarify transcription clean-up functionality and model availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->