### PR TITLE
Add New Studio action to file explorer

### DIFF
--- a/src/core/plugin/FileExplorerStudioButtonManager.ts
+++ b/src/core/plugin/FileExplorerStudioButtonManager.ts
@@ -1,0 +1,283 @@
+import { Notice, normalizePath, setIcon } from "obsidian";
+import type SystemSculptPlugin from "../../main";
+import { PlatformContext } from "../../services/PlatformContext";
+
+export const FILE_EXPLORER_STUDIO_BUTTON_CLASS = "systemsculpt-file-explorer-new-studio-button";
+
+const FILE_EXPLORER_BUTTONS_SELECTOR =
+  '.workspace-leaf-content[data-type="file-explorer"] .nav-header .nav-buttons-container';
+const NEW_STUDIO_PROJECT_NAME = "New Studio Project";
+const NEW_STUDIO_PROJECT_FILE_NAME = `${NEW_STUDIO_PROJECT_NAME}.systemsculpt`;
+
+type StudioServiceLike = ReturnType<SystemSculptPlugin["getStudioService"]>;
+type ViewManagerLike = ReturnType<SystemSculptPlugin["getViewManager"]>;
+
+type FileExplorerStudioButtonPlugin = Pick<
+  SystemSculptPlugin,
+  "app" | "getStudioService" | "getViewManager"
+>;
+
+export class FileExplorerStudioButtonManager {
+  private observer: MutationObserver | null = null;
+  private syncTimer: number | null = null;
+  private createInFlight = false;
+
+  constructor(private readonly plugin: FileExplorerStudioButtonPlugin) {}
+
+  start(): void {
+    if (!PlatformContext.get().supportsDesktopOnlyFeatures()) {
+      return;
+    }
+
+    this.syncButtons();
+
+    if (this.observer || typeof MutationObserver === "undefined" || !document.body) {
+      return;
+    }
+
+    this.observer = new MutationObserver(() => this.scheduleSync());
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  dispose(): void {
+    if (this.syncTimer != null) {
+      window.clearTimeout(this.syncTimer);
+      this.syncTimer = null;
+    }
+
+    this.observer?.disconnect();
+    this.observer = null;
+    this.removeButtons();
+  }
+
+  syncButtons(): void {
+    if (!PlatformContext.get().supportsDesktopOnlyFeatures()) {
+      this.removeButtons();
+      return;
+    }
+
+    const containers = document.querySelectorAll<HTMLElement>(FILE_EXPLORER_BUTTONS_SELECTOR);
+    containers.forEach((container) => this.syncButton(container));
+  }
+
+  private scheduleSync(): void {
+    if (this.syncTimer != null) {
+      return;
+    }
+
+    this.syncTimer = window.setTimeout(() => {
+      this.syncTimer = null;
+      this.syncButtons();
+    }, 50);
+  }
+
+  private removeButtons(): void {
+    document
+      .querySelectorAll<HTMLElement>(`.${FILE_EXPLORER_STUDIO_BUTTON_CLASS}`)
+      .forEach((button) => button.remove());
+  }
+
+  private syncButton(container: HTMLElement): void {
+    let button = container.querySelector<HTMLElement>(`.${FILE_EXPLORER_STUDIO_BUTTON_CLASS}`);
+    if (!button) {
+      button = this.createButton();
+    }
+
+    const newNoteButton = this.findActionButton(container, ["New note"]);
+    const newFolderButton = this.findActionButton(container, ["New folder"]);
+
+    if (newNoteButton) {
+      if (newNoteButton.nextElementSibling !== button) {
+        newNoteButton.insertAdjacentElement("afterend", button);
+      }
+      return;
+    }
+
+    if (newFolderButton) {
+      if (newFolderButton.previousElementSibling !== button) {
+        container.insertBefore(button, newFolderButton);
+      }
+      return;
+    }
+
+    if (button.parentElement !== container) {
+      container.appendChild(button);
+    }
+  }
+
+  private createButton(): HTMLElement {
+    const button = document.createElement("div");
+    button.classList.add(
+      "clickable-icon",
+      "nav-action-button",
+      FILE_EXPLORER_STUDIO_BUTTON_CLASS
+    );
+    button.setAttribute("aria-label", "New Studio");
+    button.setAttribute("data-tooltip-position", "bottom");
+    button.setAttribute("role", "button");
+    button.tabIndex = 0;
+    setIcon(button, "workflow");
+
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void this.createAndOpenStudioProject(button);
+    });
+
+    button.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" && event.key !== " ") {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      void this.createAndOpenStudioProject(button);
+    });
+
+    return button;
+  }
+
+  private findActionButton(container: HTMLElement, labels: string[]): HTMLElement | null {
+    const labelSet = new Set(labels.map((label) => label.toLowerCase()));
+    const candidates = container.querySelectorAll<HTMLElement>(".nav-action-button, .clickable-icon");
+
+    for (const candidate of Array.from(candidates)) {
+      const label = (
+        candidate.getAttribute("aria-label") ||
+        candidate.getAttribute("data-tooltip") ||
+        candidate.getAttribute("title") ||
+        ""
+      ).trim().toLowerCase();
+
+      if (labelSet.has(label)) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  private async createAndOpenStudioProject(button: HTMLElement): Promise<void> {
+    if (this.createInFlight) {
+      return;
+    }
+
+    this.createInFlight = true;
+    button.classList.add("is-loading");
+    button.setAttribute("aria-disabled", "true");
+
+    try {
+      const studio = this.plugin.getStudioService() as StudioServiceLike;
+      const projectPath = this.resolveTargetProjectPath(button);
+      const project = await studio.createProject(
+        projectPath
+          ? {
+              name: NEW_STUDIO_PROJECT_NAME,
+              projectPath,
+            }
+          : {
+              name: NEW_STUDIO_PROJECT_NAME,
+            }
+      );
+      const createdProjectPath = studio.getCurrentProjectPath();
+      if (!createdProjectPath) {
+        throw new Error("Studio project was created but no project path was returned.");
+      }
+
+      const viewManager = this.plugin.getViewManager() as ViewManagerLike;
+      await viewManager.activateSystemSculptStudioView(createdProjectPath);
+      new Notice(`Created Studio project: ${project.name}`);
+    } catch (error: any) {
+      new Notice(`Unable to create Studio project: ${error?.message || error}`);
+    } finally {
+      this.createInFlight = false;
+      button.classList.remove("is-loading");
+      button.removeAttribute("aria-disabled");
+    }
+  }
+
+  private resolveTargetProjectPath(button: HTMLElement): string | undefined {
+    const folderPath = this.resolveTargetFolderPath(button);
+    if (folderPath === null) {
+      return undefined;
+    }
+
+    return normalizePath(
+      folderPath
+        ? `${folderPath}/${NEW_STUDIO_PROJECT_FILE_NAME}`
+        : NEW_STUDIO_PROJECT_FILE_NAME
+    );
+  }
+
+  private resolveTargetFolderPath(button: HTMLElement): string | null {
+    const explorer = button.closest<HTMLElement>('.workspace-leaf-content[data-type="file-explorer"]');
+    const activeExplorerFolderPath = explorer
+      ? this.findActivePath(explorer, ".nav-folder-title")
+      : null;
+    const normalizedExplorerFolderPath = this.normalizeFolderPath(activeExplorerFolderPath);
+    if (normalizedExplorerFolderPath !== null) {
+      return normalizedExplorerFolderPath;
+    }
+
+    const activeExplorerFilePath = explorer ? this.findActivePath(explorer, ".nav-file-title") : null;
+    const explorerFileParent = this.parentFolderPath(activeExplorerFilePath);
+    if (explorerFileParent !== null) {
+      return explorerFileParent;
+    }
+
+    const activeFile = this.plugin.app.workspace.getActiveFile?.() as { path?: unknown } | null | undefined;
+    if (activeFile && typeof activeFile.path === "string") {
+      return this.parentFolderPath(activeFile.path);
+    }
+
+    return null;
+  }
+
+  private findActivePath(explorer: HTMLElement, titleSelector: string): string | null {
+    const activeSelectors = [
+      `${titleSelector}.is-active[data-path]`,
+      `${titleSelector}.is-selected[data-path]`,
+      `${titleSelector}.mod-active[data-path]`,
+      `${titleSelector}[aria-selected="true"][data-path]`,
+    ];
+
+    for (const selector of activeSelectors) {
+      const activeTitle = explorer.querySelector<HTMLElement>(selector);
+      const path = activeTitle?.getAttribute("data-path");
+      if (path != null) {
+        return path;
+      }
+    }
+
+    return null;
+  }
+
+  private parentFolderPath(filePath: string | null | undefined): string | null {
+    if (filePath == null) {
+      return null;
+    }
+
+    const normalized = normalizePath(String(filePath || "").trim().replace(/^\/+|\/+$/g, ""));
+    if (!normalized) {
+      return "";
+    }
+
+    const lastSlash = normalized.lastIndexOf("/");
+    return lastSlash >= 0 ? normalized.slice(0, lastSlash) : "";
+  }
+
+  private normalizeFolderPath(path: string | null | undefined): string | null {
+    if (path == null) {
+      return null;
+    }
+
+    const raw = String(path).trim();
+    if (!raw || raw === "/" || raw === "\\") {
+      return "";
+    }
+
+    return normalizePath(raw.replace(/^\/+|\/+$/g, ""));
+  }
+}

--- a/src/core/plugin/__tests__/file-explorer-studio-button.test.ts
+++ b/src/core/plugin/__tests__/file-explorer-studio-button.test.ts
@@ -146,6 +146,24 @@ describe("FileExplorerStudioButtonManager", () => {
     });
   });
 
