### PR TITLE
fix(streaming): honor Retry-After + classify BYOK 429 as transient; wire rate-limit retry (BUG-07/16/17)

### DIFF
--- a/src/services/StreamingErrorHandler.ts
+++ b/src/services/StreamingErrorHandler.ts
@@ -30,6 +30,67 @@ const MESSAGE_CONTENT_PATTERNS = [
   /message content/,
 ];
 
+/**
+ * Resolve the server-advertised retry delay (in seconds) for a 429.
+ *
+ * Order of precedence:
+ *   1. The HTTP `Retry-After` header — delta-seconds (e.g. `60`) or an
+ *      HTTP-date (e.g. `Wed, 21 Oct 2026 07:28:00 GMT`), per RFC 9110.
+ *   2. A `retry_after*` field on the parsed error body (some providers only
+ *      surface it there, never as a header).
+ *
+ * Returns `undefined` when nothing usable is present so callers can apply their
+ * own fallback. A header date in the past clamps to 0.
+ */
+const resolveRetryAfterSeconds = (response: Response, data: any): number | undefined => {
+  const fromNumeric = (value: unknown): number | undefined => {
+    const parsed = typeof value === "number" ? value : Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return Math.ceil(parsed);
+    }
+    return undefined;
+  };
+
+  const headerValue = (() => {
+    try {
+      return response.headers?.get?.("retry-after") ?? null;
+    } catch {
+      return null;
+    }
+  })();
+
+  if (typeof headerValue === "string" && headerValue.trim().length > 0) {
+    const trimmed = headerValue.trim();
+    const numeric = fromNumeric(trimmed);
+    if (numeric !== undefined) {
+      return numeric;
+    }
+    const dateMs = Date.parse(trimmed);
+    if (Number.isFinite(dateMs)) {
+      return Math.max(0, Math.ceil((dateMs - Date.now()) / 1000));
+    }
+  }
+
+  const error = data?.error;
+  const candidates = [
+    error?.retry_after_seconds,
+    error?.retryAfterSeconds,
+    error?.retry_after,
+    error?.metadata?.retry_after_seconds,
+    error?.metadata?.retry_after,
+    data?.retry_after_seconds,
+    data?.retry_after,
+  ];
+  for (const candidate of candidates) {
+    const numeric = fromNumeric(candidate);
+    if (numeric !== undefined) {
+      return numeric;
+    }
+  }
+
+  return undefined;
+};
+
 const isImageUnsupportedMessage = (message: string): boolean => {
   const lc = (message || "").toLowerCase();
   if (!lc) return false;
@@ -100,6 +161,11 @@ export class StreamingErrorHandler {
       let errorMessage = "Unknown error";
       let metadata: any = {};
       let shouldResubmit = false;
+      // Populated by the 429 branches (managed + custom) so transient rate-limit
+      // metadata is built in exactly one place per branch instead of duplicated.
+      let rateLimit:
+        | { isRateLimited: true; shouldRetry: true; retryAfterSeconds: number }
+        | null = null;
       const requestId = data?.request_id || data?.requestId || data?.error?.request_id;
       const errorType = data?.error?.type;
       const errorHttpCode = data?.error?.http_code;
@@ -167,8 +233,16 @@ export class StreamingErrorHandler {
             errorMessage = upstreamMessage || `Model ${model} is unavailable with this provider.`;
             shouldResubmit = true;
           } else if (status === 429) {
+            // BUG-17: a BYOK 429 is a transient rate limit, not a terminal quota
+            // wall. Mark it transient and surface the server's Retry-After so the
+            // Chat UI can offer a retry (mirrors the managed branch below).
             errorCode = ERROR_CODES.QUOTA_EXCEEDED;
             errorMessage = data.error.message || 'Rate limit or quota exceeded. Please try again later.';
+            rateLimit = {
+              isRateLimited: true,
+              shouldRetry: true,
+              retryAfterSeconds: resolveRetryAfterSeconds(response, data) ?? 5,
+            };
           } else {
             errorCode = (data.error.code || ERROR_CODES.STREAM_ERROR) as ErrorCode;
             errorMessage = data.error.message || 'An error occurred with the provider.';
@@ -183,6 +257,7 @@ export class StreamingErrorHandler {
             statusCode: status,
             rawError: data.error,
             upstreamMessage,
+            ...(rateLimit ?? {}),
             ...(requestId ? { requestId } : {}),
             ...(errorType ? { errorType } : {}),
             ...(errorHttpCode ? { errorHttpCode } : {}),
@@ -338,13 +413,15 @@ export class StreamingErrorHandler {
               errorMessage = errorMessage.includes('rate-limited upstream') 
                 ? errorMessage + ' OpenRouter is automatically trying alternative providers.'
                 : 'Rate limit exceeded. Please try again in a moment.';
+              // BUG-16: honor the server's Retry-After (header or body) instead of
+              // an unconditional 5s hint; fall back to 5 only when absent.
               metadata = {
                 model: data.model,
                 statusCode: status,
                 rawError: data.error,
                 isRateLimited: true,
                 shouldRetry: true,
-                retryAfterSeconds: 5 // Suggest 5 second retry delay
+                retryAfterSeconds: resolveRetryAfterSeconds(response, data) ?? 5,
               };
             } else {
               metadata = {

--- a/src/services/SystemSculptService.ts
+++ b/src/services/SystemSculptService.ts
@@ -1129,25 +1129,21 @@ export class SystemSculptService {
     };
   }
 
-  async *streamMessage({
-    messages,
-    model,
-    onError,
-    contextFiles,
-    systemPromptOverride,
-    transientSystemPromptSuffix,
-    signal,
-    forcedToolName,
-    maxTokens,
-    reasoningEffort,
-    allowTools,
-    includeReasoning,
-    debug,
-    sessionFile,
-    sessionId,
-    onPiSessionReady,
-    webSearchEnabled,
-  }: {
+  /**
+   * Public chat-stream entry point.
+   *
+   * Wraps {@link streamMessageOnce} in a bounded, abort-aware retry for transient
+   * upstream rate limits (BUG-07). The retry is gated by a single invariant: it
+   * may only fire when **no event has been yielded yet** (`hasYielded` latches on
+   * the one and only `yield` below), so already-streamed content can never be
+   * double-emitted. Once any event is emitted, the retry branch is unreachable
+   * and a later failure propagates exactly as before.
+   *
+   * Terminal error handling (abort swallow, logging, `debug.onError`, the
+   * `onError` callback, and the rethrow) lives here so it runs once, on the final
+   * outcome — never per inner attempt.
+   */
+  async *streamMessage(options: {
     messages: ChatMessage[];
     model: string;
     onError?: (error: string) => void;
@@ -1166,193 +1162,166 @@ export class SystemSculptService {
     onPiSessionReady?: (session: { sessionFile?: string; sessionId: string }) => void;
     webSearchEnabled?: boolean;
   }): AsyncGenerator<StreamEvent, void, unknown> {
+    const { model, onError, debug, signal } = options;
+    const MAX_RATE_LIMIT_RETRIES = 1;
+
+    let hasYielded = false;
+    let attempt = 0;
+
+    while (true) {
+      try {
+        for await (const event of this.streamMessageOnce(options)) {
+          // The single yield site: the moment one event leaves, retry is off the
+          // table for the rest of this turn (no double-emit, structurally).
+          hasYielded = true;
+          yield event;
+        }
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        // Only retry a transient rate limit, only before any output, only while
+        // attempts remain, and never after an abort.
+        const retry =
+          !hasYielded && attempt < MAX_RATE_LIMIT_RETRIES && !signal?.aborted
+            ? this.shouldRetryRateLimitedStreamTurn(error)
+            : null;
+        if (retry) {
+          attempt += 1;
+          await this.waitForRetryWindow(
+            this.getRateLimitedRetryDelayMs(retry.retryAfterSeconds, attempt),
+            signal,
+          );
+          if (signal?.aborted) {
+            return;
+          }
+          continue;
+        }
+
+        try {
+          errorLogger.error("Stream error in streamMessage", error, {
+            source: "SystemSculptService",
+            method: "streamMessage",
+            metadata: { model },
+          });
+        } catch {}
+        try {
+          debug?.onError?.({
+            error: error instanceof Error ? error.message : String(error),
+            details: error,
+          });
+        } catch {}
+        if (onError) {
+          let errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
+
+          if (
+            error instanceof SystemSculptError &&
+            error.code === ERROR_CODES.STREAM_ERROR &&
+            error.statusCode === 400
+          ) {
+            errorMessage +=
+              "\nPlease try again in a few moments. If the issue persists, try selecting a different model.";
+          }
+          onError(errorMessage);
+        }
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Execute a single chat-stream attempt end to end (prepare → route → stream).
+   * Errors propagate raw so {@link streamMessage} can decide whether to retry;
+   * this method must not invoke the user-facing error callbacks.
+   */
+  private async *streamMessageOnce({
+    messages,
+    model,
+    contextFiles,
+    systemPromptOverride,
+    transientSystemPromptSuffix,
+    signal,
+    forcedToolName,
+    maxTokens,
+    reasoningEffort,
+    allowTools,
+    includeReasoning,
+    debug,
+    sessionFile,
+    sessionId,
+    onPiSessionReady,
+    webSearchEnabled,
+  }: {
+    messages: ChatMessage[];
+    model: string;
+    contextFiles?: Set<string>;
+    systemPromptOverride?: string;
+    transientSystemPromptSuffix?: string;
+    signal?: AbortSignal;
+    forcedToolName?: string;
+    maxTokens?: number;
+    reasoningEffort?: string;
+    allowTools?: boolean;
+    includeReasoning?: boolean;
+    debug?: StreamDebugCallbacks;
+    sessionFile?: string;
+    sessionId?: string;
+    onPiSessionReady?: (session: { sessionFile?: string; sessionId: string }) => void;
+    webSearchEnabled?: boolean;
+  }): AsyncGenerator<StreamEvent, void, unknown> {
     this.refreshSettings();
 
-    try {
-      errorLogger.debug("Starting streamMessage", {
-        source: "SystemSculptService",
-        method: "streamMessage",
-        metadata: { model },
-      });
+    errorLogger.debug("Starting streamMessage", {
+      source: "SystemSculptService",
+      method: "streamMessage",
+      metadata: { model },
+    });
 
-      const prepared = await this.prepareChatRequest({
-        messages,
-        model,
-        contextFiles,
-        systemPromptOverride,
-        transientSystemPromptSuffix,
-        emitNotices: true,
-        allowTools,
-      });
+    const prepared = await this.prepareChatRequest({
+      messages,
+      model,
+      contextFiles,
+      systemPromptOverride,
+      transientSystemPromptSuffix,
+      emitNotices: true,
+      allowTools,
+    });
 
-      const {
-        resolvedModel,
-      } = prepared;
+    const {
+      resolvedModel,
+    } = prepared;
 
-      if (prepared.modelSource === "pi_local") {
-        const { executeLocalPiStream } = await loadLocalPiStreamExecutorModule();
-        const preview = this.buildLocalPiRequestPreview({
-          prepared,
-          sessionFile,
-          reasoningEffort,
-        });
-
-        try {
-          debug?.onRequest?.({
-            provider: String(resolvedModel.sourceProviderId || resolvedModel.provider || "unknown"),
-            endpoint: "local-pi-sdk",
-            headers: {},
-            body: preview,
-            transport: "pi-sdk",
-            canStream: true,
-            isCustomProvider: false,
-          });
-        } catch {}
-
-        for await (const event of executeLocalPiStream({
-          plugin: this.plugin,
-          prepared,
-          sessionFile,
-          onSessionReady: onPiSessionReady,
-          signal,
-          reasoningEffort,
-          debug,
-        })) {
-          yield event;
-        }
-
-        try {
-          debug?.onStreamEnd?.({
-            completed: !signal?.aborted,
-            aborted: !!signal?.aborted,
-          });
-        } catch {}
-        return;
-      }
-
-      if (prepared.modelSource === "custom_endpoint") {
-        const remoteProviderId = normalizeProviderId(
-          String(prepared.resolvedModel.sourceProviderId || prepared.resolvedModel.provider || ""),
-        );
-
-        // Anthropic/Claude runs through the native Messages API executor; the
-        // OpenAI-compatible /chat/completions path cannot serve it (#230).
-        if (remoteProviderId === "anthropic") {
-          const { executeAnthropicRemoteStream } = await loadAnthropicRemoteStreamExecutorModule();
-          for await (const event of executeAnthropicRemoteStream({
-            plugin: this.plugin,
-            prepared,
-            signal,
-            reasoningEffort,
-            debug,
-          })) {
-            yield event;
-          }
-          return;
-        }
-
-        // Gemini uses the native generateContent streaming API, not the
-        // OpenAI-compatible /chat/completions executor (#231).
-        if (remoteProviderId === "google") {
-          const { executeGeminiRemoteStream } = await loadGeminiRemoteStreamExecutorModule();
-          for await (const event of executeGeminiRemoteStream({
-            plugin: this.plugin,
-            prepared,
-            signal,
-            reasoningEffort,
-            debug,
-          })) {
-            yield event;
-          }
-          return;
-        }
-
-
-        const { executeOpenRouterRemoteStream } = await loadRemoteProviderStreamExecutorModule();
-        for await (const event of executeOpenRouterRemoteStream({
-          plugin: this.plugin,
-          prepared,
-          signal,
-          reasoningEffort,
-          debug,
-        })) {
-          yield event;
-        }
-        return;
-      }
-
-      const endpoint = `${this.baseUrl}${SYSTEMSCULPT_API_ENDPOINTS.CHAT.COMPLETIONS}`;
-      const requestBody = this.buildHostedChatRequestBody({
+    if (prepared.modelSource === "pi_local") {
+      const { executeLocalPiStream } = await loadLocalPiStreamExecutorModule();
+      const preview = this.buildLocalPiRequestPreview({
         prepared,
-        forcedToolName,
-        maxTokens,
+        sessionFile,
         reasoningEffort,
-        webSearchEnabled,
       });
 
-      if (this.trimPayloadImages(requestBody)) {
-        new Notice(
-          "Some images were removed from older messages to fit within the server's request size limit.",
-          8000,
-        );
-      }
-
-      const transport = PlatformContext.get().preferredTransport({ endpoint });
-
-      debug?.onRequest?.({
-        provider: String(resolvedModel.provider || "systemsculpt"),
-        endpoint,
-        // The license key is a credential: never write it to the debug payload,
-        // which is persisted to the vault and copied to the clipboard. Reuse the
-        // real header shape but with a redacted placeholder (mirrors the BYOK
-        // executors). The genuine key is sent on the real request below.
-        headers: SystemSculptEnvironment.buildHeaders("[redacted]"),
-        body: requestBody,
-        transport,
-        canStream: true,
-        isCustomProvider: false,
-      });
-
-      const response = await this.platformRequestClient.request({
-        url: endpoint,
-        method: "POST",
-        body: requestBody,
-        stream: true,
-        signal,
-        licenseKey: (this.settings.licenseKey || "").trim(),
-      });
-
-      debug?.onResponse?.({
-        provider: String(resolvedModel.provider || "systemsculpt"),
-        endpoint,
-        status: response.status,
-        headers: serializeResponseHeaders(response.headers),
-        isCustomProvider: false,
-      });
-
-      if (!response.ok) {
-        await StreamingErrorHandler.handleStreamError(response, false, {
-          provider: String(resolvedModel.provider || "systemsculpt"),
-          endpoint,
-          model: prepared.actualModelId,
-        });
-      }
-
-      let diagnostics: any;
-      for await (
-        const event of this.streamingService.streamResponse(response, {
-          model: prepared.actualModelId,
+      try {
+        debug?.onRequest?.({
+          provider: String(resolvedModel.sourceProviderId || resolvedModel.provider || "unknown"),
+          endpoint: "local-pi-sdk",
+          headers: {},
+          body: preview,
+          transport: "pi-sdk",
+          canStream: true,
           isCustomProvider: false,
-          signal,
-          onRawEvent: debug?.onRawEvent,
-          onDiagnostics: (value) => {
-            diagnostics = value;
-          },
-        })
-      ) {
-        try {
-          debug?.onStreamEvent?.({ event });
-        } catch {}
+        });
+      } catch {}
+
+      for await (const event of executeLocalPiStream({
+        plugin: this.plugin,
+        prepared,
+        sessionFile,
+        onSessionReady: onPiSessionReady,
+        signal,
+        reasoningEffort,
+        debug,
+      })) {
         yield event;
       }
 
@@ -1360,41 +1329,144 @@ export class SystemSculptService {
         debug?.onStreamEnd?.({
           completed: !signal?.aborted,
           aborted: !!signal?.aborted,
-          diagnostics,
         });
       } catch {}
-    } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
+      return;
+    }
+
+    if (prepared.modelSource === "custom_endpoint") {
+      const remoteProviderId = normalizeProviderId(
+        String(prepared.resolvedModel.sourceProviderId || prepared.resolvedModel.provider || ""),
+      );
+
+      // Anthropic/Claude runs through the native Messages API executor; the
+      // OpenAI-compatible /chat/completions path cannot serve it (#230).
+      if (remoteProviderId === "anthropic") {
+        const { executeAnthropicRemoteStream } = await loadAnthropicRemoteStreamExecutorModule();
+        for await (const event of executeAnthropicRemoteStream({
+          plugin: this.plugin,
+          prepared,
+          signal,
+          reasoningEffort,
+          debug,
+        })) {
+          yield event;
+        }
         return;
       }
-      try {
-        errorLogger.error("Stream error in streamMessage", error, {
-          source: "SystemSculptService",
-          method: "streamMessage",
-          metadata: { model },
-        });
-      } catch {}
-      try {
-        debug?.onError?.({
-          error: error instanceof Error ? error.message : String(error),
-          details: error,
-        });
-      } catch {}
-      if (onError) {
-        let errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
 
-        if (
-          error instanceof SystemSculptError &&
-          error.code === ERROR_CODES.STREAM_ERROR &&
-          error.statusCode === 400
-        ) {
-          errorMessage +=
-            "\nPlease try again in a few moments. If the issue persists, try selecting a different model.";
+      // Gemini uses the native generateContent streaming API, not the
+      // OpenAI-compatible /chat/completions executor (#231).
+      if (remoteProviderId === "google") {
+        const { executeGeminiRemoteStream } = await loadGeminiRemoteStreamExecutorModule();
+        for await (const event of executeGeminiRemoteStream({
+          plugin: this.plugin,
+          prepared,
+          signal,
+          reasoningEffort,
+          debug,
+        })) {
+          yield event;
         }
-        onError(errorMessage);
+        return;
       }
-      throw error;
+
+
+      const { executeOpenRouterRemoteStream } = await loadRemoteProviderStreamExecutorModule();
+      for await (const event of executeOpenRouterRemoteStream({
+        plugin: this.plugin,
+        prepared,
+        signal,
+        reasoningEffort,
+        debug,
+      })) {
+        yield event;
+      }
+      return;
     }
+
+    const endpoint = `${this.baseUrl}${SYSTEMSCULPT_API_ENDPOINTS.CHAT.COMPLETIONS}`;
+    const requestBody = this.buildHostedChatRequestBody({
+      prepared,
+      forcedToolName,
+      maxTokens,
+      reasoningEffort,
+      webSearchEnabled,
+    });
+
+    if (this.trimPayloadImages(requestBody)) {
+      new Notice(
+        "Some images were removed from older messages to fit within the server's request size limit.",
+        8000,
+      );
+    }
+
+    const transport = PlatformContext.get().preferredTransport({ endpoint });
+
+    debug?.onRequest?.({
+      provider: String(resolvedModel.provider || "systemsculpt"),
+      endpoint,
+      // The license key is a credential: never write it to the debug payload,
+      // which is persisted to the vault and copied to the clipboard. Reuse the
+      // real header shape but with a redacted placeholder (mirrors the BYOK
+      // executors). The genuine key is sent on the real request below.
+      headers: SystemSculptEnvironment.buildHeaders("[redacted]"),
+      body: requestBody,
+      transport,
+      canStream: true,
+      isCustomProvider: false,
+    });
+
+    const response = await this.platformRequestClient.request({
+      url: endpoint,
+      method: "POST",
+      body: requestBody,
+      stream: true,
+      signal,
+      licenseKey: (this.settings.licenseKey || "").trim(),
+    });
+
+    debug?.onResponse?.({
+      provider: String(resolvedModel.provider || "systemsculpt"),
+      endpoint,
+      status: response.status,
+      headers: serializeResponseHeaders(response.headers),
+      isCustomProvider: false,
+    });
+
+    if (!response.ok) {
+      await StreamingErrorHandler.handleStreamError(response, false, {
+        provider: String(resolvedModel.provider || "systemsculpt"),
+        endpoint,
+        model: prepared.actualModelId,
+      });
+    }
+
+    let diagnostics: any;
+    for await (
+      const event of this.streamingService.streamResponse(response, {
+        model: prepared.actualModelId,
+        isCustomProvider: false,
+        signal,
+        onRawEvent: debug?.onRawEvent,
+        onDiagnostics: (value) => {
+          diagnostics = value;
+        },
+      })
+    ) {
+      try {
+        debug?.onStreamEvent?.({ event });
+      } catch {}
+      yield event;
+    }
+
+    try {
+      debug?.onStreamEnd?.({
+        completed: !signal?.aborted,
+        aborted: !!signal?.aborted,
+        diagnostics,
+      });
+    } catch {}
   }
 
   /**

--- a/src/services/__tests__/StreamingErrorHandler.test.ts
+++ b/src/services/__tests__/StreamingErrorHandler.test.ts
@@ -2,12 +2,16 @@ import { StreamingErrorHandler } from "../StreamingErrorHandler";
 import { SystemSculptError, ERROR_CODES } from "../../utils/errors";
 
 describe("StreamingErrorHandler", () => {
-  const createMockResponse = (status: number, body: any): Response => ({
+  const createMockResponse = (
+    status: number,
+    body: any,
+    headers?: Record<string, string>
+  ): Response => ({
     status,
     text: jest.fn().mockResolvedValue(typeof body === "string" ? body : JSON.stringify(body)),
     ok: status >= 200 && status < 300,
     statusText: "OK",
-    headers: new Headers(),
+    headers: new Headers(headers),
     redirected: false,
     type: "basic",
     url: "",
@@ -149,6 +153,43 @@ describe("StreamingErrorHandler", () => {
         code: ERROR_CODES.QUOTA_EXCEEDED,
         message: "Rate limit exceeded",
       });
+    });
+
+    // BUG-17: a BYOK/custom-provider 429 is transient, not terminal. The classifier
+    // (quotaError.ts) keys "offer a retry" off isRateLimited/shouldRetry, so the
+    // custom branch must set them — otherwise BYOK 429s never offer a retry.
+    it("classifies a custom-provider 429 as a transient rate limit", async () => {
+      const response = createMockResponse(429, {
+        error: { message: "Rate limit exceeded" },
+      });
+
+      try {
+        await StreamingErrorHandler.handleStreamError(response, true);
+        throw new Error("expected handleStreamError to throw");
+      } catch (err) {
+        const sysErr = err as SystemSculptError;
+        expect(sysErr.code).toBe(ERROR_CODES.QUOTA_EXCEEDED);
+        expect(sysErr.metadata?.isRateLimited).toBe(true);
+        expect(sysErr.metadata?.shouldRetry).toBe(true);
+      }
+    });
+
+    // BUG-16/BUG-17: the custom 429 must honor the server Retry-After header
+    // instead of an unconditional hint.
+    it("honors the Retry-After header on a custom-provider 429", async () => {
+      const response = createMockResponse(
+        429,
+        { error: { message: "Rate limit exceeded" } },
+        { "retry-after": "42" }
+      );
+
+      try {
+        await StreamingErrorHandler.handleStreamError(response, true);
+        throw new Error("expected handleStreamError to throw");
+      } catch (err) {
+        const sysErr = err as SystemSculptError;
+        expect(sysErr.metadata?.retryAfterSeconds).toBe(42);
+      }
     });
 
     it("uses top-level message when error wrapper is missing", async () => {
@@ -392,6 +433,44 @@ describe("StreamingErrorHandler", () => {
         await StreamingErrorHandler.handleStreamError(response, false);
       } catch (err) {
         expect((err as SystemSculptError).message).toContain("OpenRouter is automatically trying");
+      }
+    });
+
+    // BUG-16: the managed 429 path used to hard-code a 5s hint, so the UI always
+    // said "wait ~5s" even when the server's Retry-After header said 60. The hint
+    // must reflect the real header value.
+    it("honors the Retry-After header on a managed 429 (BUG-16)", async () => {
+      const response = createMockResponse(
+        429,
+        { error: { message: "Request rate-limited upstream by provider" } },
+        { "retry-after": "60" }
+      );
+
+      try {
+        await StreamingErrorHandler.handleStreamError(response, false);
+        throw new Error("expected handleStreamError to throw");
+      } catch (err) {
+        const sysErr = err as SystemSculptError;
+        expect(sysErr.code).toBe(ERROR_CODES.QUOTA_EXCEEDED);
+        expect(sysErr.metadata?.isRateLimited).toBe(true);
+        expect(sysErr.metadata?.shouldRetry).toBe(true);
+        // Must reflect the server header, not the legacy hard-coded 5.
+        expect(sysErr.metadata?.retryAfterSeconds).toBe(60);
+      }
+    });
+
+    // BUG-16: when the server omits Retry-After, fall back to the 5s hint.
+    it("falls back to a 5s hint when a managed 429 has no Retry-After header", async () => {
+      const response = createMockResponse(429, {
+        error: { message: "Request rate-limited upstream by provider" },
+      });
+
+      try {
+        await StreamingErrorHandler.handleStreamError(response, false);
+        throw new Error("expected handleStreamError to throw");
+      } catch (err) {
+        const sysErr = err as SystemSculptError;
+        expect(sysErr.metadata?.retryAfterSeconds).toBe(5);
       }
     });
 

--- a/src/services/__tests__/SystemSculptService.test.ts
+++ b/src/services/__tests__/SystemSculptService.test.ts
@@ -3,6 +3,8 @@ import { SystemSculptService } from "../SystemSculptService";
 import { SystemSculptEnvironment } from "../api/SystemSculptEnvironment";
 import { AGENT_PRESET } from "../../constants/prompts";
 import { AGENT_TOOL_INSTRUCTIONS } from "../../constants/prompts/agent";
+import { StreamingErrorHandler } from "../StreamingErrorHandler";
+import { SystemSculptError, ERROR_CODES } from "../../utils/errors";
 
 const licenseService = {
   validateLicense: jest.fn().mockResolvedValue(true),
@@ -771,6 +773,163 @@ describe("SystemSculptService", () => {
     expect((service as any).platformRequestClient.request).toHaveBeenCalledWith(
       expect.objectContaining({ licenseKey: "ssk-super-secret-license" })
     );
+  });
+
+  describe("transient rate-limit retry (BUG-07)", () => {
+    const rateLimitError = (retryAfterSeconds: number) =>
+      new SystemSculptError("Rate limit exceeded", ERROR_CODES.QUOTA_EXCEEDED, 429, {
+        isRateLimited: true,
+        shouldRetry: true,
+        retryAfterSeconds,
+      });
+
+    const okStreamResponse = (text: string) =>
+      new Response(`data: {"choices":[{"delta":{"content":"${text}"}}]}\n\ndata: [DONE]\n\n`, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+
+    const notOkResponse = () =>
+      new Response("rate limited", {
+        status: 429,
+        headers: { "content-type": "application/json" },
+      });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("retries once after a 429 and succeeds when no content was streamed yet", async () => {
+      jest.useFakeTimers();
+      const plugin = createPlugin();
+      const service = SystemSculptService.getInstance(plugin);
+
+      // First attempt: non-ok 429 → handler throws a transient rate-limit error.
+      // Second attempt: ok 200 stream with content.
+      const request = jest
+        .fn()
+        .mockResolvedValueOnce(notOkResponse())
+        .mockResolvedValueOnce(okStreamResponse("Recovered"));
+      (service as any).platformRequestClient.request = request;
+
+      (StreamingErrorHandler.handleStreamError as jest.Mock).mockImplementationOnce(async () => {
+        throw rateLimitError(1);
+      });
+
+      const generator = service.streamMessage({
+        messages: [{ role: "user", content: "Hello", message_id: "msg_retry_1" } as any],
+        model: "systemsculpt@@systemsculpt/ai-agent",
+      });
+
+      const events: any[] = [];
+      const drain = (async () => {
+        for await (const event of generator) {
+          events.push(event);
+        }
+      })();
+
+      // Advance through the retry wait so the second attempt runs.
+      await jest.advanceTimersByTimeAsync(2000);
+      await drain;
+
+      // Exactly the recovered content — never the partial 429 path, never doubled.
+      expect(events).toEqual([{ type: "content", text: "Recovered" }]);
+      expect(request).toHaveBeenCalledTimes(2);
+    });
+
+    it("does NOT retry (and never double-emits) once content has already streamed", async () => {
+      const plugin = createPlugin();
+      const service = SystemSculptService.getInstance(plugin);
+      modelManagementService.getModelInfo.mockResolvedValueOnce({
+        isCustom: true,
+        actualModelId: "openai/gpt-5.4-mini",
+        modelSource: "custom_endpoint",
+        model: {
+          id: "openrouter@@openai/gpt-5.4-mini",
+          provider: "openrouter",
+          sourceMode: "custom_endpoint",
+          sourceProviderId: "openrouter",
+          piExecutionModelId: "openai/gpt-5.4-mini",
+          piRemoteAvailable: true,
+          piLocalAvailable: false,
+          supported_parameters: ["tools"],
+        },
+      });
+
+      // Emit one chunk, THEN fail with an otherwise-retryable rate limit. Because
+      // content already streamed, the retry guard must refuse to retry — so the
+      // executor runs exactly once and the error propagates (no double-emit).
+      let executorCalls = 0;
+      remoteProviderStreamExecutor.executeOpenRouterRemoteStream.mockImplementation(
+        async function* () {
+          executorCalls += 1;
+          yield { type: "content", text: "Partial" };
+          throw rateLimitError(1);
+        }
+      );
+
+      // Fail loudly if the wait is ever entered: a post-content error must never
+      // reach the retry-wait branch.
+      const waitSpy = jest.spyOn(service as any, "waitForRetryWindow");
+
+      const events: any[] = [];
+      await expect(
+        (async () => {
+          for await (const event of service.streamMessage({
+            messages: [{ role: "user", content: "Hello", message_id: "msg_retry_2" } as any],
+            model: "openrouter@@openai/gpt-5.4-mini",
+          })) {
+            events.push(event);
+          }
+        })()
+      ).rejects.toBeInstanceOf(SystemSculptError);
+
+      expect(events).toEqual([{ type: "content", text: "Partial" }]);
+      expect(executorCalls).toBe(1);
+      expect(waitSpy).not.toHaveBeenCalled();
+    });
+
+    it("honors an abort signal during the retry wait without retrying", async () => {
+      const plugin = createPlugin();
+      const service = SystemSculptService.getInstance(plugin);
+      const controller = new AbortController();
+
+      const request = jest
+        .fn()
+        .mockResolvedValueOnce(notOkResponse())
+        .mockResolvedValueOnce(okStreamResponse("ShouldNeverAppear"));
+      (service as any).platformRequestClient.request = request;
+
+      (StreamingErrorHandler.handleStreamError as jest.Mock).mockImplementationOnce(async () => {
+        throw rateLimitError(5);
+      });
+
+      // Abort exactly while the retry wait is pending: the real waitForRetryWindow
+      // resolves on abort, so the loop must observe signal.aborted and bail out
+      // without ever issuing the second request.
+      const realWait = (service as any).waitForRetryWindow.bind(service);
+      const waitSpy = jest
+        .spyOn(service as any, "waitForRetryWindow")
+        .mockImplementation((delayMs: any, signal: any) => {
+          controller.abort();
+          return realWait(delayMs, signal);
+        });
+
+      const events: any[] = [];
+      for await (const event of service.streamMessage({
+        messages: [{ role: "user", content: "Hello", message_id: "msg_retry_3" } as any],
+        model: "systemsculpt@@systemsculpt/ai-agent",
+        signal: controller.signal,
+      })) {
+        events.push(event);
+      }
+
+      // Aborted mid-wait: no content, the wait was entered once, and the second
+      // attempt is never made.
+      expect(events).toEqual([]);
+      expect(waitSpy).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("routes Pi-local chat turns through the local Pi stream executor", async () => {


### PR DESCRIPTION
## Summary

Fixes the rate-limit/`Retry-After` cluster so transient upstream throttling degrades gracefully instead of erroring. The client-side complement to website issue #48.

- **BUG-16** — the managed (SystemSculpt API) 429 path hard-coded a 5s retry hint and ignored the server's `Retry-After`, so the UI always said "wait ~5s" even when told 60. A shared `resolveRetryAfterSeconds()` now parses the `Retry-After` header (delta-seconds **or** HTTP-date per RFC 9110) plus body fallbacks, defaulting to 5 only when nothing is advertised.
- **BUG-17** — the custom/BYOK 429 path was terminal (`QUOTA_EXCEEDED` with no transient fields), so BYOK 429s never offered a retry affordance. It now sets `isRateLimited`/`shouldRetry` and the resolved `Retry-After`, mirroring the managed branch. `quotaError.ts` already keys "transient" off those fields, so the Chat UI now offers the retry.
- **BUG-07** — the abort-aware retry methods (`shouldRetryRateLimitedStreamTurn`, `getRateLimitedRetryDelayMs`, `waitForRetryWindow`) were dead code (zero callers).

**Plan:** `plans/006-wire-or-remove-rate-limit-retry-and-honor-retry-after.md`

## Decision-gate path: WIRED UP (not the safe delete fallback)

The plan's recommended path, taken because the no-double-emit guard could be made clean and provable. `streamMessage` is **re-architected** into a bounded, abort-aware retry loop that drains a new private `streamMessageOnce()` generator (the previous body, extracted verbatim — all five executor paths byte-identical modulo indentation).

The double-emit guard is **structural, not heuristic**: there is exactly one `yield` site, and `hasYielded` latches `true` the instant one event leaves it. The retry branch is `!hasYielded && attempt < 1 && !signal?.aborted`, so once any content has streamed the retry path is unreachable — already-streamed content can never be replayed. Terminal error handling (abort swallow, logging, `debug.onError`, `onError`, rethrow) moved to the outer loop so it runs once, on the final outcome. This reuses the three previously-dead methods exactly as designed (they were already abort-aware).

## Impact

Transient 429s (managed and BYOK) now (a) surface the server's real retry delay in the UI, (b) are classified transient so a retry is offered, and (c) on the managed path are automatically retried once when nothing has streamed yet — while a mid-stream failure after content still fails cleanly with no duplication.

## Guard tests (failing-first → green)

`src/services/__tests__/StreamingErrorHandler.test.ts`:
- managed 429 honors `Retry-After: 60` (not the legacy 5); falls back to 5 when the header is absent
- custom 429 is classified transient (`isRateLimited`/`shouldRetry`); honors `Retry-After: 42`

`src/services/__tests__/SystemSculptService.test.ts` (new `transient rate-limit retry (BUG-07)` describe):
- 429-then-200 retries once and succeeds **only when no content streamed yet**
- once content has streamed, an otherwise-retryable error does **not** retry, the wait is never entered, and content is never doubled
- abort during the retry wait bails without issuing the second request

The no-double-emit and abort guards were proven load-bearing: removing them makes those two tests fail (the no-double-emit test even re-runs and double-emits), then restoring them makes them pass.

## Local gates (all green)

- `npm run check:plugin:fast` — PASS (tsc, bundle, script-tests, unit)
- `npm test` — PASS (414 suites, 5720 tests)
- `npm run test:integration` — PASS (production build clean, 6 suites / 21 tests)

Note: `plans/` is intentionally left untracked/unstaged per the operator's hard rule; only the four in-scope source/test files are modified.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM
