### PR TITLE
fix(chatview): abort the in-flight stream when a chat view closes (BUG-03)

### DIFF
--- a/src/views/chatview/ChatView.ts
+++ b/src/views/chatview/ChatView.ts
@@ -3193,10 +3193,11 @@ export class ChatView extends ItemView {
   }
 
   async onClose(): Promise<void> {
-    // Cancel any pending operations
-    if (this.inputHandler && typeof (this.inputHandler as any).abortCurrentGeneration === 'function') {
-      (this.inputHandler as any).abortCurrentGeneration();
-    }
+    // Abort any in-flight stream before tearing down the DOM/metrics, so the
+    // network request and its rAF ticker stop running into a removed view
+    // (BUG-03). disposeViewResources() also funnels through this via
+    // inputHandler.unload(), but call it first/explicitly here too.
+    this.inputHandler?.abortActiveTurn?.();
 
     this.disposeViewResources();
     this.messages = [];

--- a/src/views/chatview/InputHandler.ts
+++ b/src/views/chatview/InputHandler.ts
@@ -919,10 +919,22 @@ export class InputHandler extends Component {
   }
 
   private handleStopGeneration(): void {
-    this.turnLifecycle.stop();
+    this.abortActiveTurn();
 
     // Don't force scroll when user stops generation - respect their current position
     // this.scrollManager.resetScrollState();
+  }
+
+  /**
+   * Abort the in-flight chat turn (if any), aborting its stream's AbortController.
+   *
+   * Safe to call when no turn is active: ChatTurnLifecycleController.stop() is
+   * idempotent and never throws. This is the canonical teardown hook — the Stop
+   * button, the input handler's own dispose path, and ChatView.onClose() all go
+   * through it so any route that ends a turn aborts the stream (BUG-03).
+   */
+  public abortActiveTurn(): void {
+    this.turnLifecycle.stop();
   }
 
   private async handleSendMessage(overrides?: {
@@ -1579,6 +1591,11 @@ export class InputHandler extends Component {
       return;
     }
     this.localResourcesDisposed = true;
+
+    // Abort any in-flight stream before tearing down the rest, so the network
+    // request, its rAF metrics ticker, and autosave stop running into a
+    // disposed view (BUG-03).
+    this.abortActiveTurn();
 
     if (this.renderTimeout) {
       clearTimeout(this.renderTimeout);

--- a/src/views/chatview/__tests__/input-handler-abort-on-close.test.ts
+++ b/src/views/chatview/__tests__/input-handler-abort-on-close.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { InputHandler } from "../InputHandler";
+import { ChatTurnLifecycleController } from "../controllers/ChatTurnLifecycleController";
+
+/**
+ * Guard for BUG-03: closing a chat view (or disposing its input handler) while a
+ * turn is streaming must abort the in-flight stream.
+ *
+ * Previously the only teardown hook called a phantom abort method on the input
+ * handler that never existed, so the `turnLifecycle` AbortController was never
+ * aborted on close — the stream, its rAF metrics ticker, and autosave all kept
+ * running into a removed view, burning tokens/credits. The real abort
+ * (`turnLifecycle.stop()`) was reachable only via the Stop button.
+ *
+ * These tests drive the real ChatTurnLifecycleController so a regression in the
+ * teardown wiring re-breaks them.
+ */
+
+type AbortHarness = {
+  handler: InputHandler & Record<string, any>;
+  turnLifecycle: ChatTurnLifecycleController;
+  isGenerating: () => boolean;
+};
+
+const createAbortHarness = (): AbortHarness => {
+  const handler = Object.create(InputHandler.prototype) as InputHandler & Record<string, any>;
+
+  let generating = false;
+  const turnLifecycle = new ChatTurnLifecycleController({
+    getIsGenerating: () => generating,
+    setGenerating: (next) => {
+      generating = next;
+    },
+  });
+
+  handler.turnLifecycle = turnLifecycle;
+
+  // Minimal fields disposeLocalResources() touches so the dispose path runs.
+  handler.localResourcesDisposed = false;
+  handler.renderTimeout = null;
+  handler.recorderVisualizer = null;
+  handler.recorderToggleUnsubscribe = null;
+  handler.chatContainer = document.createElement("div");
+
+  return { handler, turnLifecycle, isGenerating: () => generating };
+};
+
+/**
+ * Start a turn that hangs until its signal aborts, returning the captured signal.
+ */
+const startHangingTurn = (turnLifecycle: ChatTurnLifecycleController): Promise<AbortSignal> => {
+  return new Promise<AbortSignal>((resolveSignal) => {
+    void turnLifecycle.runTurn(
+      (signal) =>
+        new Promise<void>((resolveTurn) => {
+          resolveSignal(signal);
+          if (signal.aborted) {
+            resolveTurn();
+            return;
+          }
+          signal.addEventListener("abort", () => resolveTurn(), { once: true });
+        })
+    );
+  });
+};
+
+describe("InputHandler abort-on-close (BUG-03)", () => {
+  test("abortActiveTurn aborts the in-flight turn's controller", async () => {
+    const { handler, turnLifecycle, isGenerating } = createAbortHarness();
+
+    const signal = await startHangingTurn(turnLifecycle);
+    expect(signal.aborted).toBe(false);
+    expect(isGenerating()).toBe(true);
+
+    handler.abortActiveTurn();
+
+    expect(signal.aborted).toBe(true);
+    expect(isGenerating()).toBe(false);
+  });
+
+  test("the input handler dispose path aborts the in-flight turn", async () => {
+    const { handler, turnLifecycle } = createAbortHarness();
+
+    const signal = await startHangingTurn(turnLifecycle);
+    expect(signal.aborted).toBe(false);
+
+    // disposeLocalResources() is the route both unload() and onunload() funnel
+    // through, and is reached from ChatView.disposeViewResources() via
+    // inputHandler.unload(). Tearing down must abort the active stream.
+    handler.disposeLocalResources();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  test("abortActiveTurn is a no-op when idle (no throw, no active turn)", () => {
+    const { handler, isGenerating } = createAbortHarness();
+
+    expect(() => handler.abortActiveTurn()).not.toThrow();
+    expect(isGenerating()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closing a chat tab mid-stream never aborted the network stream. `ChatView.onClose()` called `(this.inputHandler as any).abortCurrentGeneration()` — a method that **did not exist anywhere** — so its `typeof === 'function'` guard was always false and nothing was aborted. The real abort (`turnLifecycle.stop()`) was reachable only through the Stop button, and `turnLifecycle` is a plain field (never `addChild`-ed), so `Component.unload()` never touched its `AbortController`.

This adds a real, canonical public abort method and routes every teardown path through it, then deletes the dead guard.

- `InputHandler.abortActiveTurn()` — new public method calling the idempotent, no-throw `turnLifecycle.stop()`.
- The **Stop button** (`handleStopGeneration`) now goes through `abortActiveTurn()`.
- The input handler's own dispose path (`disposeLocalResources`, reached via `unload()`/`onunload()`, which `ChatView.disposeViewResources()` already invokes) now aborts the active turn.
- `ChatView.onClose()` calls `inputHandler.abortActiveTurn()` before the DOM/metrics teardown; the dead `abortCurrentGeneration` block is removed.

## Plan

`plans/008-abort-in-flight-stream-on-chat-view-close.md`

## Impact

Because the teardown called a nonexistent method, closing a chat view mid-stream left the network **stream**, its rAF **metrics ticker**, and autosave all running into a removed view — wasting tokens/**credits** and writing against a disposed view. Now any close/dispose route aborts the in-flight `AbortController`.

## Guard test (failing-first)

`src/views/chatview/__tests__/input-handler-abort-on-close.test.ts` drives the **real** `ChatTurnLifecycleController` and asserts:
1. `abortActiveTurn()` aborts an in-flight turn's `AbortController` (and clears generating state).
2. The input handler dispose path (`disposeLocalResources`) aborts the in-flight turn.
3. `abortActiveTurn()` is a no-op when idle (no throw, no active turn).

All three **failed first** for the right reasons (`abortActiveTurn is not a function`; dispose left `signal.aborted === false`), then passed after the fix.

`grep -rn 'abortCurrentGeneration' src/` now returns nothing (dead method gone).

## Local gates (all green)

- `npm run check:plugin:fast` → PASS (tsc, bundle, script-tests, unit)
- `npm test` → PASS (415 suites, 5726 passed, 1 skipped)
- `npm run test:integration` → PASS (production build + 6 suites / 21 tests)

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM