### PR TITLE
fix(license): downgrade local validity on authoritative 401/403 reject (BUG-08)

### DIFF
--- a/src/services/LicenseService.ts
+++ b/src/services/LicenseService.ts
@@ -95,9 +95,30 @@ export class LicenseService {
       // Unexpected body shape; keep existing state but report as invalid this round
       return !!this.plugin.settings.licenseValid;
     } catch (error) {
-      // Offline or server error: preserve last known good validity
+      // An authoritative reject (server says the key is no longer valid —
+      // revoked / expired / refunded) arrives as a 401/403 and MUST downgrade
+      // the cached validity, otherwise a revoked license keeps granting
+      // managed-model access indefinitely. Any other failure (offline, DNS
+      // blip, timeout, 5xx) is transient: preserve last-known-good validity so
+      // a flaky connection never logs a paying user out.
+      if (this.isAuthoritativeReject(error)) {
+        await this.plugin.getSettingsManager().updateSettings({ licenseValid: false });
+        return false;
+      }
       return !!this.plugin.settings.licenseValid;
     }
+  }
+
+  /**
+   * Whether an error from license validation is the server *authoritatively*
+   * rejecting the key (HTTP 401/403), as opposed to a transient/offline
+   * failure. Only an authoritative reject should flip `licenseValid` to false.
+   */
+  private isAuthoritativeReject(error: unknown): boolean {
+    return (
+      error instanceof SystemSculptError &&
+      (error.statusCode === 401 || error.statusCode === 403)
+    );
   }
 
 

--- a/src/services/__tests__/LicenseService.test.ts
+++ b/src/services/__tests__/LicenseService.test.ts
@@ -392,6 +392,69 @@ describe("LicenseService", () => {
       });
     });
 
+    describe("authoritative reject (BUG-08)", () => {
+      // A server 401/403 is the server *authoritatively* saying the key is no
+      // longer valid (revoked / expired / refunded). Unlike an offline blip,
+      // it must flip the locally cached `licenseValid` to false so a revoked
+      // license can't keep granting managed-model access indefinitely.
+      beforeEach(() => {
+        mockPlugin.settings.licenseKey = "revoked-key";
+      });
+
+      it("downgrades a previously valid license to false on 401", async () => {
+        mockPlugin.settings.licenseValid = true;
+        httpRequest.mockResolvedValue({
+          status: 401,
+          json: { error: "Unauthorized" },
+        });
+
+        const service = new LicenseService(mockPlugin, "https://api.com");
+        const result = await service.validateLicense();
+
+        expect(result).toBe(false);
+        expect(mockPlugin._updateSettings).toHaveBeenCalledWith({
+          licenseValid: false,
+        });
+      });
+
+      it("downgrades a previously valid license to false on 403", async () => {
+        mockPlugin.settings.licenseValid = true;
+        httpRequest.mockResolvedValue({
+          status: 403,
+          json: { error: "Forbidden" },
+        });
+
+        const service = new LicenseService(mockPlugin, "https://api.com");
+        const result = await service.validateLicense();
+
+        expect(result).toBe(false);
+        expect(mockPlugin._updateSettings).toHaveBeenCalledWith({
+          licenseValid: false,
+        });
+      });
+    });
+
+    describe("transient failure preserves validity (BUG-08)", () => {
+      // A non-HTTP throw (DNS failure, dropped connection, timeout) is NOT an
+      // authoritative reject: a flaky connection must not log a paying user out.
+      beforeEach(() => {
+        mockPlugin.settings.licenseKey = "valid-key";
+      });
+
+      it("does not downgrade on a network-level throw (TypeError)", async () => {
+        mockPlugin.settings.licenseValid = true;
+        httpRequest.mockRejectedValue(new TypeError("Failed to fetch"));
+
+        const service = new LicenseService(mockPlugin, "https://api.com");
+        const result = await service.validateLicense();
+
+        expect(result).toBe(true);
+        expect(mockPlugin._updateSettings).not.toHaveBeenCalledWith({
+          licenseValid: false,
+        });
+      });
+    });
+
     describe("with network errors", () => {
       beforeEach(() => {
         mockPlugin.settings.licenseKey = "test-key";


### PR DESCRIPTION
## Summary

`validateLicense()` could not tell *"the server says this key is invalid"* (HTTP 401/403 — revoked / expired / refunded) from *"we're offline."* Both fell into the same `catch` that returns the **last-known** validity, so a revoked license stayed `licenseValid: true` locally **indefinitely**. Gating kept granting managed-model access, and requests then failed deeper with confusing errors.

This change discriminates an **authoritative reject** (a `SystemSculptError` with `statusCode` 401 or 403) from a **transient/offline** failure inside the catch block:

- **401 / 403** -> downgrade: `updateSettings({ licenseValid: false })` and return `false`.
- **Any other error** (network throw, timeout, 5xx, unexpected body) -> unchanged: preserve last-known-good validity (`return !!settings.licenseValid`).

The discrimination is extracted into a small private `isAuthoritativeReject(error)` helper so the catch reads as intent, not a tangle of inline type/status checks.

**Plan**: `plans/003-downgrade-license-on-authoritative-reject.md`

## Impact

- A revoked/expired/refunded license can no longer stay `licenseValid: true` locally — the next validation flips it to `false`.
- A flaky connection (DNS blip, dropped socket, timeout, transient 5xx) still preserves validity, so paying users are **not** spuriously logged out offline. Only 401/403 are treated as authoritative (per plan scope; 5xx-preserve behavior is unchanged and was relied upon by an existing test).

## Guard test (failing-first)

`src/services/__tests__/LicenseService.test.ts` — new permanent CI guard, added and confirmed red before the fix:

- `authoritative reject (BUG-08)`: server **401** and **403** with `licenseValid === true` -> resolves `false` **and** `updateSettings` called with `{ licenseValid: false }`. (The pre-existing 401/403 tests started from `licenseValid: false`, so they passed trivially and did not catch this bug.)
- `transient failure preserves validity (BUG-08)`: a network-level `TypeError` throw with `licenseValid === true` -> resolves `true` and does **not** downgrade.

Proof: with the test added, the two 401/403 downgrade cases failed (`Expected: false, Received: true` — stale last-known validity returned); the transient case passed. After the catch-block fix, all 45 cases in the file pass.

## Local gates (all green)

- `npm run check:plugin:fast` -> PASS (tsc, bundle, script-tests, unit)
- `npm test` -> 5705 passed, 1 skipped, 0 failed (413 suites)
- `npm run test:integration` -> 6 suites / 21 tests passed (production build + built-bundle)

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* License validation error handling now distinguishes between authoritative server rejections and transient failures. License status is properly downgraded when receiving definitive server rejections (HTTP 401/403 responses) while preserved for transient errors, improving the accuracy and consistency of license status tracking throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->