### PR TITLE
fix(mcp): edit tool reports zero/partial edits instead of false success (BUG-02)

### DIFF
--- a/src/mcp-tools/filesystem/MCPFilesystemServer.ts
+++ b/src/mcp-tools/filesystem/MCPFilesystemServer.ts
@@ -90,9 +90,21 @@ export class MCPFilesystemServer {
         return await this.fileOps.readFiles(args as ReadFilesParams);
       case "write":
         return await this.fileOps.writeFile(args as WriteFileParams);
-      case "edit":
-        const diff = await this.fileOps.editFile(args as EditFileParams);
-        return { path: (args as EditFileParams).path, success: true, diff };
+      case "edit": {
+        const { diff, appliedCount, requestedCount, skipped } =
+          await this.fileOps.editFile(args as EditFileParams);
+        // Honest reporting (BUG-02): success is false when nothing applied, so a
+        // mistyped find-string under strict:false can no longer masquerade as a
+        // successful edit. appliedCount/skipped let the caller retry the misses.
+        return {
+          path: (args as EditFileParams).path,
+          success: appliedCount > 0,
+          diff,
+          appliedCount,
+          requestedCount,
+          skipped,
+        };
+      }
       case "create_folders":
         return await this.directoryOps.createDirectories(args as CreateDirectoriesParams);
       case "list_items":

--- a/src/mcp-tools/filesystem/__tests__/MCPFilesystemServer.test.ts
+++ b/src/mcp-tools/filesystem/__tests__/MCPFilesystemServer.test.ts
@@ -198,9 +198,14 @@ describe("MCPFilesystemServer", () => {
     });
 
     describe("edit tool", () => {
-      it("calls editFile and returns diff", async () => {
-        const params = { path: "test.md", old_string: "old", new_string: "new" };
-        mockEditFile.mockResolvedValue("@@ -1 +1 @@\n-old\n+new");
+      it("reports success with applied/skipped counts when edits land", async () => {
+        const params = { path: "test.md", edits: [{ oldText: "old", newText: "new" }] };
+        mockEditFile.mockResolvedValue({
+          diff: "@@ -1 +1 @@\n-old\n+new",
+          appliedCount: 1,
+          requestedCount: 1,
+          skipped: [],
+        });
 
         const result = await server.executeTool("edit", params);
 
@@ -209,7 +214,32 @@ describe("MCPFilesystemServer", () => {
           path: "test.md",
           success: true,
           diff: "@@ -1 +1 @@\n-old\n+new",
+          appliedCount: 1,
+          requestedCount: 1,
+          skipped: [],
         });
+      });
+
+      it("reports success:false when zero edits applied (BUG-02)", async () => {
+        const params = {
+          path: "test.md",
+          edits: [{ oldText: "notfound", newText: "x" }],
+          strict: false,
+        };
+        mockEditFile.mockResolvedValue({
+          diff: "",
+          appliedCount: 0,
+          requestedCount: 1,
+          skipped: [{ index: 0, reason: "Edit produced no changes" }],
+        });
+
+        const result = await server.executeTool("edit", params);
+
+        // The model must not see a phantom success when nothing was applied.
+        expect(result.success).toBe(false);
+        expect(result.appliedCount).toBe(0);
+        expect(result.requestedCount).toBe(1);
+        expect(result.skipped).toEqual([{ index: 0, reason: "Edit produced no changes" }]);
       });
     });
 

--- a/src/mcp-tools/filesystem/toolDefinitions/fileToolDefinitions.ts
+++ b/src/mcp-tools/filesystem/toolDefinitions/fileToolDefinitions.ts
@@ -68,7 +68,7 @@ export const fileToolDefinitions: MCPToolInfo[] = [
   },
   {
     name: "edit",
-    description: "Apply find-and-replace edits to an existing file. Supports exact matching, regex patterns, loose whitespace matching, and line range targeting. Returns a diff showing changes made.",
+    description: "Apply find-and-replace edits to an existing file. Supports exact matching, regex patterns, loose whitespace matching, and line range targeting. Returns a diff plus appliedCount/requestedCount and a skipped[] list (each {index, reason}). When strict is false, check appliedCount: if it is less than requestedCount, the skipped edits did NOT apply (e.g. oldText not found) — fix their oldText and retry. success is false when appliedCount is 0, meaning nothing was written.",
     inputSchema: {
       type: "object",
       properties: {
@@ -136,7 +136,7 @@ export const fileToolDefinitions: MCPToolInfo[] = [
         strict: {
           type: "boolean",
           default: true,
-          description: "If true (default), fail if any edit doesn't match. If false, skip non-matching edits."
+          description: "If true (default), fail the whole operation if any edit doesn't match. If false, apply the edits that match and report the rest in skipped[] (appliedCount tells you how many landed)."
         }
       },
       required: ["path", "edits"],

--- a/src/mcp-tools/filesystem/tools/FileOperations.ts
+++ b/src/mcp-tools/filesystem/tools/FileOperations.ts
@@ -1,5 +1,5 @@
 import { App, TFile, normalizePath } from "obsidian";
-import { FileReadMetadata, ReadFilesParams, WriteFileParams, EditFileParams, FileEdit } from "../types";
+import { FileReadMetadata, ReadFilesParams, WriteFileParams, EditFileParams, EditFileResult, FileEdit, SkippedEdit } from "../types";
 import { FILESYSTEM_LIMITS } from "../constants";
 import {
   validatePath,
@@ -263,9 +263,16 @@ export class FileOperations {
   }
 
   /**
-   * Apply file edits using the clean MCP filesystem server approach
+   * Apply file edits using the clean MCP filesystem server approach.
+   *
+   * Returns an honest accounting of the operation: the `diff`, how many edits
+   * actually applied (`appliedCount`) out of `requestedCount`, and which were
+   * `skipped` (only possible under `strict:false`). When nothing applies the
+   * file is left untouched — no redundant no-op write — so the caller can tell
+   * a phantom success apart from a real one. Under `strict:true` (the default) a
+   * non-matching edit still throws, so behavior on the default path is unchanged.
    */
-  async editFile(params: EditFileParams): Promise<string> {
+  async editFile(params: EditFileParams): Promise<EditFileResult> {
     const filePath = params.path;
     const edits = params.edits;
     const strict = (params as any).strict ?? true;
@@ -277,23 +284,18 @@ export class FileOperations {
       const adapter: any = this.app.vault.adapter as any;
       const content = normalizeLineEndings(await readAdapterText(adapter, normalizedPath));
 
-      let modifiedContent = content;
-      for (const edit of edits) {
-        try {
-          modifiedContent = this.applySingleEdit(modifiedContent, edit);
-        } catch (e) {
-          if (strict) {
-            throw e;
-          }
-        }
-      }
+      const { modifiedContent, appliedCount, skipped } = this.applyEdits(content, edits, strict);
 
       const diff = createSimpleDiff(content, modifiedContent, filePath);
-      if (isBaseFile) {
-        assertValidObsidianBasesYaml(normalizedPath || filePath, modifiedContent);
+      // Only write when content actually changed — skip the redundant no-op write
+      // so a zero-match (strict:false) edit never touches the file's mtime.
+      if (modifiedContent !== content) {
+        if (isBaseFile) {
+          assertValidObsidianBasesYaml(normalizedPath || filePath, modifiedContent);
+        }
+        await writeAdapterText(adapter, normalizedPath, modifiedContent);
       }
-      await writeAdapterText(adapter, normalizedPath, modifiedContent);
-      return diff;
+      return { diff, appliedCount, requestedCount: edits.length, skipped };
     }
 
     const abstractFile = resolveExistingVaultFile(this.app, normalizedPath);
@@ -304,28 +306,53 @@ export class FileOperations {
 
     const content = normalizeLineEndings(await this.app.vault.read(abstractFile));
 
-    // Apply edits sequentially
-    let modifiedContent = content;
-    for (const edit of edits) {
-      try {
-        modifiedContent = this.applySingleEdit(modifiedContent, edit);
-      } catch (e) {
-        if (strict) {
-          throw e;
-        }
-      }
-    }
+    const { modifiedContent, appliedCount, skipped } = this.applyEdits(content, edits, strict);
 
     // Create simple diff
     const diff = createSimpleDiff(content, modifiedContent, resolvedPath);
 
-    // Apply the changes to the file
-    if (isBaseFile) {
-      assertValidObsidianBasesYaml(resolvedPath, modifiedContent);
+    // Apply the changes to the file only when something actually changed.
+    if (modifiedContent !== content) {
+      if (isBaseFile) {
+        assertValidObsidianBasesYaml(resolvedPath, modifiedContent);
+      }
+      await this.app.vault.modify(abstractFile, modifiedContent);
     }
-    await this.app.vault.modify(abstractFile, modifiedContent);
 
-    return diff;
+    return { diff, appliedCount, requestedCount: edits.length, skipped };
+  }
+
+  /**
+   * Apply a list of edits sequentially, counting successes and collecting any
+   * skipped edits. Shared by the adapter fast-path and the Vault-API path so
+   * both report identically. Under `strict:true` a non-matching edit rethrows;
+   * under `strict:false` it is recorded in `skipped` and the loop continues.
+   */
+  private applyEdits(
+    content: string,
+    edits: FileEdit[],
+    strict: boolean
+  ): { modifiedContent: string; appliedCount: number; skipped: SkippedEdit[] } {
+    let modifiedContent = content;
+    let appliedCount = 0;
+    const skipped: SkippedEdit[] = [];
+
+    edits.forEach((edit, index) => {
+      try {
+        modifiedContent = this.applySingleEdit(modifiedContent, edit);
+        appliedCount++;
+      } catch (e) {
+        if (strict) {
+          throw e;
+        }
+        skipped.push({
+          index,
+          reason: e instanceof Error ? e.message : String(e),
+        });
+      }
+    });
+
+    return { modifiedContent, appliedCount, skipped };
   }
 
   private applySingleEdit(source: string, edit: FileEdit): string {

--- a/src/mcp-tools/filesystem/tools/__tests__/FileOperations.test.ts
+++ b/src/mcp-tools/filesystem/tools/__tests__/FileOperations.test.ts
@@ -409,7 +409,7 @@ describe("FileOperations", () => {
       });
 
       expect(app.vault.modify).toHaveBeenCalledWith(fallbackFile, "hello universe");
-      expect(result).toContain("missing/missing.md");
+      expect(result.diff).toContain("missing/missing.md");
     });
 
     it("reads a Folder Notes file when handed the folder-style path (#154)", async () => {
@@ -441,7 +441,10 @@ describe("FileOperations", () => {
       });
 
       expect(app.vault.modify).toHaveBeenCalledWith(mockFile, "hello universe");
-      expect(result).toContain("diff");
+      expect(result.diff).toContain("diff");
+      expect(result.appliedCount).toBe(1);
+      expect(result.requestedCount).toBe(1);
+      expect(result.skipped).toEqual([]);
     });
 
     it("applies multiple edits in sequence", async () => {
@@ -474,7 +477,7 @@ describe("FileOperations", () => {
       ).rejects.toThrow("Edit produced no changes");
     });
 
-    it("silently skips failed edits when strict is false", async () => {
+    it("applies matching edits and reports skipped ones when strict is false (BUG-02)", async () => {
       const mockFile = new TFile({ path: "test.md" });
       (app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
       (app.vault.read as jest.Mock).mockResolvedValue("hello world");
@@ -488,7 +491,54 @@ describe("FileOperations", () => {
         strict: false,
       } as any);
 
+      // Partial application still writes the file with the edits that landed.
       expect(app.vault.modify).toHaveBeenCalledWith(mockFile, "HELLO world");
+      // ...but the caller is told only one of two edits applied, so it can retry
+      // the failed one instead of believing a phantom success (BUG-02).
+      expect(result.appliedCount).toBe(1);
+      expect(result.requestedCount).toBe(2);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0].index).toBe(0);
+      expect(result.skipped[0].reason).toBeTruthy();
+    });
+
+    it("does not write the file when zero edits match (strict:false) (BUG-02)", async () => {
+      const mockFile = new TFile({ path: "test.md" });
+      (app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
+      (app.vault.read as jest.Mock).mockResolvedValue("hello world");
+
+      const result = await fileOps.editFile({
+        path: "test.md",
+        edits: [
+          { oldText: "notfound", newText: "replacement" },
+          { oldText: "alsoMissing", newText: "other" },
+        ],
+        strict: false,
+      } as any);
+
+      // BUG-02: when nothing matches, the redundant no-op write is skipped
+      // entirely so the file's mtime/content is never touched.
+      expect(app.vault.modify).not.toHaveBeenCalled();
+      expect(result.appliedCount).toBe(0);
+      expect(result.requestedCount).toBe(2);
+      expect(result.skipped).toHaveLength(2);
+    });
+
+    it("skips the redundant no-op write when an edit replaces text with itself", async () => {
+      const mockFile = new TFile({ path: "test.md" });
+      (app.vault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
+      (app.vault.read as jest.Mock).mockResolvedValue("hello world");
+
+      // "world" -> "world" produces no net change; applySingleEdit treats a
+      // no-op replacement as "no changes", so nothing should be written.
+      const result = await fileOps.editFile({
+        path: "test.md",
+        edits: [{ oldText: "world", newText: "world" }],
+        strict: false,
+      } as any);
+
+      expect(app.vault.modify).not.toHaveBeenCalled();
+      expect(result.appliedCount).toBe(0);
     });
 
     it("replaces all occurrences when occurrence is all", async () => {

--- a/src/mcp-tools/filesystem/types.ts
+++ b/src/mcp-tools/filesystem/types.ts
@@ -109,6 +109,30 @@ export interface EditFileParams {
   strict?: boolean | null;
 }
 
+/**
+ * An edit that was requested but did not apply (only collected under
+ * `strict:false`; under `strict:true` a non-matching edit throws instead).
+ */
+export interface SkippedEdit {
+  /** Zero-based index of the edit within the requested `edits` array. */
+  index: number;
+  /** Human-readable reason the edit did not apply (e.g. "Edit produced no changes"). */
+  reason: string;
+}
+
+/**
+ * Result of an `edit` operation. Carries the human-readable `diff` (kept for
+ * backward compatibility) plus an honest accounting of how many edits actually
+ * landed. `appliedCount === 0` means nothing changed and the file was not
+ * written — callers must treat that as a failure, not a phantom success.
+ */
+export interface EditFileResult {
+  diff: string;
+  appliedCount: number;
+  requestedCount: number;
+  skipped: SkippedEdit[];
+}
+
 export interface CreateDirectoriesParams {
   paths: string[];
 }


### PR DESCRIPTION
## Summary
The `edit` filesystem MCP tool ran each edit in a try/catch. Under the documented `strict:false` option a non-matching edit was **swallowed**, the file was still written with unchanged content, and the tool returned a diff. `MCPFilesystemServer.executeTool` wrapped that into `success:true`. So a mistyped `oldText`, or one bad edit among several, silently landed nothing while the model believed the change applied.

This re-architects the edit path to report honestly:
- `editFile` now returns a structured `EditFileResult` (`diff` + `appliedCount` / `requestedCount` / `skipped[]`) instead of a bare diff string. The diff-only return was the legacy shape that left no channel for application status — replaced with the canonical structured result.
- A single shared `applyEdits` helper replaces the two duplicated loops (adapter fast-path + Vault-API path), so both report identically.
- The redundant no-op write is skipped entirely when `modifiedContent === content`, so a zero-match edit never touches the file's mtime.
- `MCPFilesystemServer.executeTool` sets `success: appliedCount > 0` and surfaces `appliedCount`/`requestedCount`/`skipped` to the caller.
- The `edit` tool description documents the new fields so models check `appliedCount` and retry the misses.
- `strict:true` (the default) still throws on a non-matching edit — byte-for-byte unchanged behavior on the default path.

**Plan:** plans/004-edit-tool-report-zero-or-partial-edits.md

## Impact
Silent note data-loss: `success:true` was returned to the agent after applying **zero** edits under `strict:false` (the file was rewritten with unchanged content and a diff was returned). The model could not distinguish a real edit from a phantom one. Now zero applied edits yield `success:false` with no write, and partial application reports exactly which edits were skipped and why.

## Guard tests (failing-test-first)
Added to the permanent unit suite (CI guard per AGENTS.md):
- `FileOperations › editFile › does not write the file when zero edits match (strict:false) (BUG-02)` — asserts `vault.modify` is not called and `appliedCount === 0`.
- `FileOperations › editFile › applies matching edits and reports skipped ones when strict is false (BUG-02)` — partial application still writes, and reports `appliedCount=1 / requestedCount=2` with the skipped edit's index + reason.
- `FileOperations › editFile › skips the redundant no-op write when an edit replaces text with itself` — no-op edit writes nothing.
- `MCPFilesystemServer › executeTool › edit tool › reports success:false when zero edits applied (BUG-02)` — server boundary returns `success:false` + counts.
- Existing `strict:true` "throws on no changes" regression guard preserved.

All four new behavioral assertions were confirmed **failing first** (`result.appliedCount` undefined; `vault.modify` still called on zero-match), then **passing** after the implementation.

## Local gates (all green)
- `npm run check:plugin:fast` → PASS (tsc, bundle, script-tests, unit)
- `npm test` → 5710 passed, 1 skipped, 0 failed
- `npm run test:integration` → production build OK; 21 passed, 0 failed

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM