### PR TITLE
fix(license): distinguish a BYOK provider key auth failure from a managed SystemSculpt license failure (#249)

### DIFF
--- a/src/services/SystemSculptService.ts
+++ b/src/services/SystemSculptService.ts
@@ -836,7 +836,10 @@ export class SystemSculptService {
       throw new SystemSculptError(
         "License key required to fetch credits balance.",
         ERROR_CODES.INVALID_LICENSE,
-        401
+        401,
+        // A missing managed license key is a genuine SystemSculpt license
+        // failure (not a BYOK provider key issue), so tag it accordingly (#249).
+        { licenseFailure: true }
       );
     }
 

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -7,6 +7,7 @@ import {
   getErrorMessage,
   ErrorCode,
   isAuthFailureMessage,
+  isManagedLicenseFailure,
   isContextOverflowErrorMessage,
 } from "../errors";
 
@@ -137,6 +138,48 @@ describe("errors", () => {
 
     it("does not flag rate limit messages", () => {
       expect(isAuthFailureMessage("Rate limit exceeded")).toBe(false);
+    });
+  });
+
+  describe("isManagedLicenseFailure (#249)", () => {
+    it("matches a managed LICENSE_EXPIRED", () => {
+      const error = new SystemSculptError("expired", ERROR_CODES.LICENSE_EXPIRED, 401, {
+        licenseFailure: true,
+      });
+      expect(isManagedLicenseFailure(error)).toBe(true);
+    });
+
+    it("matches LICENSE_EXPIRED even without the flag (no BYOK path produces it)", () => {
+      const error = new SystemSculptError("expired", ERROR_CODES.LICENSE_EXPIRED, 401, {});
+      expect(isManagedLicenseFailure(error)).toBe(true);
+    });
+
+    it("matches a managed INVALID_LICENSE only when licenseFailure is set", () => {
+      const managed = new SystemSculptError("invalid", ERROR_CODES.INVALID_LICENSE, 401, {
+        licenseFailure: true,
+      });
+      expect(isManagedLicenseFailure(managed)).toBe(true);
+    });
+
+    it("does NOT match a BYOK provider auth failure mapped to INVALID_LICENSE (no licenseFailure)", () => {
+      // The custom-provider path maps a 401 to INVALID_LICENSE with a provider
+      // but never sets licenseFailure — it is the user's own key, not a
+      // SystemSculpt subscription, so it must not read as a renewal problem.
+      const byok = new SystemSculptError("Invalid API key", ERROR_CODES.INVALID_LICENSE, 401, {
+        provider: "openrouter",
+      });
+      expect(isManagedLicenseFailure(byok)).toBe(false);
+    });
+
+    it("does not match non-license codes or non-SystemSculpt errors", () => {
+      expect(
+        isManagedLicenseFailure(
+          new SystemSculptError("boom", ERROR_CODES.STREAM_ERROR, 500, { licenseFailure: true })
+        )
+      ).toBe(false);
+      expect(isManagedLicenseFailure(new Error("plain"))).toBe(false);
+      expect(isManagedLicenseFailure("a string")).toBe(false);
+      expect(isManagedLicenseFailure(null)).toBe(false);
     });
   });
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -116,6 +116,25 @@ export class SystemSculptError extends Error {
 }
 
 /**
+ * Distinguish a genuine managed SystemSculpt license/subscription failure from a
+ * BYOK provider key auth failure. Both surface as a 401, and the custom-provider
+ * path maps its 401 to INVALID_LICENSE too — but only the managed SystemSculpt
+ * API path sets `metadata.licenseFailure`. A BYOK key problem must NOT trigger
+ * the renewal flow or flip `licenseValid`: it points the user at their own
+ * provider key, not a SystemSculpt subscription (#249). LICENSE_EXPIRED is
+ * produced only by the managed path, so it needs no discriminator; only the
+ * overloaded INVALID_LICENSE does.
+ */
+export function isManagedLicenseFailure(error: unknown): error is SystemSculptError {
+  if (!(error instanceof SystemSculptError)) return false;
+  if (error.code === ERROR_CODES.LICENSE_EXPIRED) return true;
+  return (
+    error.code === ERROR_CODES.INVALID_LICENSE &&
+    error.metadata?.licenseFailure === true
+  );
+}
+
+/**
  * Get a user-friendly error message for the given error code
  */
 export function getErrorMessage(code: ErrorCode, model?: string): string {

--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -6,7 +6,7 @@ import { ChatStorageService } from "./ChatStorageService";
 import { ScrollManagerService } from "./ScrollManagerService";
 import type SystemSculptPlugin from "../../main";
 import { showPopup, showAlert } from "../../core/ui/";
-import { SystemSculptError, isContextOverflowErrorMessage, ERROR_CODES } from "../../utils/errors";
+import { SystemSculptError, isContextOverflowErrorMessage, ERROR_CODES, isManagedLicenseFailure } from "../../utils/errors";
 import { SYSTEMSCULPT_WEBSITE } from "../../constants/externalServices";
 import { openExternalUrl } from "../../utils/externalUrl";
 import { MessageRenderer } from "./MessageRenderer";
@@ -718,22 +718,25 @@ export class ChatView extends ItemView {
       return;
     }
 
-    if (
-      error instanceof SystemSculptError &&
-      (error.code === ERROR_CODES.LICENSE_EXPIRED || error.code === ERROR_CODES.INVALID_LICENSE)
-    ) {
+    // Capture (rather than narrow `error` in the `if`) so the later
+    // `error instanceof SystemSculptError` checks still see the union type — a
+    // non-license SystemSculptError must keep flowing to the branches below.
+    const managedLicenseError = isManagedLicenseFailure(error) ? error : null;
+    if (managedLicenseError) {
       await this.resetFailedAssistantTurn();
 
-      // A rejected license is no longer valid — reflect that across the UI so
-      // gating, the account panel, and the banner all agree (#249).
+      // A rejected managed license is no longer valid — reflect that across the
+      // UI so gating, the account panel, and the banner all agree (#249). A BYOK
+      // provider key failure is excluded by isManagedLicenseFailure, so it never
+      // wrongly flips licenseValid or shows the renewal flow.
       try {
         await this.plugin.getSettingsManager().updateSettings({ licenseValid: false });
       } catch {}
 
-      const expired = error.code === ERROR_CODES.LICENSE_EXPIRED;
+      const expired = managedLicenseError.code === ERROR_CODES.LICENSE_EXPIRED;
       const renewUrl =
-        typeof error.metadata?.renewUrl === "string" && error.metadata.renewUrl
-          ? String(error.metadata.renewUrl)
+        typeof managedLicenseError.metadata?.renewUrl === "string" && managedLicenseError.metadata.renewUrl
+          ? String(managedLicenseError.metadata.renewUrl)
           : SYSTEMSCULPT_WEBSITE.LICENSE;
 
       try {
@@ -953,10 +956,7 @@ export class ChatView extends ItemView {
         // Proactively surface an expired/invalid license on chat open — before
         // the user sends a doomed message (#249). Other errors stay silent
         // (the balance UI is a convenience panel).
-        if (
-          creditsError instanceof SystemSculptError &&
-          (creditsError.code === ERROR_CODES.LICENSE_EXPIRED || creditsError.code === ERROR_CODES.INVALID_LICENSE)
-        ) {
+        if (isManagedLicenseFailure(creditsError)) {
           try {
             await this.plugin.getSettingsManager().updateSettings({ licenseValid: false });
           } catch {}

--- a/src/views/chatview/__tests__/chatview-license-error-handling.test.ts
+++ b/src/views/chatview/__tests__/chatview-license-error-handling.test.ts
@@ -88,7 +88,10 @@ describe("ChatView license error handling (#249)", () => {
 
     await ChatView.prototype.handleError.call(
       view as any,
-      new SystemSculptError("invalid", ERROR_CODES.INVALID_LICENSE, 401, {})
+      // A real managed invalid-license carries licenseFailure: true (set by the
+      // SystemSculpt API error path) — that is what distinguishes it from a BYOK
+      // provider key failure, which is also mapped to INVALID_LICENSE (#249).
+      new SystemSculptError("invalid", ERROR_CODES.INVALID_LICENSE, 401, { licenseFailure: true })
     );
 
     expect(showBannerMock).toHaveBeenCalledWith(view, {
@@ -97,6 +100,30 @@ describe("ChatView license error handling (#249)", () => {
     });
     expect(view.openSetupTab).toHaveBeenCalledWith("account");
     expect(openExternalUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("BYOK provider auth failure (INVALID_LICENSE without licenseFailure) is not treated as a SystemSculpt license problem (#249)", async () => {
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    // automation: true so the fall-through catch-all skips UI construction.
+    const view = makeHandleErrorView({ automation: true, updateSettings });
+
+    await ChatView.prototype.handleError.call(
+      view as any,
+      new SystemSculptError(
+        "Invalid API key or authentication error.",
+        ERROR_CODES.INVALID_LICENSE,
+        401,
+        { provider: "openrouter", statusCode: 401 }
+      )
+    );
+
+    // Must NOT flip the managed SystemSculpt license or show the renewal banner —
+    // the failing credential is the user's own provider key, not a subscription.
+    expect(updateSettings).not.toHaveBeenCalledWith({ licenseValid: false });
+    expect(showBannerMock).not.toHaveBeenCalled();
+    expect(showPopupMock).not.toHaveBeenCalled();
+    // The catch-all still cleans up the failed assistant turn.
+    expect(view.resetFailedAssistantTurn).toHaveBeenCalled();
   });
 
   it("during automation: heals state and banners but skips the blocking popup", async () => {
@@ -127,6 +154,22 @@ describe("ChatView license error handling (#249)", () => {
     expect(updateSettings).toHaveBeenCalledWith({ licenseValid: false });
     expect(showBannerMock).toHaveBeenCalledWith(view, { expired: true, renewUrl: "https://x/renew" });
     expect(hideBannerMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshCreditsBalance: flags a managed INVALID_LICENSE (licenseFailure) as an invalid-key banner", async () => {
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    const getCreditsBalance = jest.fn().mockRejectedValue(
+      new SystemSculptError("invalid", ERROR_CODES.INVALID_LICENSE, 401, {
+        licenseFailure: true,
+        renewUrl: "https://x/renew",
+      })
+    );
+    const view = makeRefreshView({ licenseValid: true, getCreditsBalance, updateSettings });
+
+    await ChatView.prototype.refreshCreditsBalance.call(view as any);
+
+    expect(updateSettings).toHaveBeenCalledWith({ licenseValid: false });
+    expect(showBannerMock).toHaveBeenCalledWith(view, { expired: false, renewUrl: "https://x/renew" });
   });
 
   it("refreshCreditsBalance: heals stale invalid state and hides the banner on a successful fetch", async () => {

--- a/src/views/chatview/__tests__/chatview-license-error-handling.test.ts
+++ b/src/views/chatview/__tests__/chatview-license-error-handling.test.ts
@@ -8,6 +8,7 @@ import { showPopup } from "../../../core/ui/";
 import { openExternalUrl } from "../../../utils/externalUrl";
 import { uiSetup } from "../uiSetup";
 import { SYSTEMSCULPT_WEBSITE } from "../../../constants/externalServices";
+import { ChatErrorModal } from "../modals/ChatErrorModal";
 
 jest.mock("../../../core/ui/", () => ({ showPopup: jest.fn() }));
 jest.mock("../../../utils/externalUrl", () => ({ openExternalUrl: jest.fn() }));
@@ -18,11 +19,15 @@ jest.mock("../uiSetup", () => ({
     updateToolCompatibilityWarning: jest.fn().mockResolvedValue(undefined),
   },
 }));
+jest.mock("../modals/ChatErrorModal", () => ({
+  ChatErrorModal: jest.fn().mockImplementation((opts) => ({ open: jest.fn(), opts })),
+}));
 
 const showPopupMock = showPopup as jest.Mock;
 const openExternalUrlMock = openExternalUrl as jest.Mock;
 const showBannerMock = uiSetup.showLicenseBanner as jest.Mock;
 const hideBannerMock = uiSetup.hideLicenseBanner as jest.Mock;
+const ChatErrorModalMock = ChatErrorModal as unknown as jest.Mock;
 
 const makeHandleErrorView = (opts: { automation?: boolean; updateSettings: jest.Mock }) => ({
   inputHandler: { isAutomationRequestActive: jest.fn(() => opts.automation === true) },
@@ -124,6 +129,40 @@ describe("ChatView license error handling (#249)", () => {
     expect(showPopupMock).not.toHaveBeenCalled();
     // The catch-all still cleans up the failed assistant turn.
     expect(view.resetFailedAssistantTurn).toHaveBeenCalled();
+  });
+
+  it("BYOK provider auth failure (non-automation) surfaces the provider-recovery action instead of the renewal flow (#249)", async () => {
+    const updateSettings = jest.fn().mockResolvedValue(undefined);
+    // automation: false so the interactive recovery UI actually runs — this is
+    // the positive half of the #249 fix and must stay permanently guarded.
+    const view = Object.assign(makeHandleErrorView({ automation: false, updateSettings }), {
+      titleForStreamErrorKind: jest.fn(() => "Authentication required"),
+      iconForStreamErrorKind: jest.fn(() => "key-round"),
+    });
+
+    await ChatView.prototype.handleError.call(
+      view as any,
+      new SystemSculptError(
+        "Invalid API key or authentication error.",
+        ERROR_CODES.INVALID_LICENSE,
+        401,
+        { provider: "openrouter", statusCode: 401 }
+      )
+    );
+
+    // Not a managed license problem: no renewal flow, no licenseValid flip.
+    expect(updateSettings).not.toHaveBeenCalledWith({ licenseValid: false });
+    expect(showBannerMock).not.toHaveBeenCalled();
+    expect(showPopupMock).not.toHaveBeenCalled();
+
+    // Instead the auth failure routes the user to reconnect their own provider
+    // key via the "Open Providers" recovery action.
+    expect(ChatErrorModalMock).toHaveBeenCalledTimes(1);
+    const modalArgs = ChatErrorModalMock.mock.calls[0][0];
+    expect(modalArgs.primaryActionLabel).toBe("Open Providers");
+    modalArgs.onPrimaryAction();
+    expect(view.openSetupTab).toHaveBeenCalledWith("providers");
+    expect(ChatErrorModalMock.mock.results[0].value.open).toHaveBeenCalledTimes(1);
   });
 
   it("during automation: heals state and banners but skips the blocking popup", async () => {


### PR DESCRIPTION
## Issue

Closes #249 — "License-expiry / invalid-key UX": differentiate license states so each renders with the correct copy + action, and a transient/BYOK failure never reads as "renew your subscription."

## Root cause

A managed SystemSculpt 401 and a BYOK provider-key 401 both surface as the **same** `INVALID_LICENSE` error code. The custom-provider path in `StreamingErrorHandler.handleStreamError` maps any BYOK auth failure (401/403) to `INVALID_LICENSE`, while the managed SystemSculpt API path produces the same code for a real license problem.

`ChatView.handleError` keyed its license branch on the **code alone** (`LICENSE_EXPIRED || INVALID_LICENSE`). So a BYOK user with a bad/missing provider key was:

- shown the **"Renew your SystemSculpt subscription"** popup + license banner, and
- had `licenseValid` flipped to `false` —

even though nothing is wrong with their SystemSculpt subscription; the failing credential is **their own provider key**. `refreshCreditsBalance` had the same code-only check.

## Fix

Introduce a single shared discriminator, `isManagedLicenseFailure(error)` in `src/utils/errors.ts`:

- `LICENSE_EXPIRED` is produced **only** by the managed path → always managed (no discriminator needed).
- The overloaded `INVALID_LICENSE` is a managed failure **only when** `metadata.licenseFailure === true`, a flag set solely by the managed SystemSculpt API error path. BYOK auth failures never carry it.

Route both `ChatView.handleError` and `ChatView.refreshCreditsBalance` through the predicate, and tag the `getCreditsBalance` pre-flight "no license key" throw with `{ licenseFailure: true }` so a genuinely missing managed key stays a managed failure.

Result: a BYOK provider key failure now falls through to the existing provider/auth handling ("Open Providers") instead of the SystemSculpt renewal flow, and never flips `licenseValid`. Managed license problems behave exactly as before.

### Note on the type guard

`handleError` captures the narrowed value (`const managedLicenseError = isManagedLicenseFailure(error) ? error : null;`) rather than narrowing `error` in the `if`, so the later `error instanceof SystemSculptError` branches still see the full union — a non-license `SystemSculptError` must keep flowing to the quota/model/turn-in-flight handlers below.

## Tests (failing-first)

- `src/utils/__tests__/errors.test.ts` — a 5-case matrix for `isManagedLicenseFailure`: managed `LICENSE_EXPIRED` (with/without flag), managed `INVALID_LICENSE` only when flagged, BYOK `INVALID_LICENSE` (no flag) → not managed, and non-license/non-SystemSculpt inputs → false.
- `src/views/chatview/__tests__/chatview-license-error-handling.test.ts`:
  - new test proving a BYOK `INVALID_LICENSE` (`{ provider: "openrouter" }`, no `licenseFailure`) does **not** flip `licenseValid`, does **not** show the banner/popup, but still resets the failed turn;
  - the existing managed invalid-license test now models the real `{ licenseFailure: true }` shape;
  - new `refreshCreditsBalance` test for a managed `INVALID_LICENSE` (flagged) → invalid-key banner.

## Verification

- `npm run check:plugin:fast` — tsc + bundle + script-tests + unit ✅
- `npm run test:integration` — production build + built-bundle suite (6 suites / 21 tests) ✅

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed license failure detection so the chat UI correctly displays the license status/banner and renewal or setup prompts for expired/invalid managed licenses.
  * Prevented BYOK/provider authentication failures from being incorrectly treated as managed license issues.

* **Tests**
  * Expanded automated test coverage for the new license-failure classification, including request error handling, credits balance refresh behavior, and automation vs non-automation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->