### PR TITLE
Fix Studio label repeated tap edit

### DIFF
--- a/src/views/studio/graph-v3/StudioGraphLabelNodeCard.ts
+++ b/src/views/studio/graph-v3/StudioGraphLabelNodeCard.ts
@@ -10,6 +10,18 @@ import {
 } from "./StudioGraphNodeGeometry";
 import { mountStudioGraphNodeResizeHandle } from "./StudioGraphNodeResizeHandle";
 
+const STUDIO_LABEL_DOUBLE_TAP_DELAY_MS = 450;
+const STUDIO_LABEL_DOUBLE_TAP_SLOP_PX = 8;
+const STUDIO_LABEL_TAP_DRAG_SLOP_PX = 3;
+
+type LabelTapSnapshot = {
+  at: number;
+  clientX: number;
+  clientY: number;
+};
+
+const lastLabelTapByNodeId = new Map<string, LabelTapSnapshot>();
+
 type RenderLabelNodeCardOptions = {
   nodeEl: HTMLElement;
   node: StudioNodeInstance;
@@ -51,6 +63,64 @@ function clampLabelMetric(value: number, min: number, max: number): number {
     return min;
   }
   return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+function isRepeatLabelTap(
+  nodeId: string,
+  event: PointerEvent,
+  now: number
+): boolean {
+  const previousTap = lastLabelTapByNodeId.get(nodeId);
+  if (!previousTap) {
+    return false;
+  }
+  const elapsedMs = now - previousTap.at;
+  if (elapsedMs < 0 || elapsedMs > STUDIO_LABEL_DOUBLE_TAP_DELAY_MS) {
+    return false;
+  }
+  const travel = Math.hypot(
+    event.clientX - previousTap.clientX,
+    event.clientY - previousTap.clientY
+  );
+  return travel <= STUDIO_LABEL_DOUBLE_TAP_SLOP_PX;
+}
+
+function trackPotentialLabelTap(nodeId: string, event: PointerEvent, now: number): void {
+  lastLabelTapByNodeId.set(nodeId, {
+    at: now,
+    clientX: event.clientX,
+    clientY: event.clientY,
+  });
+
+  const pointerId = event.pointerId;
+  const startClientX = event.clientX;
+  const startClientY = event.clientY;
+  const clearIfDragged = (moveEvent: PointerEvent): void => {
+    if (moveEvent.pointerId !== pointerId) {
+      return;
+    }
+    const travel = Math.hypot(
+      moveEvent.clientX - startClientX,
+      moveEvent.clientY - startClientY
+    );
+    if (travel <= STUDIO_LABEL_TAP_DRAG_SLOP_PX) {
+      return;
+    }
+    lastLabelTapByNodeId.delete(nodeId);
+    stopTracking();
+  };
+  const stopTracking = (finishEvent?: PointerEvent): void => {
+    if (finishEvent && finishEvent.pointerId !== pointerId) {
+      return;
+    }
+    window.removeEventListener("pointermove", clearIfDragged);
+    window.removeEventListener("pointerup", stopTracking);
+    window.removeEventListener("pointercancel", stopTracking);
+  };
+
+  window.addEventListener("pointermove", clearIfDragged);
+  window.addEventListener("pointerup", stopTracking);
+  window.addEventListener("pointercancel", stopTracking);
 }
 
 export function renderLabelNodeCard(options: RenderLabelNodeCardOptions): void {
@@ -212,14 +282,25 @@ export function renderLabelNodeCard(options: RenderLabelNodeCardOptions): void {
       }
       event.stopPropagation();
       if (pointerEvent.shiftKey || pointerEvent.metaKey || pointerEvent.ctrlKey) {
+        lastLabelTapByNodeId.delete(node.id);
         graphInteraction.toggleNodeSelection(node.id);
         return;
       }
+      const now = Date.now();
+      if (isRepeatLabelTap(node.id, pointerEvent, now)) {
+        event.preventDefault();
+        lastLabelTapByNodeId.delete(node.id);
+        graphInteraction.ensureSingleSelection(node.id);
+        onRequestLabelEdit(node.id);
+        return;
+      }
+      trackPotentialLabelTap(node.id, pointerEvent, now);
       graphInteraction.startNodeDrag(node.id, pointerEvent, nodeEl);
     });
     displayEl.addEventListener("dblclick", (event) => {
       event.preventDefault();
       event.stopPropagation();
+      lastLabelTapByNodeId.delete(node.id);
       graphInteraction.ensureSingleSelection(node.id);
       onRequestLabelEdit(node.id);
     });

--- a/src/views/studio/graph-v3/__tests__/studio-graph-node-card-renderer.test.ts
+++ b/src/views/studio/graph-v3/__tests__/studio-graph-node-card-renderer.test.ts
@@ -202,6 +202,13 @@ describe("renderStudioGraphNodeCard", () => {
       expect.any(MouseEvent),
       nodeEl
     );
+    window.dispatchEvent(
+      createPointerEvent("pointerup", {
+        pointerId: 17,
+        clientX: 120,
+        clientY: 140,
+      })
+    );
   });
 
   it("keeps label editing textareas out of card dragging", () => {
@@ -235,6 +242,56 @@ describe("renderStudioGraphNodeCard", () => {
 
     expect(graphInteraction.ensureSingleSelection).toHaveBeenCalledWith(node.id);
     expect(onRequestLabelEdit).toHaveBeenCalledWith(node.id);
+  });
+
+  it("opens label edit on a repeated tap even when selection re-renders the card", () => {
+    const nowSpy = jest.spyOn(Date, "now");
+    try {
+      nowSpy.mockReturnValueOnce(1000);
+      const firstRender = renderNodeCardHarness({
+        kind: "studio.label",
+        config: { value: "Tap twice" },
+      });
+      const firstDisplayEl = firstRender.nodeEl.querySelector<HTMLElement>(".ss-studio-label-display");
+      firstDisplayEl?.dispatchEvent(
+        createPointerEvent("pointerdown", {
+          pointerId: 31,
+          clientX: 120,
+          clientY: 140,
+        })
+      );
+      window.dispatchEvent(
+        createPointerEvent("pointerup", {
+          pointerId: 31,
+          clientX: 120,
+          clientY: 140,
+        })
+      );
+      expect(firstRender.onRequestLabelEdit).not.toHaveBeenCalled();
+
+      document.body.innerHTML = "";
+      nowSpy.mockReturnValueOnce(1200);
+      const secondRender = renderNodeCardHarness({
+        kind: "studio.label",
+        config: { value: "Tap twice" },
+      });
+      const secondDisplayEl = secondRender.nodeEl.querySelector<HTMLElement>(".ss-studio-label-display");
+      secondDisplayEl?.dispatchEvent(
+        createPointerEvent("pointerdown", {
+          pointerId: 32,
+          clientX: 123,
+          clientY: 142,
+        })
+      );
+
+      expect(secondRender.graphInteraction.ensureSingleSelection).toHaveBeenCalledWith(
+        secondRender.node.id
+      );
+      expect(secondRender.onRequestLabelEdit).toHaveBeenCalledWith(secondRender.node.id);
+      expect(secondRender.graphInteraction.startNodeDrag).not.toHaveBeenCalled();
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("keeps media-ingest image previews in contained mode", () => {


### PR DESCRIPTION
- Adds persistent repeated-tap detection for display-mode Studio labels so edit mode still opens if the first tap re-renders the card.\n- Keeps drag behavior movement-based and preserves native dblclick as a fallback.\n- Adds regression coverage for repeated tap across label card re-render.