### PR TITLE
fix(youtube): actionable message for transcript quota (429), no cross-transport retry (#152)

### DIFF
--- a/src/services/YouTubeTranscriptService.ts
+++ b/src/services/YouTubeTranscriptService.ts
@@ -37,6 +37,69 @@ interface TranscriptResponse {
 }
 
 /**
+ * Shape of an error payload relayed by the SystemSculpt YouTube transcript
+ * endpoint. Quota exhaustion arrives either as `{ error: "limit-exceeded", ... }`
+ * or, for async jobs, as a failed job whose `error` text embeds the upstream
+ * "429 - limit-exceeded" message (#152).
+ */
+export interface YouTubeTranscriptErrorPayload {
+  error?: string;
+  message?: string;
+  details?: string;
+}
+
+// The ways the backend signals an exhausted transcript quota, whether it relays
+// a raw provider code, an HTTP 429, or a human-readable details line.
+const TRANSCRIPT_QUOTA_PATTERN =
+  /limit[\s_-]?exceeded|usage limit|quota|rate[\s_-]?limit|too many requests|\b429\b/i;
+
+/**
+ * Turn a failed YouTube-transcript response into a clear, user-facing message.
+ *
+ * The transcript runs through the SystemSculpt backend, which calls the upstream
+ * transcript provider; when the shared plan is over quota the backend relays a
+ * 429 `limit-exceeded`. Surfacing that raw payload to the user is noise (#152),
+ * so quota exhaustion becomes actionable guidance. Any other failure keeps the
+ * server's own message (usually already specific, e.g. "Invalid video id").
+ */
+export function describeYouTubeTranscriptError(
+  status?: number,
+  payload?: YouTubeTranscriptErrorPayload | null
+): string {
+  const text = [payload?.error, payload?.message, payload?.details]
+    .map((part) => (typeof part === "string" ? part : ""))
+    .join(" ");
+
+  if (status === 429 || TRANSCRIPT_QUOTA_PATTERN.test(text)) {
+    return "YouTube transcription is temporarily unavailable because the transcript service has reached its usage limit. Please try again in a little while.";
+  }
+
+  const specific = (payload?.error || payload?.message || "").trim();
+  if (specific) return specific;
+  if (typeof status === "number" && status > 0) {
+    return `YouTube transcript request failed (HTTP ${status}).`;
+  }
+  return "YouTube transcript request failed.";
+}
+
+/**
+ * A definitive HTTP error *response* from the transcript endpoint (as opposed to
+ * a transport failure). Carrying the typed status lets `makeRequest` avoid
+ * pointlessly re-attempting a server-answered request on the other transport,
+ * and its message is already the user-facing form from
+ * `describeYouTubeTranscriptError`. (#152)
+ */
+export class YouTubeTranscriptHttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number, payload?: YouTubeTranscriptErrorPayload | null) {
+    super(describeYouTubeTranscriptError(status, payload));
+    this.name = "YouTubeTranscriptHttpError";
+    this.status = status;
+  }
+}
+
+/**
  * Service for extracting transcripts from YouTube videos via the SystemSculpt API
  */
 export class YouTubeTranscriptService {
@@ -121,7 +184,11 @@ export class YouTubeTranscriptService {
 
     // Immediate result
     if (!response.text) {
-      throw new Error(response.error || "No transcript returned");
+      throw new Error(
+        describeYouTubeTranscriptError(undefined, {
+          error: response.error || "No transcript returned",
+        })
+      );
     }
 
     console.log("[YouTubeTranscriptService] Transcript received:", {
@@ -165,7 +232,13 @@ export class YouTubeTranscriptService {
       }
 
       if (response.status === "failed") {
-        throw new Error(response.error || "Transcript generation failed");
+        // The job failed upstream; the cause (often a relayed 429 quota error)
+        // lives in `response.error`. Map it to actionable guidance (#152).
+        throw new Error(
+          describeYouTubeTranscriptError(undefined, {
+            error: response.error || "Transcript generation failed",
+          })
+        );
       }
 
       console.log("[YouTubeTranscriptService] Job still processing:", {
@@ -210,9 +283,9 @@ export class YouTubeTranscriptService {
         console.log("[YouTubeTranscriptService] Response status:", response.status);
 
         if (response.status >= 400) {
-          const errorData = response.json || {};
+          const errorData = (response.json || {}) as YouTubeTranscriptErrorPayload;
           console.error("[YouTubeTranscriptService] Error response:", errorData);
-          throw new Error(errorData.error || `HTTP ${response.status}`);
+          throw new YouTubeTranscriptHttpError(response.status, errorData);
         }
 
         return response.json as TranscriptResponse;
@@ -232,13 +305,21 @@ export class YouTubeTranscriptService {
         console.log("[YouTubeTranscriptService] Response status:", response.status);
 
         if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}));
+          const errorData = (await response
+            .json()
+            .catch(() => ({}))) as YouTubeTranscriptErrorPayload;
           console.error("[YouTubeTranscriptService] Error response:", errorData);
-          throw new Error(errorData.error || `HTTP ${response.status}`);
+          throw new YouTubeTranscriptHttpError(response.status, errorData);
         }
 
         return (await response.json()) as TranscriptResponse;
       } catch (fetchError) {
+        // A definitive HTTP error response is the server's answer, not a
+        // transport failure — don't burn a second request on the other
+        // transport (which would just re-surface the same status) (#152).
+        if (fetchError instanceof YouTubeTranscriptHttpError) {
+          throw fetchError;
+        }
         console.warn("[YouTubeTranscriptService] Fetch request failed; retrying via requestUrl", {
           endpoint,
           message: fetchError instanceof Error ? fetchError.message : String(fetchError),

--- a/src/services/__tests__/YouTubeTranscriptService.test.ts
+++ b/src/services/__tests__/YouTubeTranscriptService.test.ts
@@ -1,5 +1,8 @@
 import { requestUrl } from "obsidian";
-import { YouTubeTranscriptService } from "../YouTubeTranscriptService";
+import {
+  YouTubeTranscriptService,
+  describeYouTubeTranscriptError,
+} from "../YouTubeTranscriptService";
 import { PlatformContext } from "../PlatformContext";
 import { WEBSITE_API_BASE_URL } from "../../constants/api";
 
@@ -140,5 +143,133 @@ describe("YouTubeTranscriptService", () => {
       `${WEBSITE_API_BASE_URL}/youtube/transcripts/job123`
     );
     expect((globalThis.fetch as jest.Mock).mock.calls[1][1].method).toBe("GET");
+  });
+
+  // #152: the transcript runs through the SystemSculpt backend, which calls
+  // Supadata. When the shared Supadata plan is over quota the backend relays a
+  // 429 `limit-exceeded`. The client used to surface that raw payload; it must
+  // instead show actionable guidance and not waste a second transport attempt.
+  it("maps a 429 limit-exceeded (fetch) to actionable guidance and does not retry the other transport (#152)", async () => {
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({
+        error: "limit-exceeded",
+        message: "Limit Exceeded",
+        details: "Plan usage limit was exceeded.",
+      }),
+    });
+
+    const service = YouTubeTranscriptService.getInstance(buildPluginStub());
+    const err = (await service.getTranscript(testUrl).catch((e) => e)) as Error;
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toMatch(/usage limit/i);
+    expect(err.message).toMatch(/try again/i);
+    expect(err.message).not.toMatch(/[{}]/); // no raw JSON payload
+    expect(err.message).not.toMatch(/supadata/i); // no vendor leak
+    expect(err.message).not.toMatch(/limit-exceeded/); // no raw error code
+
+    // A definitive HTTP response must not be re-attempted via requestUrl.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(requestUrl).not.toHaveBeenCalled();
+  });
+
+  it("maps a 429 to actionable guidance when requestUrl is the transport (#152)", async () => {
+    platformGetSpy.mockReturnValue({
+      preferredTransport: jest.fn(() => "requestUrl"),
+    } as any);
+    (requestUrl as jest.Mock).mockResolvedValue({
+      status: 429,
+      json: {
+        error: "limit-exceeded",
+        message: "Limit Exceeded",
+        details: "Plan usage limit was exceeded.",
+      },
+    });
+
+    const service = YouTubeTranscriptService.getInstance(buildPluginStub());
+    const err = (await service.getTranscript(testUrl).catch((e) => e)) as Error;
+
+    expect(err.message).toMatch(/usage limit/i);
+    expect(err.message).not.toMatch(/[{}]/);
+    expect(requestUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps a failed async job carrying a Supadata limit error to actionable guidance (#152)", async () => {
+    (globalThis.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "processing", jobId: "job429" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status: "failed",
+          error:
+            'Supadata transcript failed: 429 - {"error":"limit-exceeded","message":"Limit Exceeded","details":"Plan usage limit was exceeded."}',
+        }),
+      });
+
+    const service = YouTubeTranscriptService.getInstance(buildPluginStub());
+    jest.spyOn(service as any, "sleep").mockResolvedValue(undefined);
+
+    const err = (await service.getTranscript(testUrl).catch((e) => e)) as Error;
+    expect(err.message).toMatch(/usage limit/i);
+    expect(err.message).not.toMatch(/[{}]/);
+    expect(err.message).not.toMatch(/supadata/i);
+  });
+
+  it("preserves a non-quota server error message instead of forcing the quota copy (#152)", async () => {
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "Invalid video id" }),
+    });
+
+    const service = YouTubeTranscriptService.getInstance(buildPluginStub());
+    const err = (await service.getTranscript(testUrl).catch((e) => e)) as Error;
+
+    expect(err.message).toBe("Invalid video id");
+    // 400 is a definitive client error; do not retry the other transport.
+    expect(requestUrl).not.toHaveBeenCalled();
+  });
+});
+
+describe("describeYouTubeTranscriptError (#152)", () => {
+  it("maps an HTTP 429 to actionable, payload-free guidance", () => {
+    const msg = describeYouTubeTranscriptError(429, null);
+    expect(msg).toMatch(/usage limit/i);
+    expect(msg).toMatch(/try again/i);
+    expect(msg).not.toMatch(/[{}]/);
+  });
+
+  it("detects quota exhaustion from the relayed Supadata error text regardless of status", () => {
+    const msg = describeYouTubeTranscriptError(undefined, {
+      error: 'Supadata transcript failed: 429 - {"error":"limit-exceeded"}',
+    });
+    expect(msg).toMatch(/usage limit/i);
+    expect(msg).not.toMatch(/supadata/i);
+    expect(msg).not.toMatch(/[{}]/);
+  });
+
+  it("matches a 'Plan usage limit was exceeded' details string", () => {
+    const msg = describeYouTubeTranscriptError(undefined, {
+      details: "Plan usage limit was exceeded.",
+    });
+    expect(msg).toMatch(/usage limit/i);
+  });
+
+  it("preserves a specific non-quota server message", () => {
+    expect(describeYouTubeTranscriptError(400, { error: "Invalid video id" })).toBe(
+      "Invalid video id"
+    );
+  });
+
+  it("falls back to a generic message when nothing useful is provided", () => {
+    expect(describeYouTubeTranscriptError(500, {})).toMatch(/failed/i);
+    expect(describeYouTubeTranscriptError(undefined, null)).toMatch(/failed/i);
   });
 });