+  it("creates a Studio project beside the active explorer file", async () => {
+    const buttons = appendExplorer({ activeFilePath: "Selected/Brief.md" });
+    const { manager, createProject } = createHarness({
+      activeFile: new TFile({ path: "Workspace/Other.md" }),
+    });
+
+    manager.syncButtons();
+    buttons
+      .querySelector<HTMLElement>(`.${FILE_EXPLORER_STUDIO_BUTTON_CLASS}`)
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    expect(createProject).toHaveBeenCalledWith({
+      name: "New Studio Project",
+      projectPath: "Selected/New Studio Project.systemsculpt",
+    });
+  });
+
   it("does not add the explorer action on non-desktop surfaces", () => {
     mockSupportsDesktopOnlyFeatures = false;
     const buttons = appendExplorer();

--- a/src/core/plugin/__tests__/file-explorer-studio-button.test.ts
+++ b/src/core/plugin/__tests__/file-explorer-studio-button.test.ts
@@ -1,0 +1,158 @@
+/** @jest-environment jsdom */
+
+import { App, TFile, setIcon } from "obsidian";
+import {
+  FILE_EXPLORER_STUDIO_BUTTON_CLASS,
+  FileExplorerStudioButtonManager,
+} from "../FileExplorerStudioButtonManager";
+
+let mockSupportsDesktopOnlyFeatures = true;
+
+jest.mock("../../../services/PlatformContext", () => ({
+  PlatformContext: {
+    get: () => ({
+      supportsDesktopOnlyFeatures: () => mockSupportsDesktopOnlyFeatures,
+    }),
+  },
+}));
+
+function appendExplorer(options?: {
+  activeFolderPath?: string;
+  activeFilePath?: string;
+}): HTMLElement {
+  const leaf = document.body.createDiv({ cls: "workspace-leaf-content" });
+  leaf.dataset.type = "file-explorer";
+
+  const header = leaf.createDiv({ cls: "nav-header" });
+  const buttons = header.createDiv({ cls: "nav-buttons-container" });
+  buttons.createDiv({ cls: "clickable-icon nav-action-button" }).setAttr("aria-label", "New note");
+  buttons.createDiv({ cls: "clickable-icon nav-action-button" }).setAttr("aria-label", "New folder");
+
+  const files = leaf.createDiv({ cls: "nav-files-container" });
+  if (options?.activeFolderPath !== undefined) {
+    files
+      .createDiv({ cls: "nav-folder-title is-active" })
+      .setAttr("data-path", options.activeFolderPath);
+  }
+  if (options?.activeFilePath !== undefined) {
+    files
+      .createDiv({ cls: "nav-file-title is-active" })
+      .setAttr("data-path", options.activeFilePath);
+  }
+
+  return buttons;
+}
+
+function createHarness(options?: { activeFile?: TFile | null }) {
+  const app = new App();
+  (app.workspace.getActiveFile as jest.Mock).mockReturnValue(options?.activeFile ?? null);
+
+  const createProject = jest.fn().mockResolvedValue({ name: "New Studio Project" });
+  const getCurrentProjectPath = jest
+    .fn()
+    .mockReturnValue("Projects/New Studio Project.systemsculpt");
+  const activateSystemSculptStudioView = jest.fn().mockResolvedValue(undefined);
+
+  const plugin = {
+    app,
+    getStudioService: jest.fn(() => ({
+      createProject,
+      getCurrentProjectPath,
+    })),
+    getViewManager: jest.fn(() => ({
+      activateSystemSculptStudioView,
+    })),
+  };
+
+  const manager = new FileExplorerStudioButtonManager(plugin as any);
+
+  return {
+    app,
+    manager,
+    createProject,
+    getCurrentProjectPath,
+    activateSystemSculptStudioView,
+  };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("FileExplorerStudioButtonManager", () => {
+  beforeEach(() => {
+    document.body.empty();
+    jest.clearAllMocks();
+    mockSupportsDesktopOnlyFeatures = true;
+  });
+
+  it("adds one native New Studio action beside New note in the file explorer header", () => {
+    const buttons = appendExplorer();
+    const { manager } = createHarness();
+
+    manager.syncButtons();
+    manager.syncButtons();
+
+    const studioButtons = buttons.querySelectorAll(`.${FILE_EXPLORER_STUDIO_BUTTON_CLASS}`);
+    const newNoteButton = buttons.querySelector<HTMLElement>('[aria-label="New note"]');
+    const newFolderButton = buttons.querySelector<HTMLElement>('[aria-label="New folder"]');
+    const studioButton = studioButtons[0] as HTMLElement;
+
+    expect(studioButtons).toHaveLength(1);
+    expect(studioButton.classList.contains("clickable-icon")).toBe(true);
+    expect(studioButton.classList.contains("nav-action-button")).toBe(true);
+    expect(studioButton.getAttribute("aria-label")).toBe("New Studio");
+    expect(studioButton.getAttribute("data-tooltip-position")).toBe("bottom");
+    expect(newNoteButton?.nextElementSibling).toBe(studioButton);
+    expect(studioButton.nextElementSibling).toBe(newFolderButton);
+    expect(setIcon).toHaveBeenCalledWith(studioButton, "workflow");
+  });
+
+  it("creates and opens a Studio project in the active explorer folder", async () => {
+    const buttons = appendExplorer({ activeFolderPath: "Projects" });
+    const { manager, createProject, activateSystemSculptStudioView } = createHarness();
+
+    manager.syncButtons();
+    buttons
+      .querySelector<HTMLElement>(`.${FILE_EXPLORER_STUDIO_BUTTON_CLASS}`)
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    expect(createProject).toHaveBeenCalledWith({
+      name: "New Studio Project",
+      projectPath: "Projects/New Studio Project.systemsculpt",
+    });
+    expect(activateSystemSculptStudioView).toHaveBeenCalledWith(
+      "Projects/New Studio Project.systemsculpt"
+    );
+  });
+
+  it("falls back to the active file parent when the explorer has no active folder", async () => {
+    const buttons = appendExplorer();
+    const { manager, createProject } = createHarness({
+      activeFile: new TFile({ path: "Clients/Brief.md" }),
+    });
+
+    manager.syncButtons();
+    buttons
+      .querySelector<HTMLElement>(`.${FILE_EXPLORER_STUDIO_BUTTON_CLASS}`)
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    expect(createProject).toHaveBeenCalledWith({
+      name: "New Studio Project",
+      projectPath: "Clients/New Studio Project.systemsculpt",
+    });
+  });
+
+  it("does not add the explorer action on non-desktop surfaces", () => {
+    mockSupportsDesktopOnlyFeatures = false;
+    const buttons = appendExplorer();
+    const { manager } = createHarness();
+
+    manager.syncButtons();
+
+    expect(buttons.querySelector(`.${FILE_EXPLORER_STUDIO_BUTTON_CLASS}`)).toBeNull();
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ import { PreviewService } from './services/PreviewService';
 import { StorageManager } from "./core/storage";
 import { ResumeChatService } from "./views/chatview/ResumeChatService";
 import { EmbeddingsManager } from "./services/embeddings/EmbeddingsManager";
+import { FileExplorerStudioButtonManager } from "./core/plugin/FileExplorerStudioButtonManager";
 import { VaultFileCache } from "./utils/VaultFileCache";
 import { EmbeddingsStatusBar } from "./components/EmbeddingsStatusBar";
 import { FreezeMonitor } from "./services/FreezeMonitor";
@@ -156,6 +157,7 @@ export default class SystemSculptPlugin extends Plugin {
   private webResearchApiService: WebResearchApiService | null = null;
   private webResearchCorpusService: WebResearchCorpusService | null = null;
   private studioService: StudioService | null = null;
+  private fileExplorerStudioButtonManager: FileExplorerStudioButtonManager | null = null;
   private desktopAutomationBridge: DesktopAutomationBridge | null = null;
   private pendingSettingsFocusTab: string | null = null;
   private readonly mobileStartupProbePath = normalizePath("SystemSculpt/Diagnostics/mobile-startup.json");
@@ -1881,6 +1883,18 @@ export default class SystemSculptPlugin extends Plugin {
     this.hasRegisteredStudioExtensions = true;
   }
 
+  private startFileExplorerStudioButtonIfNeeded(): void {
+    if (!PlatformContext.get().supportsDesktopOnlyFeatures()) {
+      return;
+    }
+
+    if (!this.fileExplorerStudioButtonManager) {
+      this.fileExplorerStudioButtonManager = new FileExplorerStudioButtonManager(this);
+    }
+
+    this.fileExplorerStudioButtonManager.start();
+  }
+
   private ensureCommandManager(): CommandManager {
     if (this.commandManager) {
       return this.commandManager;
@@ -1910,6 +1924,7 @@ export default class SystemSculptPlugin extends Plugin {
       }
       this.ensureViewManager();
       this.registerStudioExtensionsIfNeeded();
+      this.startFileExplorerStudioButtonIfNeeded();
       this.ensureCommandManager();
 
       try {
@@ -2021,6 +2036,11 @@ export default class SystemSculptPlugin extends Plugin {
       }
 
       await this.stopDesktopAutomationBridge();
+
+      if (this.fileExplorerStudioButtonManager) {
+        this.fileExplorerStudioButtonManager.dispose();
+        this.fileExplorerStudioButtonManager = null;
+      }
 
       // Clean up settings manager (stop automatic backups)
       if (this.settingsManager) {


### PR DESCRIPTION
- Adds a native file explorer `New Studio` action next to `New note` that creates and opens a `.systemsculpt` project.
- Keeps Studio creation desktop-only and reuses the existing Studio project/view services with coverage for placement, folder targeting, and mobile guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “New Studio” button in the file explorer for quickly creating a studio project.
  * The button appears alongside existing explorer actions and supports both mouse and keyboard use.
  * When used, it opens the newly created studio view and shows success or error feedback.

* **Bug Fixes**
  * Improved button placement and cleanup so it stays in sync with file explorer changes and is removed properly when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->