### PR TITLE
fix(settings): surface save/backup failures instead of swallowing them (BUG-19)

### DIFF
--- a/src/core/settings/SettingsManager.ts
+++ b/src/core/settings/SettingsManager.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from "obsidian";
+import { Notice, normalizePath } from "obsidian";
 import { SystemSculptSettings, DEFAULT_SETTINGS, LogLevel, createDefaultWorkflowEngineSettings } from "../../types";
 import SystemSculptPlugin from "../../main";
 import { AutomaticBackupService } from "./AutomaticBackupService";
@@ -50,6 +50,10 @@ export class SettingsManager {
     ignoreUntil: number;
     remainingBudget: number;
   }> = [];
+  // De-duplicate the user-facing save-failure Notice so a sync-lock storm (many
+  // failing saves in quick succession) shows one Notice, not one per keystroke.
+  private lastSaveFailureNoticeAt = 0;
+  private static readonly SAVE_FAILURE_NOTICE_DEDUPE_MS = 5000;
 
 
   constructor(plugin: SystemSculptPlugin) {
@@ -788,6 +792,17 @@ export class SettingsManager {
       
       await this.plugin.app.vault.adapter.write(backupPath, backupData);
     } catch (error) {
+      // Backups are a best-effort safety net: log for diagnostics but do not
+      // rethrow or block saveSettings — a failed backup must not look like a
+      // failed save, and the primary saveData write has already succeeded.
+      try {
+        this.plugin.getLogger().error("Failed to write SystemSculpt settings backup", error, {
+          source: "SettingsManager",
+          method: "backupSettings",
+        });
+      } catch {
+        // Logger must never mask the (already non-fatal) backup failure.
+      }
     }
   }
 
@@ -1085,6 +1100,42 @@ export class SettingsManager {
   }
 
   /**
+   * Surface a settings-persistence failure instead of swallowing it. The failure
+   * is always logged via the plugin logger (for diagnostics), and a single
+   * de-duplicated Notice is shown so the user knows their last change may not have
+   * persisted — without spamming one Notice per keystroke during a sync-lock
+   * storm. We log + notify rather than rethrow: `saveSettings` is invoked from the
+   * load path and from ~100 fire-and-forget `updateSettings(...)` callers, so
+   * rethrowing would convert disk-full/permission errors into uncaught rejections
+   * and could break plugin load. Observability is the fix here; serializing writes
+   * is tracked separately (BUG-09).
+   */
+  private surfaceSaveFailure(error: unknown): void {
+    try {
+      this.plugin.getLogger().error("Failed to save SystemSculpt settings", error, {
+        source: "SettingsManager",
+        method: "saveSettings",
+      });
+    } catch {
+      // Logger must never mask the original failure.
+    }
+
+    const now = Date.now();
+    if (now - this.lastSaveFailureNoticeAt < SettingsManager.SAVE_FAILURE_NOTICE_DEDUPE_MS) {
+      return;
+    }
+    this.lastSaveFailureNoticeAt = now;
+    try {
+      new Notice(
+        "Failed to save SystemSculpt settings — your last change may not persist.",
+        8000,
+      );
+    } catch {
+      // Notice is best-effort UI; never let it throw out of the catch.
+    }
+  }
+
+  /**
    * Save settings using Obsidian's native data API
    * This ensures settings are properly saved with fallback options
    */
@@ -1106,6 +1157,9 @@ export class SettingsManager {
       this.plugin.app.workspace.trigger("systemsculpt:settings-updated", oldSettings, this.plugin._internal_settings_systemsculpt_plugin);
       await this.backupSettings();
     } catch (error) {
+      // Persistence failed (disk full, permissions, sync lock, …). Do NOT
+      // swallow it: log + show a de-duplicated Notice so the loss is visible.
+      this.surfaceSaveFailure(error);
     }
   }
 

--- a/src/core/settings/__tests__/SettingsManager.test.ts
+++ b/src/core/settings/__tests__/SettingsManager.test.ts
@@ -91,15 +91,26 @@ jest.mock("../../../types", () => ({
 }));
 
 import { SettingsManager } from "../SettingsManager";
+import { Notice } from "obsidian";
 import { DEFAULT_SETTINGS, LogLevel } from "../../../types";
 import { migrateSettingsToCurrentSchema } from "../migrations/SettingsMigrator";