### PR DESCRIPTION
## What & why (#152, #211 PR-7)

`YouTube canvas → Get Transcript` failed with a raw payload dumped at the user:

```
Supadata transcript failed: 429 - {"error":"limit-exceeded","message":"Limit Exceeded","details":"Plan usage limit was exceeded."}
```

The transcript runs through the SystemSculpt backend (`/youtube/transcripts`), which calls the upstream transcript provider. When the shared managed plan is over quota the backend relays a **429 `limit-exceeded`**, and the client surfaced that JSON verbatim.

### Root cause vs. this PR's scope
The **root cause is server-side** — the managed plan's quota is exhausted — and is out of this client repo's scope to fix. This PR is the **client-side failure-UX fix**: turn the relayed quota error into clear, actionable guidance instead of a raw payload.

## Changes (`src/services/YouTubeTranscriptService.ts`)
- **`describeYouTubeTranscriptError(status, payload)`** — pure mapper. Quota exhaustion (`429`, `limit-exceeded`, `usage limit`, `quota`, `too many requests`) → *"YouTube transcription is temporarily unavailable because the transcript service has reached its usage limit. Please try again in a little while."* No raw JSON, no vendor name leaked. Any **non-quota** failure keeps the server's own specific message (e.g. `Invalid video id`).
- Mapping applied at **every throw-site**: immediate result, polled async-job failure, and both transports (`fetch` + `requestUrl`).
- **Re-architect the touched path** (per AGENTS.md): a definitive HTTP error *response* is now a typed **`YouTubeTranscriptHttpError`**, so `makeRequest` no longer re-attempts a server-answered request on the *other* transport (a 429 used to trigger a pointless second call). A genuine transport *failure* still falls back to `requestUrl` exactly as before.

## Tests — failing-first
9 new cases in `YouTubeTranscriptService.test.ts` (all 14 green; were 9-red before the impl):
- 429 via `fetch` → actionable message, **no** `requestUrl` retry, no JSON/vendor/code leak.
- 429 via `requestUrl` transport → actionable message.
- Failed async job carrying the exact #152 Supadata string → actionable message.
- Non-quota `400` → server message preserved, no cross-transport retry.
- Pure-helper unit guards (429, relayed-text detection, details-string, message preservation, generic fallback).

## Local gates
- `npm run check:plugin:fast` — tsc + bundle + script-tests + unit ✅
- `npm run test:integration` — 6 suites / 21 tests ✅

Closes #152. Part of #211 (PR-7 — final sub-PR of the recording/transcription epic).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM