### PR TITLE
fix(studio): reject "*" CLI wildcard from syncable policy (SEC-03)

### DIFF
--- a/src/studio/StudioPermissionManager.ts
+++ b/src/studio/StudioPermissionManager.ts
@@ -1,6 +1,6 @@
 import { normalizePath } from "obsidian";
 import type { StudioCapabilityGrant, StudioPermissionPolicyV1 } from "./types";
-import { nowIso, randomId } from "./utils";
+import { isBlanketCliCommandPattern, nowIso, randomId } from "./utils";
 
 function wildcardToRegExp(pattern: string): RegExp {
   const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
@@ -79,6 +79,9 @@ export class StudioPermissionManager {
       const patterns = grant.scope.allowedCommandPatterns || [];
       for (const pattern of patterns) {
         if (!pattern.trim()) continue;
+        // SEC-03 defense-in-depth: a bare "*" matches every command. Even if a
+        // policy bypassed parse-time stripping, never honor it as an allow-all.
+        if (isBlanketCliCommandPattern(pattern)) continue;
         if (wildcardToRegExp(pattern.trim()).test(trimmed)) {
           return;
         }

--- a/src/studio/StudioService.ts
+++ b/src/studio/StudioService.ts
@@ -15,7 +15,7 @@ import {
 } from "./StudioProjectSession";
 import { StudioProjectSessionManager } from "./StudioProjectSessionManager";
 import { resolveStudioDynamicSelectOptions } from "./StudioDynamicSelectOptions";
-import { randomId } from "./utils";
+import { isBlanketCliCommandPattern, randomId } from "./utils";
 import type {
   StudioAssetRef,
   StudioCapability,
@@ -366,13 +366,19 @@ export class StudioService {
       });
       changed = true;
     } else {
-      const patterns = new Set(cliGrant.scope.allowedCommandPatterns || []);
-      if (!patterns.has("*")) {
-        for (const pattern of requiredCliPatterns) {
-          if (!patterns.has(pattern)) {
-            patterns.add(pattern);
-            changed = true;
-          }
+      const existing = cliGrant.scope.allowedCommandPatterns || [];
+      // SEC-03: scrub any stale blanket "*" baked into an on-disk policy so
+      // re-opening an older project converges to the safe state (the cleanup is
+      // persisted below via savePolicy).
+      const patterns = new Set(existing.filter((p) => !isBlanketCliCommandPattern(p)));
+      if (patterns.size !== existing.length) {
+        changed = true;
+      }
+      // Always ensure the legitimate ffmpeg/ffprobe defaults are present.
+      for (const pattern of requiredCliPatterns) {
+        if (!patterns.has(pattern)) {
+          patterns.add(pattern);
+          changed = true;
         }
       }
       cliGrant.scope.allowedCommandPatterns = Array.from(patterns);

--- a/src/studio/__tests__/studio-permission-cli-wildcard.test.ts
+++ b/src/studio/__tests__/studio-permission-cli-wildcard.test.ts
@@ -1,0 +1,98 @@
+import { parseStudioPolicy } from "../schema";
+import { StudioPermissionManager } from "../StudioPermissionManager";
+import { STUDIO_POLICY_SCHEMA_V1 } from "../types";
+import type { StudioPermissionPolicyV1 } from "../types";
+
+/**
+ * SEC-03 guard: a Studio policy file lives in the vault and can be shared /
+ * synced / imported. A bare `"*"` CLI command pattern would grant arbitrary
+ * local command execution on project open with no approval. The trust boundary
+ * must refuse it both when the policy is parsed and inside the CLI gate
+ * (defense-in-depth), while still honoring legitimate per-command patterns such
+ * as the ffmpeg/ffprobe defaults (including path-prefix wildcards such as a
+ * star-slash-ffmpeg pattern).
+ */
+describe("Studio CLI wildcard rejection (SEC-03)", () => {
+  function policyWithCliPatterns(patterns: string[]): string {
+    return JSON.stringify({
+      schema: STUDIO_POLICY_SCHEMA_V1,
+      version: 1,
+      updatedAt: new Date().toISOString(),
+      grants: [
+        {
+          id: "grant_cli",
+          capability: "cli",
+          scope: { allowedCommandPatterns: patterns },
+          grantedAt: new Date().toISOString(),
+          grantedByUser: true,
+        },
+      ],
+    });
+  }
+
+  describe("parseStudioPolicy", () => {
+    it("strips a bare \"*\" command pattern while keeping the rest", () => {
+      const parsed = parseStudioPolicy(
+        policyWithCliPatterns(["*", "ffmpeg", "*/ffmpeg", "ffprobe", "*/ffprobe"])
+      );
+
+      const cliGrant = parsed.grants.find((grant) => grant.capability === "cli");
+      expect(cliGrant).toBeDefined();
+      const patterns = cliGrant?.scope.allowedCommandPatterns || [];
+
+      // The blanket grant is gone...
+      expect(patterns).not.toContain("*");
+      // ...but legitimate per-command patterns (incl. path-prefix wildcards) survive.
+      expect(patterns).toEqual(["ffmpeg", "*/ffmpeg", "ffprobe", "*/ffprobe"]);
+    });
+
+    it("drops a whitespace-padded bare wildcard too", () => {
+      const parsed = parseStudioPolicy(policyWithCliPatterns([" * ", "echo"]));
+      const cliGrant = parsed.grants.find((grant) => grant.capability === "cli");
+      const patterns = cliGrant?.scope.allowedCommandPatterns || [];
+      expect(patterns).toEqual(["echo"]);
+    });
+  });
+
+  describe("assertCliCommand", () => {
+    function managerWithCliPatterns(patterns: string[]): StudioPermissionManager {
+      const policy: StudioPermissionPolicyV1 = {
+        schema: STUDIO_POLICY_SCHEMA_V1,
+        version: 1,
+        updatedAt: new Date().toISOString(),
+        grants: [
+          {
+            id: "grant_cli",
+            capability: "cli",
+            scope: { allowedCommandPatterns: patterns },
+            grantedAt: new Date().toISOString(),
+            grantedByUser: true,
+          },
+        ],
+      };
+      return new StudioPermissionManager(policy);
+    }
+
+    it("refuses an arbitrary command even when a grant contains \"*\"", () => {
+      // Defense-in-depth: a policy that bypassed parsing (e.g. set in-memory)
+      // must still not grant everything via a bare wildcard.
+      const manager = managerWithCliPatterns(["*"]);
+      expect(() => manager.assertCliCommand("rm -rf /")).toThrow(
+        "CLI permission denied"
+      );
+    });
+
+    it("ignores a bare \"*\" but still honors a real pattern in the same grant", () => {
+      const manager = managerWithCliPatterns(["*", "ffmpeg"]);
+      expect(() => manager.assertCliCommand("rm -rf /")).toThrow(
+        "CLI permission denied"
+      );
+      expect(() => manager.assertCliCommand("ffmpeg")).not.toThrow();
+    });
+
+    it("still allows commands matched by a path-prefix wildcard pattern", () => {
+      const manager = managerWithCliPatterns(["*/ffmpeg"]);
+      expect(() => manager.assertCliCommand("/usr/local/bin/ffmpeg")).not.toThrow();
+    });
+  });
+});

--- a/src/studio/__tests__/studio-sandbox-runner.test.ts
+++ b/src/studio/__tests__/studio-sandbox-runner.test.ts
@@ -21,10 +21,13 @@ function createPolicy(): StudioPermissionPolicyV1 {
         grantedByUser: true,
       },
       {
-        id: "grant_cli_all",
+        id: "grant_cli_node",
         capability: "cli",
+        // Grant the specific command this test spawns. A bare "*" is no longer a
+        // valid CLI pattern (SEC-03): it is stripped at policy-parse time and
+        // refused inside the CLI gate, so fixtures must name real commands.
         scope: {
-          allowedCommandPatterns: ["*"],
+          allowedCommandPatterns: ["node"],
         },
         grantedAt: new Date().toISOString(),
         grantedByUser: true,

--- a/src/studio/schema.ts
+++ b/src/studio/schema.ts
@@ -7,7 +7,15 @@ import {
   type StudioPermissionPolicyV1,
   type StudioProjectV1,
 } from "./types";
-import { asNumber, asString, ensureArray, isRecord, nowIso, randomId } from "./utils";
+import {
+  asNumber,
+  asString,
+  ensureArray,
+  isBlanketCliCommandPattern,
+  isRecord,
+  nowIso,
+  randomId,
+} from "./utils";
 
 const DEFAULT_MAX_RUNS = 100;
 const DEFAULT_MAX_ARTIFACTS_MB = 1024;
@@ -424,7 +432,11 @@ export function parseStudioPolicy(rawText: string): StudioPermissionPolicyV1 {
           allowedPaths: ensureArray<unknown>(scope.allowedPaths).map((entry) => asString(entry).trim()).filter(Boolean),
           allowedCommandPatterns: ensureArray<unknown>(scope.allowedCommandPatterns)
             .map((entry) => asString(entry).trim())
-            .filter(Boolean),
+            .filter(Boolean)
+            // SEC-03: a (syncable) policy must never grant arbitrary commands via
+            // a bare "*". Drop it here so a shared project still opens, just
+            // without the blanket grant; legitimate per-command patterns survive.
+            .filter((pattern) => !isBlanketCliCommandPattern(pattern)),
           allowedDomains: ensureArray<unknown>(scope.allowedDomains).map((entry) => asString(entry).trim()).filter(Boolean),
         },
         grantedAt: asString(rawGrant.grantedAt).trim() || nowIso(),

--- a/src/studio/utils.ts
+++ b/src/studio/utils.ts
@@ -38,3 +38,19 @@ export function ensureArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
 }
 
+/**
+ * A Studio policy file lives in the vault and can be shared / synced / imported.
+ * A bare `"*"` CLI command pattern would match every command, granting arbitrary
+ * local command execution on project open with no approval. Such a blanket
+ * wildcard is never an acceptable pattern: it is dropped at policy-parse time and
+ * refused again inside the CLI gate (defense-in-depth). Legitimate per-command
+ * patterns — including path-prefix wildcards like a star-slash-ffmpeg pattern —
+ * are NOT blanket wildcards and are preserved.
+ *
+ * Single source of truth so the parse-time strip and the gate-time refusal can
+ * never drift apart.
+ */
+export function isBlanketCliCommandPattern(pattern: string): boolean {
+  return asString(pattern).trim() === "*";
+}
+


### PR DESCRIPTION
## Summary

Studio's permission manager is the only trust boundary on local CLI execution. A project's policy file lives in the vault and can be **shared / synced / imported**. A bare `"*"` in `allowedCommandPatterns` was honored verbatim by the CLI gate, so opening (and running) such a project granted **arbitrary local command execution with no approval prompt**.

This change refuses the blanket wildcard everywhere a CLI pattern is interpreted, using a single shared predicate (`isBlanketCliCommandPattern`) so the parse path and the gate path can never drift:

- **`parseStudioPolicy`** (`schema.ts`) strips a bare `"*"` at load time. A shared project still opens, just without the blanket grant; legitimate per-command patterns — including path-prefix wildcards like a star-slash-ffmpeg pattern — survive.
- **`assertCliCommand`** (`StudioPermissionManager.ts`) skips a bare `"*"` inside the gate (defense-in-depth, in case a policy ever reaches the manager without going through parsing).
- **`ensureDefaultPolicy`** (`StudioService.ts`) no longer preserves `"*"`. It now scrubs a stale `"*"` baked into an on-disk grant (the cleanup is persisted) and always ensures the legitimate `ffmpeg`/`ffprobe` defaults are present.

## Plan

`plans/002-reject-wildcard-cli-pattern-in-studio-policy.md` (SEC-03). Drift-check vs `e97e8f9` was clean; all three "Current state" excerpts matched the code.

## Security impact

Closes the worst case of SEC-03: a *syncable* policy declaring `allowedCommandPatterns:["*"]` would, on project open/run, grant unrestricted local command execution. Argument-level validation of allowed commands and a real consent UI for capability grants remain follow-ups (SEC-02), per the plan's out-of-scope.

## Guard test added

`src/studio/__tests__/studio-permission-cli-wildcard.test.ts` — a permanent CI guard covering both surfaces:
- `parseStudioPolicy` drops a bare (and whitespace-padded) `"*"` while keeping `ffmpeg`, `*/ffmpeg`, etc.
- `assertCliCommand("rm -rf /")` throws even when a grant's patterns contain `"*"`, while a real pattern in the same grant (and path-prefix wildcards) still work.

**Failing-test-first proof:** with the test in place and no implementation, the parse assertions failed (`"*"` survived parsing) and `assertCliCommand("rm -rf /")` did not throw; after the fix all 5 cases pass.

Existing `studio-sandbox-runner.test.ts` used `["*"]` purely as a catch-all fixture to spawn `node`; updated to grant the specific `node` command (it never relied on `"*"` as a documented feature).

## Local gates (all green)

- `npm run check:plugin:fast` -> PASS (tsc, bundle, script-tests, unit)
- `npm test` -> PASS (414 suites, 5707 passed, 1 skipped, 0 failed)
- `npm run test:integration` -> PASS (production build + 6 built-bundle suites, 21 tests)

## Out of scope (unchanged)

ffmpeg/ffprobe defaults, argument-level validation, the filesystem `/` grant (SEC-08), and the network-domain `"*"` handling (different surface).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM