### PR TITLE
chore(dx): wire the orphaned CSS linter into the check:plugin gate

### DIFF
--- a/scripts/check-plugin.mjs
+++ b/scripts/check-plugin.mjs
@@ -4,6 +4,7 @@
  * Unified, quiet checker for the Obsidian plugin.
  * - TypeScript typecheck (noEmit)
  * - Real production build + artifact validation
+ * - CSS lint (Obsidian-override scoping hygiene)
  * - Release workflow node:test coverage
  * - Jest unit tests
  * Prints concise summary on success; details only on failure or --verbose.
@@ -13,6 +14,7 @@ import { execSync } from 'node:child_process';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { buildProductionPlugin } from './plugin-artifacts.mjs';
+import { lintCssDirectory } from './lint-css.mjs';
 
 const args = process.argv.slice(2);
 const verbose = args.includes('--verbose');
@@ -79,9 +81,33 @@ async function checkBundle() {
   }
 }
 
+function checkCss() {
+  const cssDir = path.join(root, 'src', 'css');
+  if (!fs.existsSync(cssDir)) {
+    return { ok: true, ms: 0, note: 'no-css' };
+  }
+
+  const started = Date.now();
+  const report = lintCssDirectory({ cssDir });
+  const ms = Date.now() - started;
+
+  if (report.errorCount > 0) {
+    const lines = report.issues
+      .filter(issue => issue.severity === 'error')
+      .map(issue => `${issue.file}:${issue.line} ${issue.message} (selector: ${issue.selector})`);
+    return {
+      ok: false,
+      ms,
+      message: `${report.errorCount} CSS error(s):\n${lines.join('\n')}`,
+    };
+  }
+
+  return { ok: true, ms, note: `${report.fileCount} files` };
+}
+
 async function main() {
   const results = [];
-  const checks = ['tsc', 'bundle'];
+  const checks = ['tsc', 'bundle', 'css'];
   const jestRunner = path.join(root, 'scripts', 'jest.mjs');
   const jestCmdPrefix = fs.existsSync(jestRunner) ? `node ${JSON.stringify(jestRunner)}` : 'npx jest';
 
@@ -91,6 +117,9 @@ async function main() {
   const bundle = await checkBundle();
   results.push({ name: 'bundle', ...bundle });
 
+  const css = checkCss();
+  results.push({ name: 'css', ...css });
+
   if (!skipTests) {
     checks.push('script-tests', 'tests');
     const scriptTests = run(
@@ -98,6 +127,7 @@ async function main() {
         [
           'scripts/release-plugin.test.mjs',
           'scripts/plugin-artifacts.test.mjs',
+          'scripts/lint-css.test.mjs',
           'scripts/check-github-required-checks.test.mjs',
           'scripts/check-native-release-gates.test.mjs',
           'scripts/github-workflows.test.mjs',
@@ -148,6 +178,9 @@ async function main() {
       if (verbose) {
         console.error(r.message || '');
       }
+    } else if (r.name === 'css') {
+      console.error('[plugin] FAIL: CSS lint found unscoped Obsidian-override selectors');
+      console.error(r.message || '');
     } else if (r.name === 'script-tests') {
       console.error('[plugin] FAIL: Script-level tests failed');
       if (verbose) {

--- a/scripts/lint-css.mjs
+++ b/scripts/lint-css.mjs
@@ -208,6 +208,40 @@ function checkSelector(selectorInfo) {
 }
 
 /**
+ * Lint every CSS file under a directory.
+ *
+ * Pure (no process.exit, no console): scans `cssDir`, returns a structured
+ * report so callers (the CLI below, and the check:plugin gate) can decide how
+ * to surface results. This is what makes the guard testable.
+ *
+ * @param {{ cssDir: string }} options
+ * @returns {{ errorCount: number, warningCount: number, fileCount: number, issues: Array<{severity: string, message: string, selector: string, line: number, file: string}> }}
+ */
+export function lintCssDirectory({ cssDir }) {
+  const issues = [];
+  let errorCount = 0;
+  let warningCount = 0;
+
+  const cssFiles = findCssFiles(cssDir);
+
+  for (const file of cssFiles) {
+    const content = fs.readFileSync(file, "utf8");
+    const relPath = path.relative(ROOT_DIR, file);
+    const selectors = extractSelectors(content, relPath);
+
+    for (const sel of selectors) {
+      for (const issue of checkSelector(sel)) {
+        if (issue.severity === "error") errorCount++;
+        if (issue.severity === "warning") warningCount++;
+        issues.push(issue);
+      }
+    }
+  }
+
+  return { errorCount, warningCount, fileCount: cssFiles.length, issues };
+}
+
+/**
  * Recursively find all CSS files
  */
 function findCssFiles(dir) {
@@ -238,31 +272,15 @@ function main() {
     process.exit(1);
   }
 
-  const cssFiles = findCssFiles(CSS_DIR);
-  console.log(`Found ${cssFiles.length} CSS files\n`);
+  const { errorCount, warningCount, fileCount, issues } = lintCssDirectory({ cssDir: CSS_DIR });
+  console.log(`Found ${fileCount} CSS files\n`);
 
-  let errorCount = 0;
-  let warningCount = 0;
   const issuesByFile = new Map();
-
-  for (const file of cssFiles) {
-    const content = fs.readFileSync(file, "utf8");
-    const relPath = path.relative(ROOT_DIR, file);
-    const selectors = extractSelectors(content, relPath);
-
-    for (const sel of selectors) {
-      const issues = checkSelector(sel);
-
-      for (const issue of issues) {
-        if (issue.severity === "error") errorCount++;
-        if (issue.severity === "warning") warningCount++;
-
-        if (!issuesByFile.has(relPath)) {
-          issuesByFile.set(relPath, []);
-        }
-        issuesByFile.get(relPath).push(issue);
-      }
+  for (const issue of issues) {
+    if (!issuesByFile.has(issue.file)) {
+      issuesByFile.set(issue.file, []);
     }
+    issuesByFile.get(issue.file).push(issue);
   }
 
   // Report issues
@@ -297,4 +315,9 @@ function main() {
   }
 }
 
-main();
+// Run the CLI only when invoked directly (e.g. `node scripts/lint-css.mjs`),
+// not when imported (the check:plugin gate and the guard test import
+// lintCssDirectory instead).
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main();
+}

--- a/scripts/lint-css.test.mjs
+++ b/scripts/lint-css.test.mjs
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { lintCssDirectory } from "./lint-css.mjs";
+
+function createTempCssDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "systemsculpt-lint-css-"));
+}
+
+function writeCss(dir, name, contents) {
+  fs.writeFileSync(path.join(dir, name), contents, "utf8");
+}
+
+// Permanent guard for plan 010: the CSS linter is wired into the check:plugin
+// gate (scripts/check-plugin.mjs imports lintCssDirectory). These tests prove
+// the gate actually FAILS on a deliberate violation and PASSES on scoped CSS,
+// so the guard can never silently degrade into a no-op again.
+
+test("lintCssDirectory flags a bare Obsidian-override selector (the gate fails on a violation)", () => {
+  const dir = createTempCssDir();
+  // This is the exact class of bug the linter exists to catch: an unscoped
+  // .workspace-leaf-content override that would leak into every workspace leaf
+  // (see src/css/README.md "Historical Context").
+  writeCss(
+    dir,
+    "bad-override.css",
+    [
+      ".workspace-leaf-content [role=\"button\"] {",
+      "  position: relative;",
+      "}",
+      "",
+    ].join("\n")
+  );
+
+  const report = lintCssDirectory({ cssDir: dir });
+
+  assert.ok(
+    report.errorCount > 0,
+    `expected the linter to report at least one error, got ${report.errorCount}`
+  );
+  assert.ok(
+    report.issues.some(issue => issue.severity === "error"),
+    "expected at least one error-severity issue"
+  );
+});
+
+test("lintCssDirectory flags a bare [data-type] selector", () => {
+  const dir = createTempCssDir();
+  writeCss(
+    dir,
+    "bad-attr.css",
+    '[data-type="markdown"] { color: red; }\n'
+  );
+
+  const report = lintCssDirectory({ cssDir: dir });
+
+  assert.ok(report.errorCount > 0, "bare [data-type=] selector must be an error");
+});
+
+test("lintCssDirectory passes properly scoped plugin selectors (the gate stays green)", () => {
+  const dir = createTempCssDir();
+  writeCss(
+    dir,
+    "good-scoped.css",
+    [
+      ".systemsculpt-chat-view [role=\"button\"] {",
+      "  position: relative;",
+      "}",
+      ".workspace-leaf-content[data-type=\"systemsculpt-chat\"] {",
+      "  padding: 0;",
+      "}",
+      "",
+    ].join("\n")
+  );
+
+  const report = lintCssDirectory({ cssDir: dir });
+
+  assert.equal(report.errorCount, 0, "scoped plugin selectors must not error");
+});
+
+test("the shipped src/css tree passes the linter (gate is green today)", () => {
+  const cssDir = path.join(process.cwd(), "src", "css");
+  const report = lintCssDirectory({ cssDir });
+
+  assert.equal(
+    report.errorCount,
+    0,
+    `src/css must stay clean so the gate is green; errors:\n` +
+      report.issues
+        .filter(issue => issue.severity === "error")
+        .map(issue => `  ${issue.file}:${issue.line} ${issue.message}`)
+        .join("\n")
+  );
+  assert.ok(report.fileCount > 0, "expected to lint at least one CSS file");
+});


### PR DESCRIPTION
## Summary

`scripts/lint-css.mjs` is a real linter that enforces Obsidian-override scoping hygiene on `src/css`, and `package.json` exposes it as `npm run lint:css` — but **nothing ran it**: not `scripts/check-plugin.mjs`, not any `.github/workflows/*.yml`. The rules shipped unchecked, and `src/css/README.md`'s claim that the script "enforces these rules" was effectively false.

This wires it **canonically** into the single check gate (re-architect, don't patch around the orphan):

- **`scripts/lint-css.mjs`**: export `lintCssDirectory({ cssDir })` as a pure function (no `process.exit` / no `console`); the CLI now calls it and only runs `main()` when invoked directly, so the module is importable. The lint patterns and selector-checking logic are **unchanged**.
- **`scripts/check-plugin.mjs`**: imports `lintCssDirectory` and runs it as a `css` step after tsc/bundle, **unconditionally** (not gated behind `--fast`/`--skip-tests`). This covers both `check:plugin` and `check:plugin:fast`. CI runs `check:plugin:fast` via `ci.yml`, so the gate now guards **locally and in CI**. A real failure prints the offending file/line/selector.
- **`scripts/lint-css.test.mjs`** (new): the permanent guard, registered in the `check-plugin` `node --test` list.

**Plan:** `plans/010-wire-css-linter-into-check-gate.md`

## Baseline `lint:css` result

`npm run lint:css` → **exit 0** ("All CSS selectors are properly scoped", 82 CSS files). The stylesheet conforms today, so wiring it in is safe — no `styles.css` edits needed (out of scope).

## Where wired

`scripts/check-plugin.mjs` (the preferred single wiring point), as a `css` check after `tsc`/`bundle`. Because CI invokes `npm run check:plugin:fast`, this gives both local + CI coverage from one change. No `ci.yml` change needed. README claim is now true (no README edit needed).

## Permanent guard (proves the gate fails on a violation)

`scripts/lint-css.test.mjs` (`node --test`, run by `check:plugin`):
- `lintCssDirectory flags a bare Obsidian-override selector (the gate fails on a violation)` — feeds a bare `.workspace-leaf-content [role="button"]` override (the exact December 2025 file-explorer bug) and asserts `errorCount > 0`.
- `lintCssDirectory flags a bare [data-type] selector`.
- `lintCssDirectory passes properly scoped plugin selectors (the gate stays green)`.
- `the shipped src/css tree passes the linter (gate is green today)`.

**Fails-on-violation, then green** — proven end-to-end (not just the unit test): with a scratch `src/css/__SCRATCH_VIOLATION__.css` present, `node scripts/check-plugin.mjs --fast --skip-tests` exits **1** (`[plugin] FAIL: CSS lint found unscoped Obsidian-override selectors`); after removing it, the gate exits **0** (`[plugin] PASS [fast]: tsc, bundle, css`). Scratch file reverted.

## Local gate results

- `npm run check:plugin:fast` → **PASS** (`tsc, bundle, css, script-tests, tests`)
- `npm test` → **PASS** (416 suites, 5730 passed, 1 skipped)
- `npm run test:integration` → **PASS** (6 suites, 21 tests)

## Scope

One issue: wiring the CSS linter into the gate + permanent guard. Out of scope: `styles.css` contents, ESLint convergence (DX-02/DX-12), and any change to `lint-css.mjs`'s lint rules.

https://claude.ai/code/session_01KA69F2NfwwCqtndcZcnctM