### PR TITLE
fix(security): redact license key from chat debug request log (SEC-01)

### DIFF
--- a/src/services/SystemSculptService.ts
+++ b/src/services/SystemSculptService.ts
@@ -1302,7 +1302,11 @@ export class SystemSculptService {
       debug?.onRequest?.({
         provider: String(resolvedModel.provider || "systemsculpt"),
         endpoint,
-        headers: SystemSculptEnvironment.buildHeaders((this.settings.licenseKey || "").trim()),
+        // The license key is a credential: never write it to the debug payload,
+        // which is persisted to the vault and copied to the clipboard. Reuse the
+        // real header shape but with a redacted placeholder (mirrors the BYOK
+        // executors). The genuine key is sent on the real request below.
+        headers: SystemSculptEnvironment.buildHeaders("[redacted]"),
         body: requestBody,
         transport,
         canStream: true,

--- a/src/services/__tests__/SystemSculptService.test.ts
+++ b/src/services/__tests__/SystemSculptService.test.ts
@@ -731,6 +731,48 @@ describe("SystemSculptService", () => {
     );
   });
 
+  it("redacts the license key from debug.onRequest headers when streaming hosted chat", async () => {
+    const plugin = createPlugin();
+    plugin.settings.licenseKey = "ssk-super-secret-license";
+    const service = SystemSculptService.getInstance(plugin);
+    const debug = {
+      onRequest: jest.fn(),
+      onResponse: jest.fn(),
+      onStreamEnd: jest.fn(),
+    };
+
+    (service as any).platformRequestClient.request = jest.fn().mockResolvedValue(
+      new Response('data: {"choices":[{"delta":{"content":"Hi"}}]}\n\ndata: [DONE]\n\n', {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })
+    );
+
+    await collectEvents(
+      service.streamMessage({
+        messages: [{ role: "user", content: "Hello", message_id: "msg_redact_1" } as any],
+        model: "systemsculpt@@systemsculpt/ai-agent",
+        debug,
+      })
+    );
+
+    expect(debug.onRequest).toHaveBeenCalledTimes(1);
+    const requestPayload = debug.onRequest.mock.calls[0][0];
+    const debugHeaders = requestPayload.headers as Record<string, string>;
+
+    // The real license key must never reach the debug payload (it is persisted to
+    // disk and copied to the clipboard). Mirrors the BYOK executor redaction.
+    expect(JSON.stringify(debugHeaders)).not.toContain("ssk-super-secret-license");
+    if ("x-license-key" in debugHeaders) {
+      expect(debugHeaders["x-license-key"]).toBe("[redacted]");
+    }
+
+    // The real request must still send the genuine key (out of scope to redact).
+    expect((service as any).platformRequestClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({ licenseKey: "ssk-super-secret-license" })
+    );
+  });
+
   it("routes Pi-local chat turns through the local Pi stream executor", async () => {
     const plugin = createPlugin();
     const service = SystemSculptService.getInstance(plugin);


### PR DESCRIPTION
## Summary

On every hosted-model chat turn, the plugin's debug callback recorded the live `x-license-key` header into a payload that is persisted to a vault file under `diagnostics/chat-debug/*.ndjson` and copied to the clipboard by the "Copy Chat Debug" command. Users paste those bundles into bug reports and the vault file rides Obsidian Sync / iCloud / Dropbox, so the credential leaks off-device. The debug `headers` exist only for display — the real request passes the key directly to `platformRequestClient.request`, so redacting the debug payload has zero functional impact. The fix replaces `buildHeaders(realKey)` in the `onRequest` payload with `buildHeaders("[redacted]")`, mirroring the BYOK executors (`Authorization: "Bearer [redacted]"`); the real request still sends the genuine key.

Plan: plans/001-redact-license-key-in-chat-debug.md

## Security impact

A license key is a credential and must never be written to disk or the clipboard. This closes the only remaining leak of `x-license-key` into the chat-debug sink (the three BYOK provider executors were already redacting). The three sink layers (`ChatDebugLogService` vault file, "Copy Chat Debug" clipboard, NDJSON persistence) now receive `[redacted]` instead of the live key. Defense-in-depth redaction at the sink (`ChatDebugLogService`/`ChatView`) is a separate plan (SEC-10) and out of scope here — this fixes the source. Note: prior debug bundles already wrote the key, so any previously shared bundle should be treated as exposed and affected keys rotated (operational follow-up, not code).

## Test that now guards it

New permanent CI guard in `src/services/__tests__/SystemSculptService.test.ts`: `"redacts the license key from debug.onRequest headers when streaming hosted chat"`. It drives the hosted streaming path with a non-empty `settings.licenseKey`, captures `debug.onRequest`, and asserts the captured headers carry no real key (any `x-license-key` is `"[redacted]"` or absent) while the real request still sends the genuine key. Proven failing-test-first: the test FAILED before the fix (captured headers contained `"x-license-key":"ssk-super-secret-license"`) and PASSES after.

## Local gate results

- `npm run check:plugin:fast` — PASS (tsc, bundle, script-tests, unit)
- `npm test` — PASS (413 suites, 5702 passed, 1 skipped)
- `npm run test:integration` — PASS (production build + built-bundle suite, 6 suites / 21 tests)

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * License keys in debug payloads are now redacted and replaced with a placeholder value instead of exposing the actual credential.

* **Tests**
  * Added comprehensive test case to verify license key redaction is properly applied in debug request headers, while confirming underlying platform requests continue using genuine credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->