### PR TITLE
fix(embeddings): keep vectors aligned with chunks on whitespace-only input (BUG-01)

### DIFF
--- a/src/services/__tests__/SystemSculptProvider.alignment.test.ts
+++ b/src/services/__tests__/SystemSculptProvider.alignment.test.ts
@@ -1,0 +1,117 @@
+jest.mock("../../utils/httpClient", () => {
+  return {
+    httpRequest: jest.fn(),
+    isHostTemporarilyDisabled: jest.fn(() => ({ disabled: false, retryInMs: 0 })),
+  };
+});
+
+jest.mock("../../utils/errorLogger", () => ({
+  errorLogger: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const { httpRequest } = require("../../utils/httpClient") as {
+  httpRequest: jest.Mock;
+};
+
+import { SystemSculptProvider } from "../embeddings/providers/SystemSculptProvider";
+
+/**
+ * BUG-01: keep returned vectors aligned with their input chunks.
+ *
+ * `generateEmbeddings` must return exactly one slot per ORIGINAL input, in
+ * order. Whitespace-only / empty inputs (which the provider must not send to
+ * the API) are represented as `null` at their original index — the processor
+ * (`EmbeddingsProcessor.processBatch`) requires `embeddings.length ===
+ * texts.length` and skips per-index `null`. Dropping the entry instead shifts
+ * every later vector onto the wrong chunk (silent semantic-search corruption).
+ */
+describe("SystemSculptProvider vector/chunk alignment (BUG-01)", () => {
+  beforeEach(() => {
+    httpRequest.mockReset();
+  });
+
+  // The HTTP layer echoes one vector per text the provider actually sends,
+  // tagged with the text so we can assert which chunk each vector binds to.
+  function echoOneVectorPerSentText() {
+    httpRequest.mockImplementation(({ body }: { body: string }) => {
+      const payload = JSON.parse(body);
+      const embeddings = (payload.texts as string[]).map((text, idx) => [
+        idx,
+        text.length,
+      ]);
+      return Promise.resolve({
+        status: 200,
+        text: JSON.stringify({ embeddings }),
+        headers: { "content-type": "application/json" },
+      });
+    });
+  }
+
+  it("preserves positional alignment when a whitespace-only chunk sits in the middle", async () => {
+    echoOneVectorPerSentText();
+    const provider = new SystemSculptProvider("test-license");
+
+    const result = await provider.generateEmbeddings(["real text", "   ", "more text"]);
+
+    // One slot per original input, in order.
+    expect(result).toHaveLength(3);
+    // The whitespace slot carries no vector...
+    expect(result[1]).toBeNull();
+    // ...and the surrounding chunks keep their own vectors (not shifted up).
+    expect(Array.isArray(result[0])).toBe(true);
+    expect(Array.isArray(result[2])).toBe(true);
+    // The API was only asked to embed the two real chunks.
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(httpRequest.mock.calls[0][0].body).texts as string[];
+    expect(sent).toEqual(["real text", "more text"]);
+  });
+
+  it("returns an all-null array (never a shorter one) when every input is whitespace", async () => {
+    echoOneVectorPerSentText();
+    const provider = new SystemSculptProvider("test-license");
+
+    const result = await provider.generateEmbeddings(["   ", "\t", "\n"]);
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual([null, null, null]);
+    // Nothing valid to embed -> no API call.
+    expect(httpRequest).not.toHaveBeenCalled();
+  });
+
+  it("keeps alignment across client-side sub-batches with interspersed empties", async () => {
+    echoOneVectorPerSentText();
+    const provider = new SystemSculptProvider("test-license");
+
+    // 30 inputs (> the 25/request cap) with a whitespace chunk at index 5.
+    const inputs = Array.from({ length: 30 }, (_, idx) =>
+      idx === 5 ? "   " : `chunk-${idx}`,
+    );
+
+    const result = await provider.generateEmbeddings(inputs);
+
+    expect(result).toHaveLength(30);
+    expect(result[5]).toBeNull();
+    for (let i = 0; i < result.length; i++) {
+      if (i === 5) continue;
+      expect(Array.isArray(result[i])).toBe(true);
+    }
+  });
+
+  it("throws loudly if the server drops a row instead of silently misaligning", async () => {
+    // Two valid inputs, but the server returns only one vector.
+    httpRequest.mockResolvedValue({
+      status: 200,
+      text: JSON.stringify({ embeddings: [[0.1, 0.2]] }),
+      headers: { "content-type": "application/json" },
+    });
+    const provider = new SystemSculptProvider("test-license");
+
+    await expect(
+      provider.generateEmbeddings(["alpha", "beta"]),
+    ).rejects.toThrow(/count|length|mismatch/i);
+  });
+});

--- a/src/services/__tests__/SystemSculptProvider.wafCoverage.test.ts
+++ b/src/services/__tests__/SystemSculptProvider.wafCoverage.test.ts
@@ -9,10 +9,20 @@ describe("SystemSculptProvider WAF signal coverage", () => {
     const obsidian = await import("obsidian");
     requestUrlMock = obsidian.requestUrl as jest.Mock;
     requestUrlMock.mockReset();
-    requestUrlMock.mockResolvedValue({
-      status: 200,
-      text: JSON.stringify({ embeddings: [[0.1, 0.2, 0.3]] }),
-      headers: { "content-type": "application/json" },
+    // Echo one vector per sent text so batch requests get a count-aligned
+    // response (the provider asserts vectors.length === texts.length).
+    requestUrlMock.mockImplementation((opts: { body?: string }) => {
+      let count = 1;
+      try {
+        const payload = opts?.body ? JSON.parse(opts.body) : undefined;
+        if (Array.isArray(payload?.texts)) count = payload.texts.length;
+      } catch {}
+      const embeddings = Array.from({ length: count }, () => [0.1, 0.2, 0.3]);
+      return Promise.resolve({
+        status: 200,
+        text: JSON.stringify({ embeddings }),
+        headers: { "content-type": "application/json" },
+      });
     });
 
     const { SystemSculptProvider } = await import("../embeddings/providers/SystemSculptProvider");

--- a/src/services/embeddings/providers/SystemSculptProvider.ts
+++ b/src/services/embeddings/providers/SystemSculptProvider.ts
@@ -51,7 +51,10 @@ export class SystemSculptProvider implements EmbeddingsProvider {
     this.model = DEFAULT_EMBEDDING_MODEL;
   }
 
-  async generateEmbeddings(texts: string[], options?: EmbeddingsGenerateOptions): Promise<number[][]> {
+  async generateEmbeddings(
+    texts: string[],
+    options?: EmbeddingsGenerateOptions
+  ): Promise<(number[] | null)[]> {
     if (!this.licenseKey) {
       throw new Error('License key is required for SystemSculpt embeddings');
     }
@@ -60,26 +63,47 @@ export class SystemSculptProvider implements EmbeddingsProvider {
       return [];
     }
 
-    // Validate and truncate texts
-    const validTexts = texts
-      .filter(text => text && typeof text === 'string' && text.trim().length > 0)
-      .map(text => {
-        const sanitized = this.sanitizeTextForApi(text);
-        // Ensure each text is within token limits
-        // Use a more conservative limit (5000 tokens) to account for server overhead
-        const truncated = tokenCounter.truncateToTokenLimit(sanitized, 5000);
-        return truncated;
-      });
+    // Sanitize/truncate each input, but NEVER drop entries: whitespace-only or
+    // non-string inputs become `null` at their original index. The returned
+    // array always has one slot per input so callers can pair `result[i]` with
+    // `texts[i]`. Sending the filtered (shorter) list and returning it shifts
+    // every later vector onto the wrong chunk -> silent semantic-search
+    // corruption (BUG-01). The processor requires `length === input.length`
+    // and skips per-index `null`.
+    const prepared = texts.map(text => {
+      if (!text || typeof text !== 'string' || text.trim().length === 0) {
+        return null;
+      }
+      const sanitized = this.sanitizeTextForApi(text);
+      // Use a conservative token limit (5000) to account for server overhead.
+      return tokenCounter.truncateToTokenLimit(sanitized, 5000);
+    });
 
-    if (validTexts.length === 0) {
-      return [];
+    // Indices we actually send to the API, in order.
+    const sendIndices: number[] = [];
+    const sendTexts: string[] = [];
+    prepared.forEach((value, index) => {
+      if (value !== null) {
+        sendIndices.push(index);
+        sendTexts.push(value);
+      }
+    });
+
+    if (sendTexts.length === 0) {
+      // Nothing valid to embed: every slot is null, but the length is preserved.
+      return prepared.map(() => null);
     }
 
-    if (validTexts.length > this.maxTextsPerRequest) {
-      return this.generateEmbeddingsInClientBatches(validTexts, options);
-    }
+    const vectors = sendTexts.length > this.maxTextsPerRequest
+      ? await this.generateEmbeddingsInClientBatches(sendTexts, options)
+      : await this.performEmbeddingRequest(sendTexts, options);
 
-    return this.performEmbeddingRequest(validTexts, options);
+    // Re-thread the returned vectors back into their original positions.
+    const aligned: (number[] | null)[] = prepared.map(() => null);
+    for (let i = 0; i < sendIndices.length; i++) {
+      aligned[sendIndices[i]] = vectors[i] ?? null;
+    }
+    return aligned;
   }
 
   private sanitizeTextForApi(text: string): string {
@@ -361,10 +385,25 @@ export class SystemSculptProvider implements EmbeddingsProvider {
           this.expectedDimension = sampleDim;
         }
 
-        // Support single or batch responses
-        if (Array.isArray(data.embeddings)) return data.embeddings;
-        if (Array.isArray(data.embedding)) return [data.embedding];
-        return [];
+        // Support single or batch responses. Assert one vector per text we
+        // sent so a server that drops rows fails loudly here instead of
+        // silently misaligning vectors with chunks downstream (BUG-01).
+        const vectors: number[][] = Array.isArray(data.embeddings)
+          ? data.embeddings
+          : Array.isArray(data.embedding)
+            ? [data.embedding]
+            : [];
+        if (vectors.length !== payloadTexts.length) {
+          throw new EmbeddingsProviderError(
+            `Embedding count mismatch: expected ${payloadTexts.length}, got ${vectors.length}`,
+            {
+              code: 'UNEXPECTED_RESPONSE',
+              providerId: this.id,
+              endpoint: url,
+            }
+          );
+        }
+        return vectors;
 
       } catch (error) {
         let normalized = this.normalizeError(error, url);

--- a/src/services/embeddings/types.ts
+++ b/src/services/embeddings/types.ts
@@ -133,7 +133,13 @@ export interface EmbeddingsProvider {
   /** Best-effort hint of the embedding vector dimension produced by this provider. */
   expectedDimension?: number;
 
-  generateEmbeddings(texts: string[], options?: EmbeddingsGenerateOptions): Promise<number[][]>;
+  /**
+   * Returns one slot per input text, in order. A slot is `null` when the
+   * provider produced no vector for that input (e.g. a whitespace-only chunk
+   * that must not be sent to the API). Callers MUST pair `result[i]` with
+   * `texts[i]` and skip `null` slots — never assume a 1:1 dense array.
+   */
+  generateEmbeddings(texts: string[], options?: EmbeddingsGenerateOptions): Promise<(number[] | null)[]>;
   validateConfiguration(): Promise<boolean>;
   getModels?(): Promise<string[]>;
   /**


### PR DESCRIPTION
## Summary

`SystemSculptProvider.generateEmbeddings` filtered whitespace-only / empty inputs out before calling the API, then returned vectors for the **filtered** list. Callers (`EmbeddingsProcessor.processBatch`, `EmbeddingsManager`) pair `result[i]` with the **original** `texts[i]`, so any dropped slot shifted every later vector onto the wrong chunk — or tripped the processor's `embeddings.length === texts.length` guard and failed the whole batch.

The fix re-threads the result so it always has **one slot per original input**: whitespace-only / empty inputs become `null` at their original index (the processor already requires matching length and skips per-index `null` via `if (!raw)`), and only valid texts are sent to the API. `performEmbeddingRequest` now asserts `vectors.length === texts.length` so a server that drops a row fails loudly instead of misaligning. The `EmbeddingsProvider.generateEmbeddings` interface return type is widened to `(number[] | null)[]` to make the per-slot contract honest — the processor internals already modeled `number[] | null` (`generateEmbeddingsWithHtmlForbiddenIsolation`), so this aligns the public contract with the canonical design rather than perpetuating the lossy-filter pattern.

Plan: `plans/007-keep-embedding-vectors-aligned-with-chunks.md`

**Null-vs-sentinel decision (plan STOP condition):** the processor both (a) requires `embeddings.length === texts.length` and (b) tolerates per-index `null` (skips it, records a failed chunk). So the plan's preferred **`null`** approach fits the processor contract exactly — no sentinel needed.

## Impact

Without this fix, a single whitespace-only chunk anywhere in a batch silently bound every subsequent vector to the wrong chunk — corrupting semantic search results with no error — or, when the count guard caught it, failed the entire embeddings batch. `CustomProvider` never filtered, so the two providers had already diverged; the contract is now consistent.

## Guard test (failing-test-first)

New `src/services/__tests__/SystemSculptProvider.alignment.test.ts` (runs in the standard `npm test` / `check:plugin:fast` lanes — a permanent CI guard):
- whitespace-only chunk in the middle → result length 3, `result[1] === null`, neighbors keep their own vectors, API only asked to embed the 2 real chunks;
- all-whitespace input → all-`null`, never a shorter array, no API call;
- 30 inputs (> 25/request cap) with an interspersed empty → alignment preserved across client sub-batches;
- server drops a row → `performEmbeddingRequest` throws (count mismatch).

**Failed-then-passed proof:** before the fix all 4 cases failed for the right reason (e.g. whitespace-middle returned length 2; all-empty returned `[]`; sub-batch returned length 29; mismatch resolved instead of throwing). After the fix all 4 pass.

Also updated the shared mock in the pre-existing `SystemSculptProvider.wafCoverage.test.ts` to echo one vector per sent text (it previously returned a single fixed vector for a 3-text batch, which the new count assertion correctly rejects).

## Local gate results (all green)

- `npm run check:plugin:fast` → PASS (tsc, bundle, script-tests, tests)
- `npm test` → 415 suites, 5727 passed, 1 skipped, 0 failed
- `npm run test:integration` → 6 suites, 21 passed
- `npm run test:embeddings` → 25 suites, 275 passed

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Enhanced embedding generation to maintain strict alignment between input chunks and results, with null placeholders for whitespace-only inputs.
* Added validation to detect and reject server responses with mismatched embedding counts, preventing silent data misalignment.
* Improved batch request processing for embedding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->