+
+const NoticeMock = Notice as unknown as jest.Mock;
 
 describe("SettingsManager", () => {
   let mockPlugin: any;
   let settingsManager: SettingsManager;
+  let mockLogger: { error: jest.Mock; warn: jest.Mock; info: jest.Mock; debug: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockLogger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
 
     mockPlugin = {
       manifest: {
@@ -109,6 +120,7 @@ describe("SettingsManager", () => {
       saveData: jest.fn().mockResolvedValue(undefined),
       storage: null,
       register: jest.fn(),
+      getLogger: jest.fn(() => mockLogger),
       app: {
         vault: {
           configDir: ".obsidian",
@@ -116,8 +128,10 @@ describe("SettingsManager", () => {
             basePath: "/tmp/systemsculpt-test-vault",
             exists: jest.fn().mockResolvedValue(false),
             read: jest.fn(),
+            write: jest.fn().mockResolvedValue(undefined),
             list: jest.fn().mockResolvedValue({ files: [] }),
           },
+          createFolder: jest.fn().mockResolvedValue(undefined),
         },
         workspace: {
           trigger: jest.fn(),
@@ -949,6 +963,87 @@ describe("SettingsManager", () => {
       const result = await restoreFromBackup();
 
       expect(result).toBeNull();
+    });
+  });
+
+  // Guard for plan 009 (BUG-19): a failing saveData/backup write must never be
+  // swallowed silently. Before this guard, saveSettings/backupSettings wrapped
+  // their body in an empty `catch (error) {}`, so a disk-full / permission /
+  // sync-lock failure resolved as success — memory changed, disk did not, and
+  // the change was lost on reload. The failure must be observable (logged via
+  // the plugin logger + a user-facing Notice).
+  describe("surfacing save/backup failures (plan 009 / BUG-19)", () => {
+    it("logs and shows a Notice when saveData rejects", async () => {
+      await settingsManager.loadSettings();
+      NoticeMock.mockClear();
+      mockLogger.error.mockClear();
+
+      const saveError = new Error("ENOSPC: no space left on device");
+      mockPlugin.saveData.mockRejectedValueOnce(saveError);
+
+      // updateSettings -> saveSettings; the persistence failure must surface.
+      await settingsManager.updateSettings({ settingsMode: "advanced" });
+
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      const [message, forwardedError] = mockLogger.error.mock.calls[0];
+      expect(typeof message).toBe("string");
+      expect(forwardedError).toBe(saveError);
+      expect(NoticeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("de-duplicates the Notice across a burst of consecutive save failures", async () => {
+      await settingsManager.loadSettings();
+      NoticeMock.mockClear();
+      mockLogger.error.mockClear();
+
+      mockPlugin.saveData.mockRejectedValue(new Error("EBUSY: resource busy"));
+
+      // Simulate a sync-lock storm: many saves fail back-to-back. The user must
+      // not be spammed with one Notice per keystroke.
+      await settingsManager.updateSettings({ settingsMode: "advanced" });
+      await settingsManager.updateSettings({ debugMode: true });
+      await settingsManager.updateSettings({ agentModeEnabled: false });
+
+      // Every failure is logged for diagnostics, but the Notice is de-duplicated.
+      expect(mockLogger.error.mock.calls.length).toBeGreaterThanOrEqual(3);
+      expect(NoticeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not log or show a Notice on the happy path", async () => {
+      await settingsManager.loadSettings();
+      NoticeMock.mockClear();
+      mockLogger.error.mockClear();
+
+      await settingsManager.updateSettings({ settingsMode: "advanced" });
+
+      expect(settingsManager.settings.settingsMode).toBe("advanced");
+      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(NoticeMock).not.toHaveBeenCalled();
+    });
+
+    it("logs a backup failure but does not break updateSettings", async () => {
+      await settingsManager.loadSettings();
+      NoticeMock.mockClear();
+      mockLogger.error.mockClear();
+      mockLogger.warn.mockClear();
+
+      // saveData succeeds; only the best-effort backup write fails.
+      mockPlugin.app.vault.adapter.exists.mockResolvedValue(true);
+      mockPlugin.app.vault.adapter.write = jest
+        .fn()
+        .mockRejectedValue(new Error("EACCES: permission denied"));
+
+      await expect(
+        settingsManager.updateSettings({ settingsMode: "advanced" })
+      ).resolves.toBeUndefined();
+
+      // The in-memory change still applied and was persisted via saveData.
+      expect(settingsManager.settings.settingsMode).toBe("advanced");
+      expect(mockPlugin.saveData).toHaveBeenCalled();
+      // Backup failure is observable in diagnostics (best-effort: logged, no throw).
+      const backupLogged =
+        mockLogger.error.mock.calls.length > 0 || mockLogger.warn.mock.calls.length > 0;
+      expect(backupLogged).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
`SettingsManager.saveSettings` and `backupSettings` each wrapped their whole body in an empty `catch (error) {}`. A failing `saveData` (disk full, permission denied, sync lock) was therefore **invisible**: `updateSettings` resolved as success, in-memory settings reflected the change, disk did not, and the change was silently lost on the next reload. This PR makes the failure observable.

- `saveSettings` catch: log via the existing plugin logger (`getLogger().error(...)`) **and** show a single **de-duplicated** Obsidian `Notice` ("Failed to save SystemSculpt settings — your last change may not persist."). The Notice is rate-limited (5s window) so a sync-lock storm shows one Notice, not one per keystroke; each failure is still logged for diagnostics.
- `backupSettings` catch: log only — backups are a best-effort safety net, so a backup-write failure is recorded but never rethrown and never blocks the (already-succeeded) primary save.
- No new logging mechanism introduced — reuses `PluginLogger` and Obsidian `Notice`, matching usage elsewhere in `src/core/settings/`.

**Plan:** `plans/009-surface-settings-save-failures.md`

## Decision-gate path: log + de-duplicated Notice, WITHOUT rethrow
The plan's recommended path was log + Notice + **rethrow** from `saveSettings`. I took the plan's documented **fallback** (log + de-duplicated Notice, no rethrow) because rethrowing cascades to callers in ways that cannot be cleanly contained:

- `saveSettings` has **~10** direct callers and `updateSettings` has **~116** callers; many are genuinely fire-and-forget (`void getSettingsManager().updateSettings(...)`, chained `.updateSettings(...)` with no `.catch`, and even a non-awaited `SystemSculptService.instance.updateSettings(...)`). Rethrowing would turn disk-full/permission errors into **uncaught promise rejections** across the plugin.
- `loadSettings()` does `await this.saveSettings()` on the **startup path**. Rethrowing on a save failure at load time could break plugin initialization — strictly worse than the silent-loss bug being fixed.

This honors the plan's STOP condition ("if rethrowing cascades to many fire-and-forget callers in ways you cannot cleanly contain, fall back to log + de-duplicated Notice without rethrow and state that you did"). Observability — not propagation — is the fix here. Serializing concurrent writes (the lost-update race) remains out of scope (BUG-09).

## Impact
Previously: on disk-full / permission / sync-lock, a settings change appeared to succeed but was silently dropped on reload, with zero signal to the user or logs. Now: every such failure is logged, and the user sees a single clear Notice that their last change may not have persisted.

## Guard test (failing-test-first)
New `describe("surfacing save/backup failures (plan 009 / BUG-19)")` block in `src/core/settings/__tests__/SettingsManager.test.ts`:
- rejecting `saveData` → logs once (forwarding the original error) + shows exactly one `Notice`;
- a burst of consecutive save failures → de-duplicates to **one** Notice while logging each failure;
- happy path → no log, no Notice;
- backup-write failure → logged but `updateSettings` still resolves and the in-memory change + primary `saveData` persist.

Confirmed **red first** against the empty catches (logger/Notice called 0 times), then **green** after the fix. Permanent CI guard per AGENTS.md.

## Local gates (all green)
- `npm run check:plugin:fast` — PASS (tsc + bundle + script tests + unit)
- `npm test` — PASS (415 suites, 5730 tests)
- `npm run test:integration` — PASS (production build + 6 built-bundle suites, 21 tests)

`grep -n 'catch (error) {' src/core/settings/SettingsManager.ts` shows no empty body for `saveSettings`/`backupSettings` (remaining match is `restoreFromBackup`, which intentionally returns null and is out of scope).

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and notifications when settings fail to persist to disk, ensuring you're alerted if changes may not be saved.
  * Implemented notification de-duplication to prevent repeated alerts during consecutive save failures.
  * Improved error logging and handling for settings backup operations to increase reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->