### PR TITLE
Fix Studio label drag and resize stability

### DIFF
--- a/src/css/views/systemsculpt-studio.css
+++ b/src/css/views/systemsculpt-studio.css
@@ -1383,7 +1383,8 @@ select.ss-pi-wizard__select { width: 100%; }
 }
 
 .ss-studio-graph-viewport.is-interacting .ss-studio-group-frame,
-.ss-studio-graph-viewport.is-interacting .ss-studio-node-card {
+.ss-studio-graph-viewport.is-interacting .ss-studio-node-card,
+.ss-studio-node-card:has(> .ss-studio-node-resize-handle.is-active) {
   transition: none;
   animation-play-state: paused;
 }
@@ -1391,7 +1392,8 @@ select.ss-pi-wizard__select { width: 100%; }
 /* Drop the halo only during active node drag — per-frame filter repaint
    adds real cost there. Zoom/scroll is a pure transform composite and
    keeps the halo visible. */
-.ss-studio-graph-viewport.is-interacting .ss-studio-node-card {
+.ss-studio-graph-viewport.is-interacting .ss-studio-node-card,
+.ss-studio-node-card:has(> .ss-studio-node-resize-handle.is-active) {
   filter: none;
 }
 
@@ -3719,6 +3721,7 @@ select.ss-pi-wizard__select { width: 100%; }
 
 .ss-studio-label-display,
 .ss-studio-label-editor {
+  box-sizing: border-box;
   width: 100%;
   height: 100%;
   border-radius: var(--ss-radius-md);
@@ -3733,7 +3736,12 @@ select.ss-pi-wizard__select { width: 100%; }
   padding: var(--ss-space-10) 11px;
   white-space: pre-wrap;
   overflow: auto;
-  user-select: text;
+  cursor: grab;
+  user-select: none;
+}
+
+.ss-studio-label-display:active {
+  cursor: grabbing;
 }
 
 .ss-studio-label-editor {

--- a/src/views/studio/StudioGraphSelectionController.ts
+++ b/src/views/studio/StudioGraphSelectionController.ts
@@ -752,8 +752,6 @@ export class StudioGraphSelectionController {
       return;
     }
 
-    startEvent.preventDefault();
-
     const pointerId = startEvent.pointerId;
     const startX = startEvent.clientX;
     const startY = startEvent.clientY;
@@ -819,6 +817,7 @@ export class StudioGraphSelectionController {
       const travel = Math.hypot(pendingClientX - startX, pendingClientY - startY);
       if (!dragged && travel > 3) {
         dragged = true;
+        startEvent.preventDefault();
         captureHistoryOnNextMutation = true;
         this.host.onNodeDragStateChange?.(true);
         syncHoveredGroup();
@@ -863,6 +862,12 @@ export class StudioGraphSelectionController {
       const latestEvent = this.resolveLatestPointerEvent(moveEvent);
       pendingClientX = latestEvent.clientX;
       pendingClientY = latestEvent.clientY;
+      if (
+        Math.hypot(pendingClientX - startX, pendingClientY - startY) > 3 &&
+        typeof moveEvent.preventDefault === "function"
+      ) {
+        moveEvent.preventDefault();
+      }
       scheduleDragFrame();
     };
 

--- a/src/views/studio/__tests__/studio-graph-selection-controller.test.ts
+++ b/src/views/studio/__tests__/studio-graph-selection-controller.test.ts
@@ -543,6 +543,7 @@ describe("StudioGraphSelectionController drag behavior", () => {
     } as unknown as PointerEvent;
 
     const harness = installWindowPointerListenerHarness();
+    const movePreventDefault = jest.fn();
     try {
       controller.startNodeDrag("node_1", startEvent, nodeEl);
       harness.emit(
@@ -551,6 +552,7 @@ describe("StudioGraphSelectionController drag behavior", () => {
           pointerId: 11,
           clientX: 140,
           clientY: 180,
+          preventDefault: movePreventDefault,
         } as PointerEvent
       );
       harness.emit(
@@ -566,6 +568,7 @@ describe("StudioGraphSelectionController drag behavior", () => {
     }
 
     expect(startEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(movePreventDefault).toHaveBeenCalledTimes(1);
     expect(project.graph.nodes[0].position).toEqual({ x: 80, y: 110 });
     expect(nodeEl.style.transform).toBe("translate(80px, 110px)");
     expect(renderEdgeLayer).toHaveBeenCalled();
@@ -582,6 +585,54 @@ describe("StudioGraphSelectionController drag behavior", () => {
       expect.any(Function),
       { captureHistory: false, mode: "discrete" }
     );
+  });
+
+  it("does not prevent the initial pointer default until a node actually drags", () => {
+    const host = createHost();
+    const project = {
+      graph: {
+        nodes: [
+          {
+            id: "node_1",
+            position: { x: 40, y: 50 },
+            kind: "studio.label",
+            config: {},
+          },
+        ],
+      },
+    } as any;
+    host.getCurrentProject = () => project;
+    host.commitProjectMutation = jest.fn((_reason, mutator) => mutator(project) !== false);
+
+    const controller = new StudioGraphSelectionController(host);
+    const nodeEl = createElementStub();
+    controller.registerNodeElement("node_1", nodeEl);
+    const startEvent = {
+      button: 0,
+      pointerId: 21,
+      clientX: 100,
+      clientY: 120,
+      preventDefault: jest.fn(),
+    } as unknown as PointerEvent;
+
+    const harness = installWindowPointerListenerHarness();
+    try {
+      controller.startNodeDrag("node_1", startEvent, nodeEl);
+      harness.emit(
+        "pointerup",
+        {
+          pointerId: 21,
+          clientX: 100,
+          clientY: 120,
+        } as PointerEvent
+      );
+    } finally {
+      harness.restore();
+    }
+
+    expect(startEvent.preventDefault).not.toHaveBeenCalled();
+    expect(project.graph.nodes[0].position).toEqual({ x: 40, y: 50 });
+    expect(controller.getSelectedNodeIds()).toEqual(["node_1"]);
   });
 
   it("allows marquee selection while busy so multi-node layout changes stay available during runs", () => {

--- a/src/views/studio/graph-v3/StudioGraphLabelNodeCard.ts
+++ b/src/views/studio/graph-v3/StudioGraphLabelNodeCard.ts
@@ -205,16 +205,17 @@ export function renderLabelNodeCard(options: RenderLabelNodeCardOptions): void {
     });
     textSurfaceEl = displayEl;
     applyFontSize(fontSize);
-    displayEl.addEventListener("click", (event) => {
-      const pointerEvent = event as MouseEvent;
+    displayEl.addEventListener("pointerdown", (event) => {
+      const pointerEvent = event as PointerEvent;
       if (pointerEvent.button !== 0) {
         return;
       }
+      event.stopPropagation();
       if (pointerEvent.shiftKey || pointerEvent.metaKey || pointerEvent.ctrlKey) {
         graphInteraction.toggleNodeSelection(node.id);
         return;
       }
-      graphInteraction.ensureSingleSelection(node.id);
+      graphInteraction.startNodeDrag(node.id, pointerEvent, nodeEl);
     });
     displayEl.addEventListener("dblclick", (event) => {
       event.preventDefault();

--- a/src/views/studio/graph-v3/StudioGraphNodeResizeHandle.ts
+++ b/src/views/studio/graph-v3/StudioGraphNodeResizeHandle.ts
@@ -89,6 +89,8 @@ export function mountStudioGraphNodeResizeHandle(
   let startHeight = 0;
   let pendingWidth = 0;
   let pendingHeight = 0;
+  let lastAppliedWidth = 0;
+  let lastAppliedHeight = 0;
   let didMutateDuringDrag = false;
   let capturedHistoryForDrag = false;
 
@@ -100,11 +102,15 @@ export function mountStudioGraphNodeResizeHandle(
     const bounds = resolveStudioGraphNodeResizeBounds(options.node);
     const nextWidth = clampRounded(pendingWidth, bounds.minWidth, bounds.maxWidth);
     const nextHeight = clampRounded(pendingHeight, bounds.minHeight, bounds.maxHeight);
-    const previousWidth = Number(nodeConfig.width);
-    const previousHeight = Number(nodeConfig.height);
-    if (previousWidth === nextWidth && previousHeight === nextHeight) {
+    if (lastAppliedWidth === nextWidth && lastAppliedHeight === nextHeight) {
       return;
     }
+    options.applySize({
+      width: nextWidth,
+      height: nextHeight,
+    });
+    lastAppliedWidth = nextWidth;
+    lastAppliedHeight = nextHeight;
     if (options.onNodeSizeChange) {
       options.onNodeSizeChange(
         options.node.id,
@@ -126,10 +132,6 @@ export function mountStudioGraphNodeResizeHandle(
         options.onNodeConfigMutated(options.node);
       }
     }
-    options.applySize({
-      width: nextWidth,
-      height: nextHeight,
-    });
     didMutateDuringDrag = true;
   };
 
@@ -137,7 +139,14 @@ export function mountStudioGraphNodeResizeHandle(
     if (frameId !== null) {
       return;
     }
-    frameId = window.requestAnimationFrame(applyPendingSize);
+    let frameFiredSynchronously = false;
+    frameId = window.requestAnimationFrame(() => {
+      frameFiredSynchronously = true;
+      applyPendingSize();
+    });
+    if (frameFiredSynchronously) {
+      frameId = null;
+    }
   };
 
   const stopTracking = (): void => {
@@ -165,8 +174,8 @@ export function mountStudioGraphNodeResizeHandle(
       options.onNodeSizeChange(
         options.node.id,
         {
-          width: Number(nodeConfig.width) || clampRounded(pendingWidth, 1, Number.MAX_SAFE_INTEGER),
-          height: Number(nodeConfig.height) || clampRounded(pendingHeight, 1, Number.MAX_SAFE_INTEGER),
+          width: lastAppliedWidth,
+          height: lastAppliedHeight,
         },
         {
           mode: "discrete",
@@ -214,10 +223,13 @@ export function mountStudioGraphNodeResizeHandle(
     const initialSize = options.readInitialSize
       ? options.readInitialSize()
       : readInitialSizeFromNode(options.node, options.nodeEl);
-    startWidth = initialSize.width;
-    startHeight = initialSize.height;
+    const bounds = resolveStudioGraphNodeResizeBounds(options.node);
+    startWidth = clampRounded(initialSize.width, bounds.minWidth, bounds.maxWidth);
+    startHeight = clampRounded(initialSize.height, bounds.minHeight, bounds.maxHeight);
     pendingWidth = startWidth;
     pendingHeight = startHeight;
+    lastAppliedWidth = startWidth;
+    lastAppliedHeight = startHeight;
     handleEl.classList.add("is-active");
     if (typeof handleEl.setPointerCapture === "function") {
       try {

--- a/src/views/studio/graph-v3/__tests__/studio-graph-node-card-renderer.test.ts
+++ b/src/views/studio/graph-v3/__tests__/studio-graph-node-card-renderer.test.ts
@@ -62,7 +62,33 @@ const IDLE_NODE_RUN_STATE: StudioNodeRunDisplayState = {
   outputs: null,
 };
 
-function renderNodeCard(options: {
+type RenderNodeCardHarness = {
+  graphInteraction: ReturnType<typeof createGraphInteractionStub>;
+  node: StudioNodeInstance;
+  nodeEl: HTMLElement;
+  onRequestLabelEdit: jest.Mock;
+  onStopLabelEdit: jest.Mock;
+};
+
+function createPointerEvent(
+  type: string,
+  options: { pointerId: number; clientX: number; clientY: number; button?: number }
+): PointerEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: options.clientX,
+    clientY: options.clientY,
+    button: options.button ?? 0,
+  });
+  Object.defineProperty(event, "pointerId", {
+    value: options.pointerId,
+    configurable: true,
+  });
+  return event as PointerEvent;
+}
+
+function renderNodeCardHarness(options: {
   kind: string;
   config?: StudioNodeInstance["config"];
   nodeRunState?: StudioNodeRunDisplayState;
@@ -70,7 +96,8 @@ function renderNodeCard(options: {
   onOpenImageEditor?: (node: StudioNodeInstance) => void;
   onEditImageWithAi?: (node: StudioNodeInstance) => void;
   onCopyNodeImageToClipboard?: (node: StudioNodeInstance) => void;
-}): HTMLElement {
+  isLabelEditing?: boolean;
+}): RenderNodeCardHarness {
   const {
     kind,
     config = {},
@@ -79,10 +106,13 @@ function renderNodeCard(options: {
     onOpenImageEditor,
     onEditImageWithAi,
     onCopyNodeImageToClipboard,
+    isLabelEditing = false,
   } = options;
   const node = createNode(kind, config);
   const layer = document.body.createDiv({ cls: "ss-studio-test-layer" });
   const graphInteraction = createGraphInteractionStub();
+  const onRequestLabelEdit = jest.fn();
+  const onStopLabelEdit = jest.fn();
 
   renderStudioGraphNodeCard({
     layer,
@@ -104,10 +134,10 @@ function renderNodeCard(options: {
     onEditImageWithAi,
     onCopyNodeImageToClipboard,
     onNodeGeometryMutated: jest.fn(),
-    isLabelEditing: jest.fn(() => false),
+    isLabelEditing: jest.fn(() => isLabelEditing),
     consumeLabelAutoFocus: jest.fn(() => false),
-    onRequestLabelEdit: jest.fn(),
-    onStopLabelEdit: jest.fn(),
+    onRequestLabelEdit,
+    onStopLabelEdit,
     onRevealPathInFinder: jest.fn(),
   });
 
@@ -115,6 +145,17 @@ function renderNodeCard(options: {
   if (!nodeEl) {
     throw new Error(`Expected rendered node card for ${kind}`);
   }
+  return {
+    graphInteraction,
+    node,
+    nodeEl,
+    onRequestLabelEdit,
+    onStopLabelEdit,
+  };
+}
+
+function renderNodeCard(options: Parameters<typeof renderNodeCardHarness>[0]): HTMLElement {
+  const { nodeEl } = renderNodeCardHarness(options);
   return nodeEl;
 }
 
@@ -138,6 +179,62 @@ describe("renderStudioGraphNodeCard", () => {
     expect(nodeEl.classList.contains("has-resize-handle")).toBe(true);
     expect(handleEl).not.toBeNull();
     expect(handleEl?.getAttribute("aria-label")).toBe("Resize node");
+  });
+
+  it("starts dragging display-mode label cards from the label body", () => {
+    const { graphInteraction, node, nodeEl } = renderNodeCardHarness({
+      kind: "studio.label",
+      config: { value: "Move me" },
+    });
+    const displayEl = nodeEl.querySelector<HTMLElement>(".ss-studio-label-display");
+
+    expect(displayEl).not.toBeNull();
+    displayEl?.dispatchEvent(
+      createPointerEvent("pointerdown", {
+        pointerId: 17,
+        clientX: 120,
+        clientY: 140,
+      })
+    );
+
+    expect(graphInteraction.startNodeDrag).toHaveBeenCalledWith(
+      node.id,
+      expect.any(MouseEvent),
+      nodeEl
+    );
+  });
+
+  it("keeps label editing textareas out of card dragging", () => {
+    const { graphInteraction, nodeEl } = renderNodeCardHarness({
+      kind: "studio.label",
+      config: { value: "Editable text" },
+      isLabelEditing: true,
+    });
+    const editorEl = nodeEl.querySelector<HTMLTextAreaElement>(".ss-studio-label-editor");
+
+    expect(editorEl).not.toBeNull();
+    editorEl?.dispatchEvent(
+      createPointerEvent("pointerdown", {
+        pointerId: 19,
+        clientX: 120,
+        clientY: 140,
+      })
+    );
+
+    expect(graphInteraction.startNodeDrag).not.toHaveBeenCalled();
+  });
+
+  it("opens label edit mode on double click", () => {
+    const { graphInteraction, node, nodeEl, onRequestLabelEdit } = renderNodeCardHarness({
+      kind: "studio.label",
+      config: { value: "Double click me" },
+    });
+    const displayEl = nodeEl.querySelector<HTMLElement>(".ss-studio-label-display");
+
+    displayEl?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
+
+    expect(graphInteraction.ensureSingleSelection).toHaveBeenCalledWith(node.id);
+    expect(onRequestLabelEdit).toHaveBeenCalledWith(node.id);
   });
 
   it("keeps media-ingest image previews in contained mode", () => {

--- a/src/views/studio/graph-v3/__tests__/studio-graph-node-resize-handle.test.ts
+++ b/src/views/studio/graph-v3/__tests__/studio-graph-node-resize-handle.test.ts
@@ -153,17 +153,46 @@ describe("mountStudioGraphNodeResizeHandle", () => {
     expect(onNodeGeometryMutated).not.toHaveBeenCalled();
   });
 
+  it("marks the resize handle active while pointer tracking is live", () => {
+    const node = createNode("studio.label");
+    const nodeEl = document.body.createDiv();
+
+    mountStudioGraphNodeResizeHandle({
+      node,
+      nodeEl,
+      title: "Resize label",
+      ariaLabel: "Resize label",
+      interactionLocked: false,
+      getGraphZoom: () => 1,
+      onNodeConfigMutated: jest.fn(),
+      onNodeGeometryMutated: jest.fn(),
+      applySize: () => undefined,
+      readInitialSize: () => ({ width: 300, height: 200 }),
+    });
+
+    const handleEl = nodeEl.querySelector<HTMLElement>(".ss-studio-node-resize-handle");
+    expect(handleEl).not.toBeNull();
+
+    handleEl?.dispatchEvent(createPointerEvent("pointerdown", { pointerId: 13, clientX: 100, clientY: 100 }));
+    expect(handleEl?.classList.contains("is-active")).toBe(true);
+
+    window.dispatchEvent(createPointerEvent("pointerup", { pointerId: 13, clientX: 100, clientY: 100 }));
+    expect(handleEl?.classList.contains("is-active")).toBe(false);
+  });
+
   it("uses node size change callbacks instead of direct config mutation", () => {
     const node = createNode();
     const nodeEl = document.body.createDiv();
     const onNodeConfigMutated = jest.fn();
     const onNodeGeometryMutated = jest.fn();
+    const mutationOrder: string[] = [];
     const onNodeSizeChange = jest.fn(
       (
         _nodeId: string,
         size: { width: number; height: number },
         _options?: { mode?: "continuous" | "discrete"; captureHistory?: boolean }
       ) => {
+        mutationOrder.push(`callback:${size.width}x${size.height}`);
         node.config.width = size.width;
         node.config.height = size.height;
       }
@@ -180,6 +209,7 @@ describe("mountStudioGraphNodeResizeHandle", () => {
       onNodeSizeChange,
       onNodeGeometryMutated,
       applySize: ({ width, height }) => {
+        mutationOrder.push(`dom:${width}x${height}`);
         nodeEl.style.width = `${width}px`;
         nodeEl.style.minHeight = `${height}px`;
       },
@@ -206,7 +236,56 @@ describe("mountStudioGraphNodeResizeHandle", () => {
       { width: 340, height: 250 },
       expect.objectContaining({ mode: "discrete", captureHistory: false })
     );
+    expect(mutationOrder).toEqual([
+      "dom:340x250",
+      "callback:340x250",
+      "callback:340x250",
+    ]);
     expect(onNodeConfigMutated).not.toHaveBeenCalled();
     expect(onNodeGeometryMutated).not.toHaveBeenCalled();
+  });
+
+  it("finalizes callback-driven resizes from the latest pending size when config is stale", () => {
+    const node = createNode("studio.label");
+    node.config.width = 300;
+    node.config.height = 200;
+    const nodeEl = document.body.createDiv();
+    const onNodeSizeChange = jest.fn();
+
+    mountStudioGraphNodeResizeHandle({
+      node,
+      nodeEl,
+      title: "Resize label",
+      ariaLabel: "Resize label",
+      interactionLocked: false,
+      getGraphZoom: () => 1,
+      onNodeConfigMutated: jest.fn(),
+      onNodeSizeChange,
+      onNodeGeometryMutated: jest.fn(),
+      applySize: ({ width, height }) => {
+        nodeEl.style.width = `${width}px`;
+        nodeEl.style.height = `${height}px`;
+      },
+      readInitialSize: () => ({ width: 300, height: 200 }),
+    });
+
+    const handleEl = nodeEl.querySelector<HTMLElement>(".ss-studio-node-resize-handle");
+    expect(handleEl).not.toBeNull();
+    handleEl?.dispatchEvent(createPointerEvent("pointerdown", { pointerId: 23, clientX: 100, clientY: 100 }));
+    window.dispatchEvent(createPointerEvent("pointermove", { pointerId: 23, clientX: 140, clientY: 150 }));
+    window.dispatchEvent(createPointerEvent("pointerup", { pointerId: 23, clientX: 140, clientY: 150 }));
+
+    expect(onNodeSizeChange).toHaveBeenNthCalledWith(
+      1,
+      node.id,
+      { width: 340, height: 250 },
+      expect.objectContaining({ mode: "continuous", captureHistory: true })
+    );
+    expect(onNodeSizeChange).toHaveBeenNthCalledWith(
+      2,
+      node.id,
+      { width: 340, height: 250 },
+      expect.objectContaining({ mode: "discrete", captureHistory: false })
+    );
   });
 });


### PR DESCRIPTION
- Makes display-mode Studio labels drag from the label body while keeping edit-mode textareas text-selectable.\n- Smooths label/node resizing by applying DOM size before mutation callbacks, finalizing from the tracked size, and reducing active resize paint work.\n- Adds coverage for label drag/edit behavior and resize callback finalization.