### PR TITLE
Edit Studio text nodes in Obsidian's live-preview markdown editor

### DIFF
--- a/src/css/views/studio.css
+++ b/src/css/views/studio.css
@@ -1174,7 +1174,8 @@
 }
 
 .ss-studio-text-node-display,
-.ss-studio-text-node-editor {
+.ss-studio-text-node-editor,
+.ss-studio-text-node-live-editor {
   display: block;
   box-sizing: border-box;
   width: 100%;
@@ -1238,18 +1239,9 @@
   margin-bottom: 0;
 }
 
-/* Obsidian-note editing: the live-preview editor host mirrors the display
- * surface's box so entering and leaving edit mode never shifts layout. */
+/* Obsidian-note editing: the live-preview editor host shares the text-node
+ * box contract above; only the editable-cursor signal is its own. */
 .ss-studio-text-node-live-editor {
-  display: block;
-  box-sizing: border-box;
-  width: 100%;
-  max-width: 100%;
-  min-width: 0;
-  padding: var(--ss-space-1);
-  font-size: var(--ss-studio-text-node-font-size, inherit);
-  line-height: var(--ss-leading-base);
-  color: var(--ss-ink);
   cursor: text;
 }
 

--- a/src/css/views/studio.css
+++ b/src/css/views/studio.css
@@ -1223,6 +1223,72 @@
   box-shadow: none;
 }
 
+/* Rendered-markdown display: the resting card shows the value the way a
+ * note preview would — real headings, tables, checklists — so the source
+ * pre-wrap rule gives way to normal block flow. */
+.ss-studio-text-node-display.is-markdown {
+  white-space: normal;
+}
+
+.ss-studio-text-node-display.is-markdown > :first-child {
+  margin-top: 0;
+}
+
+.ss-studio-text-node-display.is-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+/* Obsidian-note editing: the live-preview editor host mirrors the display
+ * surface's box so entering and leaving edit mode never shifts layout. */
+.ss-studio-text-node-live-editor {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  padding: var(--ss-space-1);
+  font-size: var(--ss-studio-text-node-font-size, inherit);
+  line-height: var(--ss-leading-base);
+  color: var(--ss-ink);
+  cursor: text;
+}
+
+/* The embedded editor carries Obsidian's own markdown-source-view chrome;
+ * strip the note-page framing so only the text shows on the canvas. */
+.ss-studio-text-node-live-editor .markdown-source-view {
+  padding: 0;
+  background: transparent;
+}
+
+.ss-studio-text-node-live-editor .cm-editor {
+  background: transparent;
+  font-size: inherit;
+}
+
+.ss-studio-text-node-live-editor .cm-editor .cm-scroller {
+  overflow: visible;
+  min-height: 0;
+  padding: 0;
+  font-size: inherit;
+  line-height: var(--ss-leading-base);
+}
+
+/* Kill the readable-line-width sizer margins a full note view would get. */
+.ss-studio-text-node-live-editor .cm-editor .cm-sizer {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ss-studio-text-node-live-editor .cm-editor .cm-content {
+  padding: 0;
+  caret-color: var(--ss-ink);
+}
+
+.ss-studio-text-node-live-editor .cm-editor.cm-focused {
+  outline: none;
+}
+
 /* ------------------------------------------------------------------ *
  * Inspector overlay
  * ------------------------------------------------------------------ */

--- a/src/editor/__tests__/embeddable-markdown-editor.test.ts
+++ b/src/editor/__tests__/embeddable-markdown-editor.test.ts
@@ -267,6 +267,44 @@ describe("createEmbeddableMarkdownEditor", () => {
     expect(container.childElementCount).toBe(0);
   });
 
+  it("restores the original setActiveLeaf after out-of-order destruction of two editors", () => {
+    const { app } = createFakeApp();
+    const originalSetActiveLeaf = app.workspace.setActiveLeaf;
+
+    const first = createEmbeddableMarkdownEditor(app, document.body.createDiv(), {
+      value: "a",
+    });
+    const second = createEmbeddableMarkdownEditor(app, document.body.createDiv(), {
+      value: "b",
+    });
+
+    // Teardown in creation order — the regression case: a per-instance wrap
+    // chain would leave a destroyed editor's wrapper installed forever.
+    first!.destroy();
+    second!.destroy();
+
+    expect(app.workspace.setActiveLeaf).toBe(originalSetActiveLeaf);
+  });
+
+  it("keeps setActiveLeaf suppressed only while an editor has focus", () => {
+    const { app } = createFakeApp();
+    const originalSetActiveLeaf = app.workspace.setActiveLeaf;
+    const handle = createEmbeddableMarkdownEditor(app, document.body.createDiv(), {
+      value: "a",
+    });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+
+    rawEditor.editor.cm.hasFocus = true;
+    app.workspace.setActiveLeaf("leaf-while-focused");
+    expect(originalSetActiveLeaf).not.toHaveBeenCalled();
+
+    rawEditor.editor.cm.hasFocus = false;
+    app.workspace.setActiveLeaf("leaf-while-blurred");
+    expect(originalSetActiveLeaf).toHaveBeenCalledWith("leaf-while-blurred");
+
+    handle!.destroy();
+  });
+
   it("focus() forwards to the CodeMirror view", () => {
     const { app } = createFakeApp();
     const container = document.body.createDiv();

--- a/src/editor/__tests__/embeddable-markdown-editor.test.ts
+++ b/src/editor/__tests__/embeddable-markdown-editor.test.ts
@@ -1,7 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import { createEmbeddableMarkdownEditor } from "../embeddable-markdown-editor";
+import {
+  createEmbeddableMarkdownEditor,
+  isEmbeddableMarkdownEditorSupported,
+} from "../embeddable-markdown-editor";
 
 /**
  * Fake of Obsidian's INTERNAL markdown editor class chain. The real chain is
@@ -314,6 +317,51 @@ describe("createEmbeddableMarkdownEditor", () => {
 
     handle!.focus();
     expect(rawEditor.editor.cm.focus).toHaveBeenCalled();
+  });
+
+  it("set() replaces the document and value reflects it", () => {
+    const { app } = createFakeApp();
+    const handle = createEmbeddableMarkdownEditor(app, document.body.createDiv(), {
+      value: "before",
+    });
+
+    handle!.set("after");
+    expect(handle!.value).toBe("after");
+  });
+
+  it("reports support based on whether the internal editor resolves", () => {
+    const { app } = createFakeApp();
+    expect(isEmbeddableMarkdownEditorSupported(app)).toBe(true);
+    expect(isEmbeddableMarkdownEditorSupported({} as never)).toBe(false);
+  });
+
+  it("routes the Escape key handler to onEscape", () => {
+    const { app } = createFakeApp();
+    const onEscape = jest.fn();
+    const handle = createEmbeddableMarkdownEditor(app, document.body.createDiv(), {
+      value: "x",
+      onEscape,
+    });
+    const rawEditor = handle!.editor as { handleEmbeddableEscape?: () => boolean };
+
+    expect(rawEditor.handleEmbeddableEscape?.()).toBe(true);
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes paste events to onPaste", () => {
+    const { app } = createFakeApp();
+    const onPaste = jest.fn();
+    const handle = createEmbeddableMarkdownEditor(app, document.body.createDiv(), {
+      value: "x",
+      onPaste,
+    });
+    const rawEditor = handle!.editor as {
+      handleEmbeddablePaste?: (event: ClipboardEvent) => void;
+    };
+
+    const pasteEvent = new Event("paste") as ClipboardEvent;
+    rawEditor.handleEmbeddablePaste?.(pasteEvent);
+    expect(onPaste).toHaveBeenCalledWith(pasteEvent);
   });
 
   it("selectAll() dispatches a whole-document selection", () => {

--- a/src/editor/__tests__/embeddable-markdown-editor.test.ts
+++ b/src/editor/__tests__/embeddable-markdown-editor.test.ts
@@ -216,7 +216,7 @@ describe("createEmbeddableMarkdownEditor", () => {
     const handle = createEmbeddableMarkdownEditor(app, container, { value: "x" });
     const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
 
-    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("focusin"));
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
     expect(app.keymap.pushScope).toHaveBeenCalled();
     expect(app.workspace.activeEditor).toBe(rawEditor.owner);
 
@@ -236,7 +236,7 @@ describe("createEmbeddableMarkdownEditor", () => {
     });
     const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
 
-    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("blur"));
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
     expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
@@ -253,10 +253,36 @@ describe("createEmbeddableMarkdownEditor", () => {
     const inEditorCheckbox = rawEditor.editorEl.createEl("input");
 
     rawEditor.editor.cm.contentDOM.dispatchEvent(
-      new FocusEvent("blur", { relatedTarget: inEditorCheckbox })
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: inEditorCheckbox })
     );
 
     expect(onBlur).not.toHaveBeenCalled();
+  });
+
+  it("ends the session when an in-editor control loses focus to the outside", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+    const outsideEl = document.body.createDiv();
+    const onBlur = jest.fn();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, {
+      value: "- [ ] task",
+      onBlur,
+    });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+    const inEditorCheckbox = rawEditor.editorEl.createEl("input");
+
+    // Focus hops content -> in-editor checkbox (session stays alive) ...
+    rawEditor.editor.cm.contentDOM.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: inEditorCheckbox })
+    );
+    expect(onBlur).not.toHaveBeenCalled();
+
+    // ... then checkbox -> somewhere outside the card: NOW the session ends.
+    inEditorCheckbox.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: outsideEl })
+    );
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
   it("does not pop a keymap scope that was never pushed", () => {
@@ -279,10 +305,10 @@ describe("createEmbeddableMarkdownEditor", () => {
     });
     const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
 
-    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("focusin"));
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
     // Blur then destroy — the DOM-removal blur in Chrome makes this the
     // double-pop path.
-    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("blur"));
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
     handle!.destroy();
 
     expect(app.keymap.popScope).toHaveBeenCalledTimes(1);
@@ -300,7 +326,7 @@ describe("createEmbeddableMarkdownEditor", () => {
     const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
 
     handle!.destroy();
-    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("blur"));
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
     expect(onBlur).not.toHaveBeenCalled();
   });
 

--- a/src/editor/__tests__/embeddable-markdown-editor.test.ts
+++ b/src/editor/__tests__/embeddable-markdown-editor.test.ts
@@ -240,6 +240,54 @@ describe("createEmbeddableMarkdownEditor", () => {
     expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the edit session alive when focus moves to a control inside the editor", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+    const onBlur = jest.fn();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, {
+      value: "- [ ] task",
+      onBlur,
+    });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+    const inEditorCheckbox = rawEditor.editorEl.createEl("input");
+
+    rawEditor.editor.cm.contentDOM.dispatchEvent(
+      new FocusEvent("blur", { relatedTarget: inEditorCheckbox })
+    );
+
+    expect(onBlur).not.toHaveBeenCalled();
+  });
+
+  it("does not pop a keymap scope that was never pushed", () => {
+    const { app } = createFakeApp();
+    const handle = createEmbeddableMarkdownEditor(app, document.body.createDiv(), {
+      value: "x",
+    });
+
+    // Destroy without the editor ever gaining focus.
+    handle!.destroy();
+
+    expect(app.keymap.pushScope).not.toHaveBeenCalled();
+    expect(app.keymap.popScope).not.toHaveBeenCalled();
+  });
+
+  it("pops the keymap scope at most once for a focused editor", () => {
+    const { app } = createFakeApp();
+    const handle = createEmbeddableMarkdownEditor(app, document.body.createDiv(), {
+      value: "x",
+    });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("focusin"));
+    // Blur then destroy — the DOM-removal blur in Chrome makes this the
+    // double-pop path.
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("blur"));
+    handle!.destroy();
+
+    expect(app.keymap.popScope).toHaveBeenCalledTimes(1);
+  });
+
   it("suppresses onBlur after the editor is unloaded (Chrome DOM-removal blur)", () => {
     const { app } = createFakeApp();
     const container = document.body.createDiv();

--- a/src/editor/__tests__/embeddable-markdown-editor.test.ts
+++ b/src/editor/__tests__/embeddable-markdown-editor.test.ts
@@ -1,0 +1,295 @@
+/**
+ * @jest-environment jsdom
+ */
+import { createEmbeddableMarkdownEditor } from "../embeddable-markdown-editor";
+
+/**
+ * Fake of Obsidian's INTERNAL markdown editor class chain. The real chain is
+ * resolved at runtime from `app.embedRegistry.embedByExtension.md` by walking
+ * two prototype levels up from the widget's `editMode` instance — exactly the
+ * shape mocked here:
+ *
+ *   editMode instance → FakeEmbedEditMode → FakeScrollableMarkdownEditor
+ *                                            ↑ resolved base class
+ */
+class FakeScrollableMarkdownEditor {
+  app: unknown;
+  containerEl: HTMLElement;
+  owner: Record<string, unknown>;
+  editorEl: HTMLElement;
+  editor: {
+    cm: {
+      state: { doc: { toString: () => string } };
+      dispatch: jest.Mock;
+      contentDOM: HTMLElement;
+      focus: jest.Mock;
+      hasFocus: boolean;
+    };
+  };
+  _loaded = true;
+  unloadCount = 0;
+  private registeredDisposers: Array<() => void> = [];
+  private currentValue = "";
+
+  constructor(app: unknown, container: HTMLElement, owner: Record<string, unknown>) {
+    this.app = app;
+    this.containerEl = container;
+    this.owner = owner;
+    this.editorEl = container.createDiv({ cls: "markdown-source-view" });
+    const contentDOM = this.editorEl.createDiv({ cls: "cm-content" });
+    this.editor = {
+      cm: {
+        state: { doc: { toString: () => this.currentValue } },
+        dispatch: jest.fn(),
+        contentDOM,
+        focus: jest.fn(),
+        hasFocus: false,
+      },
+    };
+  }
+
+  set(value: string): void {
+    this.currentValue = value;
+  }
+
+  register(disposer: () => void): void {
+    this.registeredDisposers.push(disposer);
+  }
+
+  unload(): void {
+    if (!this._loaded) {
+      return;
+    }
+    this._loaded = false;
+    this.unloadCount += 1;
+    for (const disposer of this.registeredDisposers.splice(0)) {
+      disposer();
+    }
+    (this as { onunload?: () => void }).onunload?.();
+  }
+
+  onUpdate(_update: unknown, _changed: boolean): void {}
+
+  buildLocalExtensions(): unknown[] {
+    return [];
+  }
+
+  destroy(): void {}
+}
+
+class FakeEmbedEditMode extends FakeScrollableMarkdownEditor {}
+
+function createFakeApp(): {
+  app: any;
+  widgetUnload: jest.Mock;
+} {
+  const widgetUnload = jest.fn();
+  const app: any = {
+    scope: {},
+    keymap: {
+      pushScope: jest.fn(),
+      popScope: jest.fn(),
+    },
+    workspace: {
+      activeEditor: null,
+      setActiveLeaf: jest.fn(),
+    },
+  };
+  app.embedRegistry = {
+    embedByExtension: {
+      md: (_context: unknown, _file: unknown, _subpath: string) => {
+        const widget = {
+          editable: false,
+          editMode: undefined as FakeEmbedEditMode | undefined,
+          showEditor() {
+            this.editMode = new FakeEmbedEditMode(
+              app,
+              document.body.createDiv(),
+              {}
+            );
+          },
+          unload: widgetUnload,
+        };
+        return widget;
+      },
+    },
+  };
+  return { app, widgetUnload };
+}
+
+describe("createEmbeddableMarkdownEditor", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.restoreAllMocks();
+  });
+
+  it("returns null when the app exposes no embed registry", () => {
+    const container = document.body.createDiv();
+    const handle = createEmbeddableMarkdownEditor({} as never, container, {});
+    expect(handle).toBeNull();
+  });
+
+  it("returns null when internal editor resolution throws", () => {
+    const container = document.body.createDiv();
+    const app: any = {
+      embedRegistry: {
+        embedByExtension: {
+          md: () => {
+            throw new Error("internal shape changed");
+          },
+        },
+      },
+    };
+    expect(createEmbeddableMarkdownEditor(app, container, {})).toBeNull();
+  });
+
+  it("constructs an editor seeded with the initial value and unloads the probe widget", () => {
+    const { app, widgetUnload } = createFakeApp();
+    const container = document.body.createDiv();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, {
+      value: "# Hello\n\nSome **bold** text",
+    });
+
+    expect(handle).not.toBeNull();
+    expect(handle?.value).toBe("# Hello\n\nSome **bold** text");
+    expect(widgetUnload).toHaveBeenCalled();
+  });
+
+  it("applies the optional cls to the editor element", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, {
+      value: "",
+      cls: "ss-test-editor",
+    });
+
+    expect(handle?.editorEl?.classList.contains("ss-test-editor")).toBe(true);
+  });
+
+  it("reports document changes through onChange", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+    const onChange = jest.fn();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, {
+      value: "before",
+      onChange,
+    });
+    expect(handle).not.toBeNull();
+
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+    rawEditor.onUpdate(
+      { state: { doc: { toString: () => "after" } } },
+      true
+    );
+
+    expect(onChange).toHaveBeenCalledWith("after");
+  });
+
+  it("does not report unchanged updates", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+    const onChange = jest.fn();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, {
+      value: "before",
+      onChange,
+    });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+    rawEditor.onUpdate(
+      { state: { doc: { toString: () => "before" } } },
+      false
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("claims the workspace active editor while focused and releases it on destroy", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, { value: "x" });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("focusin"));
+    expect(app.keymap.pushScope).toHaveBeenCalled();
+    expect(app.workspace.activeEditor).toBe(rawEditor.owner);
+
+    handle!.destroy();
+    expect(app.keymap.popScope).toHaveBeenCalled();
+    expect(app.workspace.activeEditor).toBeNull();
+  });
+
+  it("invokes onBlur when the editor content loses focus", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+    const onBlur = jest.fn();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, {
+      value: "x",
+      onBlur,
+    });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("blur"));
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses onBlur after the editor is unloaded (Chrome DOM-removal blur)", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+    const onBlur = jest.fn();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, {
+      value: "x",
+      onBlur,
+    });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+
+    handle!.destroy();
+    rawEditor.editor.cm.contentDOM.dispatchEvent(new FocusEvent("blur"));
+    expect(onBlur).not.toHaveBeenCalled();
+  });
+
+  it("destroys idempotently with a single unload", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, { value: "x" });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+
+    handle!.destroy();
+    handle!.destroy();
+
+    expect(rawEditor.unloadCount).toBe(1);
+    expect(container.childElementCount).toBe(0);
+  });
+
+  it("focus() forwards to the CodeMirror view", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, { value: "abc" });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+
+    handle!.focus();
+    expect(rawEditor.editor.cm.focus).toHaveBeenCalled();
+  });
+
+  it("selectAll() dispatches a whole-document selection", () => {
+    const { app } = createFakeApp();
+    const container = document.body.createDiv();
+
+    const handle = createEmbeddableMarkdownEditor(app, container, { value: "abc" });
+    const rawEditor = handle!.editor as FakeScrollableMarkdownEditor;
+
+    handle!.selectAll();
+    expect(rawEditor.editor.cm.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selection: expect.objectContaining({ anchor: 0, head: 3 }),
+      })
+    );
+  });
+});

--- a/src/editor/embeddable-markdown-editor.ts
+++ b/src/editor/embeddable-markdown-editor.ts
@@ -1,0 +1,460 @@
+import type { App } from "obsidian";
+import * as obsidian from "obsidian";
+import { Prec, type Extension } from "@codemirror/state";
+import {
+  EditorView,
+  keymap,
+  placeholder as cmPlaceholder,
+  type ViewUpdate,
+} from "@codemirror/view";
+
+/**
+ * Embeddable Obsidian markdown editor — the SAME live-preview CodeMirror
+ * editor Obsidian mounts inside embedded notes and Canvas text cards, so an
+ * embedded surface edits exactly like a note: inline syntax rendering,
+ * checkboxes, tables, code fences, the user's editor plugins and vault
+ * Live Preview setting all apply.
+ *
+ * Obsidian does not export this editor class, so it is resolved at runtime
+ * with the community-established technique (obsidian-kanban, Fevol's
+ * embeddable-editor): instantiate a throwaway markdown embed through
+ * `app.embedRegistry.embedByExtension.md`, flip it editable to force the
+ * editor into existence, and walk two prototype levels up from its
+ * `editMode` to reach the reusable MarkdownEditor base class.
+ *
+ * Every touchpoint with the internal shape is defensive: if any step no
+ * longer matches (future Obsidian versions, test environments without the
+ * registry), `createEmbeddableMarkdownEditor` returns `null` and callers
+ * fall back to their plain-text editing surface.
+ */
+
+export type EmbeddableMarkdownEditorOptions = {
+  value?: string;
+  placeholder?: string;
+  /** Extra class applied to the editor element (the markdown-source-view). */
+  cls?: string;
+  onChange?: (value: string) => void;
+  onEscape?: () => void;
+  onBlur?: () => void;
+  onPaste?: (event: ClipboardEvent) => void;
+};
+
+export type EmbeddableMarkdownEditorHandle = {
+  /** Current markdown source held by the editor document. */
+  readonly value: string;
+  /** Replace the whole document. */
+  set(value: string): void;
+  focus(): void;
+  selectAll(): void;
+  destroy(): void;
+  /** The internal editor element (markdown-source-view), when exposed. */
+  readonly editorEl: HTMLElement | null;
+  /** Raw internal editor instance — advanced use and tests only. */
+  readonly editor: unknown;
+};
+
+type InternalEditorOwner = {
+  app: App;
+  onMarkdownScroll: () => void;
+  getMode: () => string;
+  editMode?: unknown;
+  editor?: unknown;
+};
+
+type InternalMarkdownEditorConstructor = new (
+  app: App,
+  container: HTMLElement,
+  owner: InternalEditorOwner
+) => InternalMarkdownEditorInstance;
+
+type InternalMarkdownEditorInstance = {
+  editor?: {
+    cm?: {
+      state?: { doc?: { toString(): string; length?: number } };
+      dispatch?: (spec: unknown) => void;
+      contentDOM?: HTMLElement;
+      focus?: () => void;
+      hasFocus?: boolean;
+    };
+  };
+  editorEl?: HTMLElement;
+  containerEl?: HTMLElement;
+  owner?: InternalEditorOwner;
+  set?: (value: string, clear?: boolean) => void;
+  register?: (disposer: () => void) => void;
+  unload?: () => void;
+  destroy?: () => void;
+  _loaded?: boolean;
+};
+
+/**
+ * Resolution result cache, per App instance. `null` records a failed
+ * resolution so a broken internal shape is probed exactly once per session.
+ */
+const resolvedEditorClassByApp = new WeakMap<
+  object,
+  InternalMarkdownEditorConstructor | null
+>();
+
+function resolveInternalMarkdownEditorClass(
+  app: App
+): InternalMarkdownEditorConstructor | null {
+  const cached = resolvedEditorClassByApp.get(app as unknown as object);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let resolved: InternalMarkdownEditorConstructor | null = null;
+  try {
+    const embedCreator = (app as unknown as {
+      embedRegistry?: {
+        embedByExtension?: Record<
+          string,
+          (context: unknown, file: unknown, subpath: string) => unknown
+        >;
+      };
+    }).embedRegistry?.embedByExtension?.md;
+    if (typeof embedCreator === "function") {
+      const widget = embedCreator(
+        { app, containerEl: document.createElement("div") },
+        null,
+        ""
+      ) as {
+        editable?: boolean;
+        editMode?: unknown;
+        showEditor?: () => void;
+        unload?: () => void;
+      };
+      widget.editable = true;
+      widget.showEditor?.();
+      const editMode = widget.editMode;
+      if (editMode) {
+        const basePrototype = Object.getPrototypeOf(
+          Object.getPrototypeOf(editMode)
+        ) as { constructor?: unknown };
+        if (typeof basePrototype?.constructor === "function") {
+          resolved = basePrototype.constructor as InternalMarkdownEditorConstructor;
+        }
+      }
+      widget.unload?.();
+    }
+  } catch (error) {
+    console.warn(
+      "[SystemSculpt] Embedded markdown editor resolution failed; falling back to plain editing",
+      error instanceof Error ? error.message : String(error)
+    );
+    resolved = null;
+  }
+
+  resolvedEditorClassByApp.set(app as unknown as object, resolved);
+  return resolved;
+}
+
+/**
+ * Options for the editor currently being constructed. `buildLocalExtensions`
+ * runs from inside the base-class constructor — before the subclass body has
+ * assigned instance fields — so construction stashes the options here for
+ * the synchronous window of the `new` call.
+ */
+let constructingOptions: EmbeddableMarkdownEditorOptions | null = null;
+
+const embeddableClassByBase = new WeakMap<
+  InternalMarkdownEditorConstructor,
+  InternalMarkdownEditorConstructor
+>();
+
+function getEmbeddableEditorClass(
+  Base: InternalMarkdownEditorConstructor
+): InternalMarkdownEditorConstructor {
+  const cached = embeddableClassByBase.get(Base);
+  if (cached) {
+    return cached;
+  }
+
+  class EmbeddableMarkdownEditor extends (Base as new (
+    ...args: never[]
+  ) => object) {
+    embeddableOptions: EmbeddableMarkdownEditorOptions;
+    private embeddableScope: unknown = null;
+    private embeddableDestroyed = false;
+
+    constructor(
+      app: App,
+      container: HTMLElement,
+      options: EmbeddableMarkdownEditorOptions
+    ) {
+      super(
+        ...([
+          app,
+          container,
+          {
+            app,
+            // Mocks the owning MarkdownView surface the editor expects:
+            // scroll bookkeeping and the mode used to pick live preview.
+            onMarkdownScroll: () => {},
+            getMode: () => "source",
+          },
+        ] as never[])
+      );
+      this.embeddableOptions = options;
+      const self = this as unknown as InternalMarkdownEditorInstance & {
+        app: App;
+      };
+      self.app = app;
+
+      // Commands and link handling resolve the editor through the owner
+      // view, so the mock owner must point back at this editor instance.
+      const owner = self.owner;
+      if (owner) {
+        owner.editMode = this;
+        owner.editor = self.editor;
+      }
+
+      // Hotkeys take precedence over the CM keymap; a dedicated scope keeps
+      // Mod+Enter (globally "open link under cursor in new leaf") from
+      // hijacking editing inside the embedded surface.
+      const ScopeCtor = (obsidian as { Scope?: new (parent: unknown) => unknown })
+        .Scope;
+      if (ScopeCtor && (app as { scope?: unknown }).scope !== undefined) {
+        const scope = new ScopeCtor((app as { scope?: unknown }).scope) as {
+          register?: (
+            modifiers: string[],
+            key: string,
+            handler: () => boolean
+          ) => void;
+        };
+        scope.register?.(["Mod"], "Enter", () => true);
+        this.embeddableScope = scope;
+      }
+
+      self.set?.(options.value ?? "", true);
+
+      // Keep the workspace from yanking focus back to a leaf while the
+      // embedded editor owns it. Registered so unload restores the original.
+      const workspace = (app as {
+        workspace?: {
+          setActiveLeaf?: (...args: unknown[]) => void;
+          activeEditor?: unknown;
+        };
+      }).workspace;
+      if (workspace && typeof workspace.setActiveLeaf === "function") {
+        const original = workspace.setActiveLeaf.bind(workspace);
+        const patched = (...args: unknown[]): void => {
+          if (!this.embeddableHasFocus()) {
+            original(...args);
+          }
+        };
+        workspace.setActiveLeaf = patched;
+        self.register?.(() => {
+          if (workspace.setActiveLeaf === patched) {
+            workspace.setActiveLeaf = original;
+          }
+        });
+      }
+
+      const contentDOM = self.editor?.cm?.contentDOM;
+      if (contentDOM) {
+        contentDOM.addEventListener("focusin", () => {
+          this.pushKeymapScope();
+          if (workspace) {
+            workspace.activeEditor = self.owner;
+          }
+        });
+        contentDOM.addEventListener("blur", () => {
+          this.popKeymapScope();
+          // Chrome fires blur when an element is removed from the DOM;
+          // only a still-loaded editor reports a real blur.
+          if (self._loaded !== false) {
+            this.embeddableOptions.onBlur?.();
+          }
+        });
+      }
+
+      if (options.cls) {
+        self.editorEl?.classList.add(options.cls);
+      }
+    }
+
+    private embeddableHasFocus(): boolean {
+      const self = this as unknown as InternalMarkdownEditorInstance;
+      return self.editor?.cm?.hasFocus === true;
+    }
+
+    private pushKeymapScope(): void {
+      if (!this.embeddableScope) {
+        return;
+      }
+      const app = (this as unknown as { app?: App }).app;
+      (app as unknown as {
+        keymap?: { pushScope?: (scope: unknown) => void };
+      })?.keymap?.pushScope?.(this.embeddableScope);
+    }
+
+    private popKeymapScope(): void {
+      if (!this.embeddableScope) {
+        return;
+      }
+      const app = (this as unknown as { app?: App }).app;
+      (app as unknown as {
+        keymap?: { popScope?: (scope: unknown) => void };
+      })?.keymap?.popScope?.(this.embeddableScope);
+    }
+
+    getEmbeddableOptions(): EmbeddableMarkdownEditorOptions {
+      return this.embeddableOptions ?? constructingOptions ?? {};
+    }
+
+    onUpdate(update: ViewUpdate, changed: boolean): void {
+      const superOnUpdate = (Base.prototype as {
+        onUpdate?: (update: ViewUpdate, changed: boolean) => void;
+      }).onUpdate;
+      superOnUpdate?.call(this, update, changed);
+      if (changed) {
+        const value =
+          update?.state?.doc?.toString() ??
+          (this as unknown as InternalMarkdownEditorInstance).editor?.cm?.state?.doc?.toString() ??
+          "";
+        this.getEmbeddableOptions().onChange?.(value);
+      }
+    }
+
+    buildLocalExtensions(): Extension[] {
+      const superBuild = (Base.prototype as {
+        buildLocalExtensions?: () => Extension[];
+      }).buildLocalExtensions;
+      const extensions: Extension[] = superBuild ? superBuild.call(this) : [];
+      const options = this.getEmbeddableOptions();
+
+      if (options.placeholder) {
+        extensions.push(cmPlaceholder(options.placeholder));
+      }
+      extensions.push(
+        EditorView.domEventHandlers({
+          paste: (event) => {
+            this.getEmbeddableOptions().onPaste?.(event);
+          },
+        })
+      );
+      extensions.push(
+        Prec.highest(
+          keymap.of([
+            {
+              key: "Escape",
+              run: () => {
+                this.getEmbeddableOptions().onEscape?.();
+                return true;
+              },
+              preventDefault: true,
+            },
+          ])
+        )
+      );
+      return extensions;
+    }
+
+    destroyEmbeddable(): void {
+      if (this.embeddableDestroyed) {
+        return;
+      }
+      this.embeddableDestroyed = true;
+      const self = this as unknown as InternalMarkdownEditorInstance & {
+        app?: App;
+      };
+      if (self._loaded !== false) {
+        self.unload?.();
+      }
+      this.popKeymapScope();
+      const workspace = (self.app as unknown as {
+        workspace?: { activeEditor?: unknown };
+      })?.workspace;
+      if (workspace && workspace.activeEditor === self.owner) {
+        workspace.activeEditor = null;
+      }
+      self.containerEl?.empty?.();
+      const superDestroy = (Base.prototype as { destroy?: () => void }).destroy;
+      superDestroy?.call(this);
+    }
+
+    onunload(): void {
+      const superOnunload = (Base.prototype as { onunload?: () => void })
+        .onunload;
+      superOnunload?.call(this);
+      this.destroyEmbeddable();
+    }
+  }
+
+  const built = EmbeddableMarkdownEditor as unknown as InternalMarkdownEditorConstructor;
+  embeddableClassByBase.set(Base, built);
+  return built;
+}
+
+export function isEmbeddableMarkdownEditorSupported(app: App): boolean {
+  return resolveInternalMarkdownEditorClass(app) !== null;
+}
+
+export function createEmbeddableMarkdownEditor(
+  app: App,
+  containerEl: HTMLElement,
+  options: EmbeddableMarkdownEditorOptions
+): EmbeddableMarkdownEditorHandle | null {
+  const Base = resolveInternalMarkdownEditorClass(app);
+  if (!Base) {
+    return null;
+  }
+
+  const EmbeddableClass = getEmbeddableEditorClass(Base);
+  let instance: InternalMarkdownEditorInstance & {
+    destroyEmbeddable?: () => void;
+  };
+  constructingOptions = options;
+  try {
+    instance = new (EmbeddableClass as unknown as new (
+      app: App,
+      container: HTMLElement,
+      options: EmbeddableMarkdownEditorOptions
+    ) => InternalMarkdownEditorInstance & { destroyEmbeddable?: () => void })(
+      app,
+      containerEl,
+      options
+    );
+  } catch (error) {
+    console.warn(
+      "[SystemSculpt] Embedded markdown editor construction failed; falling back to plain editing",
+      error instanceof Error ? error.message : String(error)
+    );
+    return null;
+  } finally {
+    constructingOptions = null;
+  }
+
+  const readValue = (): string =>
+    instance.editor?.cm?.state?.doc?.toString() ?? "";
+
+  return {
+    get value(): string {
+      return readValue();
+    },
+    set(value: string): void {
+      instance.set?.(value, true);
+    },
+    focus(): void {
+      instance.editor?.cm?.focus?.();
+    },
+    selectAll(): void {
+      const length =
+        instance.editor?.cm?.state?.doc?.length ?? readValue().length;
+      instance.editor?.cm?.dispatch?.({
+        selection: { anchor: 0, head: length },
+      });
+    },
+    destroy(): void {
+      instance.destroyEmbeddable?.();
+    },
+    get editorEl(): HTMLElement | null {
+      return instance.editorEl ?? null;
+    },
+    get editor(): unknown {
+      return instance;
+    },
+  };
+}

--- a/src/editor/embeddable-markdown-editor.ts
+++ b/src/editor/embeddable-markdown-editor.ts
@@ -313,29 +313,28 @@ function getEmbeddableEditorClass(
         });
       }
 
-      const contentDOM = self.editor?.cm?.contentDOM;
-      if (contentDOM) {
-        contentDOM.addEventListener("focusin", () => {
+      // Focus tracking lives on the editing surface as a WHOLE, not just the
+      // CodeMirror content: live preview renders focusable controls (task
+      // checkboxes, embeds) inside the editor, and hopping between them and
+      // the text must not end the session — only focus leaving the surface
+      // entirely does. focusin/focusout bubble, blur does not.
+      const focusRootEl =
+        self.containerEl ?? self.editorEl ?? self.editor?.cm?.contentDOM;
+      if (focusRootEl) {
+        focusRootEl.addEventListener("focusin", () => {
           this.pushKeymapScope();
           if (workspace) {
             workspace.activeEditor = self.owner;
           }
         });
-        contentDOM.addEventListener("blur", (event) => {
-          // Live preview renders focusable controls (task checkboxes,
-          // embeds) inside the editor; focus moving onto one is not the
-          // user leaving the editor.
+        focusRootEl.addEventListener("focusout", (event) => {
           const related = (event as FocusEvent).relatedTarget;
-          if (
-            related instanceof Node &&
-            (self.editorEl?.contains(related) === true ||
-              self.containerEl?.contains(related) === true)
-          ) {
+          if (related instanceof Node && focusRootEl.contains(related)) {
             return;
           }
           this.popKeymapScope();
-          // Chrome fires blur when an element is removed from the DOM;
-          // only a still-loaded editor reports a real blur.
+          // Chrome fires focusout when a focused element is removed from
+          // the DOM; only a still-loaded editor reports a real blur.
           if (self._loaded !== false) {
             this.embeddableOptions.onBlur?.();
           }

--- a/src/editor/embeddable-markdown-editor.ts
+++ b/src/editor/embeddable-markdown-editor.ts
@@ -247,6 +247,7 @@ function getEmbeddableEditorClass(
   ) => object) {
     embeddableOptions: EmbeddableMarkdownEditorOptions;
     private embeddableScope: unknown = null;
+    private embeddableScopePushed = false;
     private embeddableDestroyed = false;
 
     constructor(
@@ -320,7 +321,18 @@ function getEmbeddableEditorClass(
             workspace.activeEditor = self.owner;
           }
         });
-        contentDOM.addEventListener("blur", () => {
+        contentDOM.addEventListener("blur", (event) => {
+          // Live preview renders focusable controls (task checkboxes,
+          // embeds) inside the editor; focus moving onto one is not the
+          // user leaving the editor.
+          const related = (event as FocusEvent).relatedTarget;
+          if (
+            related instanceof Node &&
+            (self.editorEl?.contains(related) === true ||
+              self.containerEl?.contains(related) === true)
+          ) {
+            return;
+          }
           this.popKeymapScope();
           // Chrome fires blur when an element is removed from the DOM;
           // only a still-loaded editor reports a real blur.
@@ -336,19 +348,26 @@ function getEmbeddableEditorClass(
     }
 
     private pushKeymapScope(): void {
-      if (!this.embeddableScope) {
+      if (!this.embeddableScope || this.embeddableScopePushed) {
         return;
       }
+      this.embeddableScopePushed = true;
       const app = (this as unknown as { app?: App }).app;
       (app as unknown as {
         keymap?: { pushScope?: (scope: unknown) => void };
       })?.keymap?.pushScope?.(this.embeddableScope);
     }
 
+    /**
+     * Pops only what was pushed: destroy-without-focus would otherwise pop a
+     * scope that is not on the stack, and Chrome's DOM-removal blur during
+     * destroy would pop a second time — both scramble the hotkey stack.
+     */
     private popKeymapScope(): void {
-      if (!this.embeddableScope) {
+      if (!this.embeddableScope || !this.embeddableScopePushed) {
         return;
       }
+      this.embeddableScopePushed = false;
       const app = (this as unknown as { app?: App }).app;
       (app as unknown as {
         keymap?: { popScope?: (scope: unknown) => void };

--- a/src/editor/embeddable-markdown-editor.ts
+++ b/src/editor/embeddable-markdown-editor.ts
@@ -158,6 +158,77 @@ function resolveInternalMarkdownEditorClass(
  */
 let constructingOptions: EmbeddableMarkdownEditorOptions | null = null;
 
+type WorkspaceWithSetActiveLeaf = {
+  setActiveLeaf?: (...args: unknown[]) => void;
+  activeEditor?: unknown;
+};
+
+type SetActiveLeafPatchState = {
+  original: (...args: unknown[]) => void;
+  wrapper: (...args: unknown[]) => void;
+  editors: Set<InternalMarkdownEditorInstance>;
+};
+
+/**
+ * One shared `setActiveLeaf` patch per workspace, reference-counted across
+ * every live embedded editor. A per-editor wrap chain would break on
+ * out-of-order teardown (the middle wrapper can never be unlinked); here the
+ * single wrapper suppresses leaf activation while ANY live embedded editor
+ * has focus, and the original method is restored when the last editor
+ * releases.
+ */
+const setActiveLeafPatchByWorkspace = new WeakMap<object, SetActiveLeafPatchState>();
+
+function acquireSetActiveLeafPatch(
+  workspace: WorkspaceWithSetActiveLeaf,
+  editor: InternalMarkdownEditorInstance
+): void {
+  if (typeof workspace.setActiveLeaf !== "function") {
+    return;
+  }
+  let state = setActiveLeafPatchByWorkspace.get(workspace as object);
+  if (!state) {
+    const original = workspace.setActiveLeaf;
+    const editors = new Set<InternalMarkdownEditorInstance>();
+    const wrapper = (...args: unknown[]): void => {
+      for (const activeEditor of editors) {
+        if (activeEditor.editor?.cm?.hasFocus === true) {
+          return;
+        }
+      }
+      original.apply(workspace, args);
+    };
+    state = { original, wrapper, editors };
+    setActiveLeafPatchByWorkspace.set(workspace as object, state);
+    workspace.setActiveLeaf = wrapper;
+  }
+  state.editors.add(editor);
+}
+
+function releaseSetActiveLeafPatch(
+  workspace: WorkspaceWithSetActiveLeaf | undefined,
+  editor: InternalMarkdownEditorInstance
+): void {
+  if (!workspace) {
+    return;
+  }
+  const state = setActiveLeafPatchByWorkspace.get(workspace as object);
+  if (!state) {
+    return;
+  }
+  state.editors.delete(editor);
+  if (state.editors.size > 0) {
+    return;
+  }
+  setActiveLeafPatchByWorkspace.delete(workspace as object);
+  // Only restore when the wrapper is still installed; if something else
+  // wrapped after us, the now-empty editor set makes our wrapper a pure
+  // pass-through, so leaving it in a foreign chain stays harmless.
+  if (workspace.setActiveLeaf === state.wrapper) {
+    workspace.setActiveLeaf = state.original;
+  }
+}
+
 const embeddableClassByBase = new WeakMap<
   InternalMarkdownEditorConstructor,
   InternalMarkdownEditorConstructor
@@ -229,26 +300,15 @@ function getEmbeddableEditorClass(
 
       self.set?.(options.value ?? "", true);
 
-      // Keep the workspace from yanking focus back to a leaf while the
-      // embedded editor owns it. Registered so unload restores the original.
-      const workspace = (app as {
-        workspace?: {
-          setActiveLeaf?: (...args: unknown[]) => void;
-          activeEditor?: unknown;
-        };
-      }).workspace;
-      if (workspace && typeof workspace.setActiveLeaf === "function") {
-        const original = workspace.setActiveLeaf.bind(workspace);
-        const patched = (...args: unknown[]): void => {
-          if (!this.embeddableHasFocus()) {
-            original(...args);
-          }
-        };
-        workspace.setActiveLeaf = patched;
+      // Keep the workspace from yanking focus back to a leaf while an
+      // embedded editor owns it. The patch is shared and reference-counted,
+      // so any number of editors can come and go in any order.
+      const workspace = (app as { workspace?: WorkspaceWithSetActiveLeaf })
+        .workspace;
+      if (workspace) {
+        acquireSetActiveLeafPatch(workspace, self);
         self.register?.(() => {
-          if (workspace.setActiveLeaf === patched) {
-            workspace.setActiveLeaf = original;
-          }
+          releaseSetActiveLeafPatch(workspace, self);
         });
       }
 
@@ -273,11 +333,6 @@ function getEmbeddableEditorClass(
       if (options.cls) {
         self.editorEl?.classList.add(options.cls);
       }
-    }
-
-    private embeddableHasFocus(): boolean {
-      const self = this as unknown as InternalMarkdownEditorInstance;
-      return self.editor?.cm?.hasFocus === true;
     }
 
     private pushKeymapScope(): void {

--- a/src/editor/embeddable-markdown-editor.ts
+++ b/src/editor/embeddable-markdown-editor.ts
@@ -359,6 +359,15 @@ function getEmbeddableEditorClass(
       return this.embeddableOptions ?? constructingOptions ?? {};
     }
 
+    handleEmbeddableEscape(): boolean {
+      this.getEmbeddableOptions().onEscape?.();
+      return true;
+    }
+
+    handleEmbeddablePaste(event: ClipboardEvent): void {
+      this.getEmbeddableOptions().onPaste?.(event);
+    }
+
     onUpdate(update: ViewUpdate, changed: boolean): void {
       const superOnUpdate = (Base.prototype as {
         onUpdate?: (update: ViewUpdate, changed: boolean) => void;
@@ -386,7 +395,7 @@ function getEmbeddableEditorClass(
       extensions.push(
         EditorView.domEventHandlers({
           paste: (event) => {
-            this.getEmbeddableOptions().onPaste?.(event);
+            this.handleEmbeddablePaste(event);
           },
         })
       );
@@ -395,10 +404,7 @@ function getEmbeddableEditorClass(
           keymap.of([
             {
               key: "Escape",
-              run: () => {
-                this.getEmbeddableOptions().onEscape?.();
-                return true;
-              },
+              run: () => this.handleEmbeddableEscape(),
               preventDefault: true,
             },
           ])

--- a/src/tests/mocks/obsidian.js
+++ b/src/tests/mocks/obsidian.js
@@ -702,10 +702,32 @@ class Setting {
   }
 }
 
+/**
+ * Minimal hotkey scope mirror — enough for code that layers a child scope
+ * over `app.scope` and registers key overrides on it.
+ */
+class Scope {
+  constructor(parent) {
+    this.parent = parent ?? null;
+    this.keys = [];
+  }
+
+  register(modifiers, key, func) {
+    const handler = { modifiers, key, func };
+    this.keys.push(handler);
+    return handler;
+  }
+
+  unregister(handler) {
+    this.keys = this.keys.filter((entry) => entry !== handler);
+  }
+}
+
 module.exports = {
   App,
   apiVersion: "1.5.0",
   Plugin,
+  Scope,
   Notice: class Notice {
     constructor(message) {
       // eslint-disable-next-line no-console

--- a/src/views/studio/SystemSculptStudioView.ts
+++ b/src/views/studio/SystemSculptStudioView.ts
@@ -33,6 +33,8 @@ import {
   type StudioProjectSessionMutationReason,
 } from "../../studio/StudioProjectSession";
 import { renderStudioGraphWorkspace } from "./graph-v3/StudioGraphWorkspaceRenderer";
+import { createEmbeddableMarkdownEditor } from "../../editor/embeddable-markdown-editor";
+import type { StudioTextNodeMarkdownEditorFactory } from "./graph-v3/StudioGraphTextNodeCard";
 import {
   createGroupFromSelection as createNodeGroupFromSelection,
   removeNodesFromGroups,
@@ -239,6 +241,13 @@ export class SystemSculptStudioView extends ItemView {
   private pendingViewportState: StudioGraphViewportState | null = null;
   private editingTextNodeIds = new Set<string>();
   private pendingTextNodeAutofocusNodeId: string | null = null;
+  /**
+   * Live embedded markdown editors keyed by text-node id. Each graph render
+   * rebuilds card DOM wholesale, so every mounted editor registers a teardown
+   * here and `disposeTextNodeEditors` runs before the DOM is dropped —
+   * CodeMirror views must be destroyed, not garbage-collected.
+   */
+  private textNodeEditorTeardowns = new Map<string, () => void>();
   private readonly runPresentation = new StudioRunPresentationState();
   private readonly graphInteraction: StudioGraphInteractionEngine;
   private graphZoomMode: StudioGraphZoomMode = "interactive";
@@ -365,6 +374,7 @@ export class SystemSculptStudioView extends ItemView {
     this.currentProject = null;
     this.editingTextNodeIds.clear();
     this.pendingTextNodeAutofocusNodeId = null;
+    this.disposeTextNodeEditors();
     this.inspectorOverlay?.destroy();
     this.inspectorOverlay = null;
     this.nodeContextMenuOverlay?.destroy();
@@ -3542,6 +3552,54 @@ export class SystemSculptStudioView extends ItemView {
     return this.removeNodes([nodeId]);
   }
 
+  /**
+   * Text-node edit sessions run in Obsidian's own embedded live-preview
+   * markdown editor, so editing a text card feels exactly like editing a
+   * note: syntax renders live, tables and checkboxes stay interactive. The
+   * factory returns null when the internal editor cannot be built, and the
+   * card falls back to its plain textarea.
+   */
+  private readonly createTextNodeMarkdownEditor: StudioTextNodeMarkdownEditorFactory = (
+    containerEl,
+    options
+  ) => {
+    return createEmbeddableMarkdownEditor(this.app, containerEl, {
+      value: options.value,
+      placeholder: options.placeholder,
+      onChange: options.onChange,
+      onEscape: options.onEscape,
+      onBlur: options.onBlur,
+    });
+  };
+
+  private registerTextNodeEditorTeardown(nodeId: string, teardown: () => void): void {
+    const normalizedNodeId = String(nodeId || "").trim();
+    if (!normalizedNodeId) {
+      return;
+    }
+    this.textNodeEditorTeardowns.get(normalizedNodeId)?.();
+    this.textNodeEditorTeardowns.set(normalizedNodeId, teardown);
+  }
+
+  /**
+   * Destroys every live embedded editor. Runs before each graph re-render
+   * (the render replaces card DOM wholesale) and on view teardown, so no
+   * CodeMirror view outlives the elements it is mounted in.
+   */
+  private disposeTextNodeEditors(): void {
+    const teardowns = Array.from(this.textNodeEditorTeardowns.values());
+    this.textNodeEditorTeardowns.clear();
+    for (const teardown of teardowns) {
+      try {
+        teardown();
+      } catch (error) {
+        console.warn("[SystemSculpt Studio] Failed to dispose a text-node editor", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
   private consumeTextNodeAutoFocus(nodeId: string): boolean {
     const normalizedNodeId = String(nodeId || "").trim();
     if (!normalizedNodeId) {
@@ -4445,6 +4503,9 @@ export class SystemSculptStudioView extends ItemView {
       consumeTextNodeAutoFocus: (nodeId) => this.consumeTextNodeAutoFocus(nodeId),
       onRequestTextNodeEdit: (nodeId) => this.requestTextNodeEdit(nodeId, { autoFocus: true }),
       onStopTextNodeEdit: (nodeId) => this.stopTextNodeEdit(nodeId),
+      createTextNodeMarkdownEditor: this.createTextNodeMarkdownEditor,
+      registerTextNodeEditorTeardown: (nodeId, teardown) =>
+        this.registerTextNodeEditorTeardown(nodeId, teardown),
       onRevealPathInFinder: (path) => {
         void this.revealPathInFinder(path);
       },
@@ -4581,6 +4642,8 @@ export class SystemSculptStudioView extends ItemView {
   private render(): void {
     this.captureGraphViewportState();
     this.resetViewportScrollingState();
+    // The render below replaces all card DOM; destroy live editors first.
+    this.disposeTextNodeEditors();
     this.graphInteraction.clearRenderBindings();
     this.nodeContextMenuOverlay?.hide();
     this.nodeActionContextMenuOverlay?.hide();

--- a/src/views/studio/__tests__/studio-view-save-persistence.test.ts
+++ b/src/views/studio/__tests__/studio-view-save-persistence.test.ts
@@ -38,6 +38,7 @@ type OnCloseContext = {
   currentProject: Record<string, unknown> | null;
   editingTextNodeIds: Set<string>;
   pendingTextNodeAutofocusNodeId: string | null;
+  disposeTextNodeEditors: jest.Mock<void, []>;
   inspectorOverlay: { destroy: jest.Mock<void, []> } | null;
   nodeContextMenuOverlay: { destroy: jest.Mock<void, []> } | null;
   nodeActionContextMenuOverlay: { destroy: jest.Mock<void, []> } | null;
@@ -106,6 +107,7 @@ function createOnCloseContext(): OnCloseContext {
     currentProject: { graph: { nodes: [] } },
     editingTextNodeIds: new Set(["node-a"]),
     pendingTextNodeAutofocusNodeId: "node-a",
+    disposeTextNodeEditors: jest.fn(),
     inspectorOverlay: { destroy: jest.fn() },
     nodeContextMenuOverlay: { destroy: jest.fn() },
     nodeActionContextMenuOverlay: { destroy: jest.fn() },
@@ -143,6 +145,7 @@ describe("SystemSculptStudioView save persistence", () => {
     expect(context.flushPendingProjectSaveWork).toHaveBeenCalledTimes(1);
     expect(context.releaseRetainedProjectSession).toHaveBeenCalledTimes(1);
     expect(context.captureGraphViewportState).toHaveBeenCalledTimes(1);
+    expect(context.disposeTextNodeEditors).toHaveBeenCalledTimes(1);
     expect(context.app.workspace.requestSaveLayout).toHaveBeenCalledTimes(1);
     expect(context.currentProjectSession).toBeNull();
     expect(context.currentProjectPath).toBeNull();

--- a/src/views/studio/graph-v3/StudioGraphNodeCardRenderer.ts
+++ b/src/views/studio/graph-v3/StudioGraphNodeCardRenderer.ts
@@ -59,6 +59,8 @@ export function renderStudioGraphNodeCard(options: RenderStudioGraphNodeCardOpti
     consumeTextNodeAutoFocus,
     onRequestTextNodeEdit,
     onStopTextNodeEdit,
+    createTextNodeMarkdownEditor,
+    registerTextNodeEditorTeardown,
     onRevealPathInFinder,
     resolveNodeBadge,
   } = options;
@@ -101,6 +103,9 @@ export function renderStudioGraphNodeCard(options: RenderStudioGraphNodeCardOpti
       shouldAutoFocus: consumeTextNodeAutoFocus(node.id),
       onRequestTextNodeEdit,
       onStopTextNodeEdit,
+      renderMarkdownPreview,
+      createMarkdownEditor: createTextNodeMarkdownEditor,
+      registerEditorTeardown: registerTextNodeEditorTeardown,
     });
     return;
   }

--- a/src/views/studio/graph-v3/StudioGraphNodeCardTypes.ts
+++ b/src/views/studio/graph-v3/StudioGraphNodeCardTypes.ts
@@ -9,6 +9,7 @@ import type {
 import type { StudioGraphInteractionEngine } from "../StudioGraphInteractionEngine";
 import type { StudioNodeDetailMode } from "./StudioGraphNodeDetailMode";
 import type { StudioNodeRunDisplayState } from "../StudioRunPresentationState";
+import type { StudioTextNodeMarkdownEditorFactory } from "./StudioGraphTextNodeCard";
 
 export type StudioGraphNodeMutationOptions = {
   mode?: StudioProjectSessionAutosaveMode;
@@ -84,6 +85,8 @@ export type RenderStudioGraphNodeCardOptions = {
   consumeTextNodeAutoFocus: (nodeId: string) => boolean;
   onRequestTextNodeEdit: (nodeId: string) => void;
   onStopTextNodeEdit: (nodeId: string) => void;
+  createTextNodeMarkdownEditor?: StudioTextNodeMarkdownEditorFactory;
+  registerTextNodeEditorTeardown?: (nodeId: string, teardown: () => void) => void;
   onRevealPathInFinder: (path: string) => void;
   resolveNodeBadge?: (node: StudioNodeInstance) => {
     text: string;

--- a/src/views/studio/graph-v3/StudioGraphTextNodeCard.ts
+++ b/src/views/studio/graph-v3/StudioGraphTextNodeCard.ts
@@ -389,6 +389,15 @@ export function renderTextNodeCard(options: RenderTextNodeCardOptions): void {
       if (pointerEvent.button !== 0) {
         return;
       }
+      // Rendered markdown carries its own controls (links, task checkboxes,
+      // embeds); their pointer gestures belong to the control, not to card
+      // dragging. The card-level pointer policy skips these targets too.
+      if (
+        event.target instanceof Element &&
+        event.target.closest("a, input, button, audio, video") !== null
+      ) {
+        return;
+      }
       event.stopPropagation();
       if (pointerEvent.shiftKey || pointerEvent.metaKey || pointerEvent.ctrlKey) {
         lastTextNodeTapByNodeId.delete(node.id);

--- a/src/views/studio/graph-v3/StudioGraphTextNodeCard.ts
+++ b/src/views/studio/graph-v3/StudioGraphTextNodeCard.ts
@@ -234,12 +234,18 @@ function mountLiveMarkdownEditor(options: MountLiveMarkdownEditorOptions): boole
   }
 
   adoptTextSurface(hostEl);
+  let editorDisposed = false;
   registerEditorTeardown?.(node.id, () => {
+    editorDisposed = true;
     editorHandle.destroy();
   });
 
   if (shouldAutoFocus) {
     window.requestAnimationFrame(() => {
+      // A re-render can tear the editor down before this frame fires.
+      if (editorDisposed) {
+        return;
+      }
       editorHandle.focus();
       editorHandle.selectAll();
     });

--- a/src/views/studio/graph-v3/StudioGraphTextNodeCard.ts
+++ b/src/views/studio/graph-v3/StudioGraphTextNodeCard.ts
@@ -436,16 +436,19 @@ export function renderTextNodeCard(options: RenderTextNodeCardOptions): void {
       return;
     }
     displayEl.addClass("is-markdown");
+    const fallBackToPlainText = (): void => {
+      // Raw text needs the pre-wrap source styling back, not markdown
+      // block flow.
+      displayEl.removeClass("is-markdown");
+      displayEl.empty();
+      displayEl.setText(textValue);
+    };
     try {
       void Promise.resolve(
         renderMarkdownPreview(node, textValue, displayEl)
-      ).catch(() => {
-        displayEl.empty();
-        displayEl.setText(textValue);
-      });
+      ).catch(fallBackToPlainText);
     } catch {
-      displayEl.empty();
-      displayEl.setText(textValue);
+      fallBackToPlainText();
     }
   }
 

--- a/src/views/studio/graph-v3/StudioGraphTextNodeCard.ts
+++ b/src/views/studio/graph-v3/StudioGraphTextNodeCard.ts
@@ -11,6 +11,7 @@ import {
   STUDIO_GRAPH_TEXT_NODE_DEFAULT_FONT_SIZE,
 } from "../../../studio/StudioNodeGeometry";
 import { mountStudioGraphNodeResizeFrame } from "./StudioGraphNodeResizeFrame";
+import { markStudioNodeCardInteractive } from "./StudioGraphNodeCardPointer";
 
 const STUDIO_TEXT_NODE_DOUBLE_TAP_DELAY_MS = 450;
 const STUDIO_TEXT_NODE_DOUBLE_TAP_SLOP_PX = 8;
@@ -23,6 +24,37 @@ type TextNodeTapSnapshot = {
 };
 
 const lastTextNodeTapByNodeId = new Map<string, TextNodeTapSnapshot>();
+
+/**
+ * Editing surface handle produced by the host view's embedded-markdown-editor
+ * factory. Mirrors the shape of `EmbeddableMarkdownEditorHandle` without
+ * importing it, so this render module stays free of app-level dependencies.
+ */
+export type StudioTextNodeMarkdownEditorHandle = {
+  readonly value: string;
+  set(value: string): void;
+  focus(): void;
+  selectAll(): void;
+  destroy(): void;
+  readonly editorEl: HTMLElement | null;
+  readonly editor: unknown;
+};
+
+/**
+ * Builds an Obsidian live-preview markdown editor inside `containerEl`, or
+ * returns null when the embedded editor is unavailable — the card then falls
+ * back to the plain textarea surface.
+ */
+export type StudioTextNodeMarkdownEditorFactory = (
+  containerEl: HTMLElement,
+  options: {
+    value: string;
+    placeholder: string;
+    onChange?: (value: string) => void;
+    onEscape?: () => void;
+    onBlur?: () => void;
+  }
+) => StudioTextNodeMarkdownEditorHandle | null;
 
 type RenderTextNodeCardOptions = {
   nodeEl: HTMLElement;
@@ -46,6 +78,13 @@ type RenderTextNodeCardOptions = {
   shouldAutoFocus: boolean;
   onRequestTextNodeEdit: (nodeId: string) => void;
   onStopTextNodeEdit: (nodeId: string) => void;
+  renderMarkdownPreview?: (
+    node: StudioNodeInstance,
+    markdown: string,
+    containerEl: HTMLElement
+  ) => Promise<void> | void;
+  createMarkdownEditor?: StudioTextNodeMarkdownEditorFactory;
+  registerEditorTeardown?: (nodeId: string, teardown: () => void) => void;
 };
 
 /**
@@ -122,6 +161,92 @@ function trackPotentialTextNodeTap(nodeId: string, event: PointerEvent, now: num
   window.addEventListener("pointercancel", stopTracking);
 }
 
+type MountLiveMarkdownEditorOptions = {
+  contentEl: HTMLElement;
+  node: StudioNodeInstance;
+  textValue: string;
+  createMarkdownEditor: StudioTextNodeMarkdownEditorFactory;
+  registerEditorTeardown?: (nodeId: string, teardown: () => void) => void;
+  onNodeConfigMutated: (node: StudioNodeInstance) => void;
+  onNodeConfigValueChange?: RenderTextNodeCardOptions["onNodeConfigValueChange"];
+  onStopTextNodeEdit: (nodeId: string) => void;
+  shouldAutoFocus: boolean;
+  adoptTextSurface: (el: HTMLElement) => void;
+};
+
+/**
+ * Mounts the embedded Obsidian live-preview editor for a text-node edit
+ * session. Returns false when the factory cannot produce an editor, in which
+ * case the caller renders the plain textarea instead. The host owns the
+ * editor's lifetime through the registered teardown — the graph re-render
+ * that follows `onStopTextNodeEdit` destroys the editor before the card's
+ * DOM is dropped.
+ */
+function mountLiveMarkdownEditor(options: MountLiveMarkdownEditorOptions): boolean {
+  const {
+    contentEl,
+    node,
+    textValue,
+    createMarkdownEditor,
+    registerEditorTeardown,
+    onNodeConfigMutated,
+    onNodeConfigValueChange,
+    onStopTextNodeEdit,
+    shouldAutoFocus,
+    adoptTextSurface,
+  } = options;
+
+  const hostEl = contentEl.createDiv({
+    cls: "ss-studio-text-node-live-editor",
+    attr: {
+      "aria-label": `${node.title || "Text"} content`,
+    },
+  });
+  // Pointer gestures inside the editor belong to the editor (text selection,
+  // checkbox toggles, table cells), never to card dragging.
+  markStudioNodeCardInteractive(hostEl);
+
+  const commitValue = (nextValue: string): void => {
+    if (onNodeConfigValueChange) {
+      onNodeConfigValueChange(node.id, "value", nextValue, { mode: "continuous" });
+      return;
+    }
+    node.config.value = nextValue;
+    onNodeConfigMutated(node);
+  };
+
+  const editorHandle = createMarkdownEditor(hostEl, {
+    value: textValue,
+    placeholder: "Text",
+    onChange: (nextValue) => {
+      commitValue(nextValue);
+    },
+    onEscape: () => {
+      onStopTextNodeEdit(node.id);
+    },
+    onBlur: () => {
+      onStopTextNodeEdit(node.id);
+    },
+  });
+  if (!editorHandle) {
+    hostEl.remove();
+    return false;
+  }
+
+  adoptTextSurface(hostEl);
+  registerEditorTeardown?.(node.id, () => {
+    editorHandle.destroy();
+  });
+
+  if (shouldAutoFocus) {
+    window.requestAnimationFrame(() => {
+      editorHandle.focus();
+      editorHandle.selectAll();
+    });
+  }
+  return true;
+}
+
 export function renderTextNodeCard(options: RenderTextNodeCardOptions): void {
   const {
     nodeEl,
@@ -136,6 +261,9 @@ export function renderTextNodeCard(options: RenderTextNodeCardOptions): void {
     shouldAutoFocus,
     onRequestTextNodeEdit,
     onStopTextNodeEdit,
+    renderMarkdownPreview,
+    createMarkdownEditor,
+    registerEditorTeardown,
   } = options;
 
   nodeEl.addClass("ss-studio-text-node-card");
@@ -159,6 +287,36 @@ export function renderTextNodeCard(options: RenderTextNodeCardOptions): void {
   const fontSize = getCurrentFontSize() || STUDIO_GRAPH_TEXT_NODE_DEFAULT_FONT_SIZE;
 
   if (isEditing) {
+    // Obsidian-note parity: edit through the embedded live-preview markdown
+    // editor whenever the host can build one. The editor is created against
+    // internal Obsidian API, so a null factory result (unsupported internals,
+    // busy view, headless tests) falls through to the plain textarea.
+    const liveEditorMounted =
+      !busy && createMarkdownEditor
+        ? mountLiveMarkdownEditor({
+            contentEl,
+            node,
+            textValue,
+            createMarkdownEditor,
+            registerEditorTeardown,
+            onNodeConfigMutated,
+            onNodeConfigValueChange,
+            onStopTextNodeEdit,
+            shouldAutoFocus,
+            adoptTextSurface: (el) => {
+              textSurfaceEl = el;
+              applyFontSize(fontSize);
+            },
+          })
+        : false;
+    if (!liveEditorMounted) {
+      renderTextNodeTextarea();
+    }
+  } else {
+    renderTextNodeDisplay();
+  }
+
+  function renderTextNodeTextarea(): void {
     const textAreaEl = contentEl.createEl("textarea", {
       cls: "ss-studio-text-node-editor",
       attr: {
@@ -212,15 +370,20 @@ export function renderTextNodeCard(options: RenderTextNodeCardOptions): void {
         textAreaEl.select();
       });
     }
-  } else {
+  }
+
+  function renderTextNodeDisplay(): void {
     const hasText = textValue.trim().length > 0;
     const displayEl = contentEl.createDiv({
       cls: "ss-studio-text-node-display",
-      text: hasText ? textValue : "Text",
+      text: hasText ? "" : "Text",
     });
     displayEl.classList.toggle("is-placeholder", !hasText);
     textSurfaceEl = displayEl;
     applyFontSize(fontSize);
+    if (hasText) {
+      renderTextNodeDisplayContent(displayEl);
+    }
     displayEl.addEventListener("pointerdown", (event) => {
       const pointerEvent = event as PointerEvent;
       if (pointerEvent.button !== 0) {
@@ -250,6 +413,31 @@ export function renderTextNodeCard(options: RenderTextNodeCardOptions): void {
       graphInteraction.ensureSingleSelection(node.id);
       onRequestTextNodeEdit(node.id);
     });
+  }
+
+  /**
+   * Obsidian-note parity for the resting card: the value is markdown, so it
+   * displays as rendered markdown (headings, tables, checklists) through the
+   * host's renderer. Without a renderer (headless tests, degraded hosts) the
+   * raw text is shown exactly as before.
+   */
+  function renderTextNodeDisplayContent(displayEl: HTMLElement): void {
+    if (!renderMarkdownPreview) {
+      displayEl.setText(textValue);
+      return;
+    }
+    displayEl.addClass("is-markdown");
+    try {
+      void Promise.resolve(
+        renderMarkdownPreview(node, textValue, displayEl)
+      ).catch(() => {
+        displayEl.empty();
+        displayEl.setText(textValue);
+      });
+    } catch {
+      displayEl.empty();
+      displayEl.setText(textValue);
+    }
   }
 
   mountStudioGraphNodeResizeFrame({

--- a/src/views/studio/graph-v3/StudioGraphWorkspaceRenderer.ts
+++ b/src/views/studio/graph-v3/StudioGraphWorkspaceRenderer.ts
@@ -18,6 +18,7 @@ import type {
   StudioGraphNodeMutationOptions,
   StudioGraphNodeResizePatch,
 } from "./StudioGraphNodeCardTypes";
+import type { StudioTextNodeMarkdownEditorFactory } from "./StudioGraphTextNodeCard";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -82,6 +83,8 @@ export type StudioGraphWorkspaceRendererOptions = {
   consumeTextNodeAutoFocus: (nodeId: string) => boolean;
   onRequestTextNodeEdit: (nodeId: string) => void;
   onStopTextNodeEdit: (nodeId: string) => void;
+  createTextNodeMarkdownEditor?: StudioTextNodeMarkdownEditorFactory;
+  registerTextNodeEditorTeardown?: (nodeId: string, teardown: () => void) => void;
   onRevealPathInFinder: (path: string) => void;
   resolveNodeBadge?: (node: StudioNodeInstance) => {
     text: string;
@@ -137,6 +140,8 @@ export function renderStudioGraphWorkspace(
     consumeTextNodeAutoFocus,
     onRequestTextNodeEdit,
     onStopTextNodeEdit,
+    createTextNodeMarkdownEditor,
+    registerTextNodeEditorTeardown,
     onRevealPathInFinder,
     resolveNodeBadge,
   } = options;
@@ -416,6 +421,8 @@ export function renderStudioGraphWorkspace(
       consumeTextNodeAutoFocus,
       onRequestTextNodeEdit,
       onStopTextNodeEdit,
+      createTextNodeMarkdownEditor,
+      registerTextNodeEditorTeardown,
       onRevealPathInFinder,
       resolveNodeBadge,
     });

--- a/src/views/studio/graph-v3/__tests__/studio-graph-text-node-css-contract.test.ts
+++ b/src/views/studio/graph-v3/__tests__/studio-graph-text-node-css-contract.test.ts
@@ -24,4 +24,29 @@ describe("Studio text-node CSS contract", () => {
     expect(sharedTextSurfaceRule).toMatch(/overflow-wrap:\s*anywhere;/);
     expect(sharedTextSurfaceRule).toMatch(/word-break:\s*break-word;/);
   });
+
+  it("constrains the live-preview editor host inside the text-node frame", () => {
+    const css = readStudioCss();
+    const liveEditorRule = readRuleBody(
+      css,
+      /\.ss-studio-text-node-live-editor\s*\{(?<body>[^}]*)\}/s
+    );
+
+    expect(liveEditorRule).toMatch(/box-sizing:\s*border-box;/);
+    expect(liveEditorRule).toMatch(/max-width:\s*100%;/);
+    expect(liveEditorRule).toMatch(/min-width:\s*0;/);
+    expect(liveEditorRule).toMatch(
+      /font-size:\s*var\(--ss-studio-text-node-font-size, inherit\);/
+    );
+  });
+
+  it("lets rendered markdown flow as normal blocks instead of pre-wrap source", () => {
+    const css = readStudioCss();
+    const markdownDisplayRule = readRuleBody(
+      css,
+      /\.ss-studio-text-node-display\.is-markdown\s*\{(?<body>[^}]*)\}/s
+    );
+
+    expect(markdownDisplayRule).toMatch(/white-space:\s*normal;/);
+  });
 });

--- a/src/views/studio/graph-v3/__tests__/studio-graph-text-node-css-contract.test.ts
+++ b/src/views/studio/graph-v3/__tests__/studio-graph-text-node-css-contract.test.ts
@@ -11,11 +11,11 @@ function readRuleBody(css: string, selectorPattern: RegExp): string {
 }
 
 describe("Studio text-node CSS contract", () => {
-  it("keeps long text constrained inside the text-node resize frame", () => {
+  it("keeps every text surface constrained by ONE shared box rule — display, textarea, and live editor", () => {
     const css = readStudioCss();
     const sharedTextSurfaceRule = readRuleBody(
       css,
-      /\.ss-studio-text-node-display,\s*\.ss-studio-text-node-editor\s*\{(?<body>[^}]*)\}/s
+      /\.ss-studio-text-node-display,\s*\.ss-studio-text-node-editor,\s*\.ss-studio-text-node-live-editor\s*\{(?<body>[^}]*)\}/s
     );
 
     expect(sharedTextSurfaceRule).toMatch(/box-sizing:\s*border-box;/);
@@ -23,21 +23,25 @@ describe("Studio text-node CSS contract", () => {
     expect(sharedTextSurfaceRule).toMatch(/min-width:\s*0;/);
     expect(sharedTextSurfaceRule).toMatch(/overflow-wrap:\s*anywhere;/);
     expect(sharedTextSurfaceRule).toMatch(/word-break:\s*break-word;/);
-  });
-
-  it("constrains the live-preview editor host inside the text-node frame", () => {
-    const css = readStudioCss();
-    const liveEditorRule = readRuleBody(
-      css,
-      /\.ss-studio-text-node-live-editor\s*\{(?<body>[^}]*)\}/s
-    );
-
-    expect(liveEditorRule).toMatch(/box-sizing:\s*border-box;/);
-    expect(liveEditorRule).toMatch(/max-width:\s*100%;/);
-    expect(liveEditorRule).toMatch(/min-width:\s*0;/);
-    expect(liveEditorRule).toMatch(
+    expect(sharedTextSurfaceRule).toMatch(
       /font-size:\s*var\(--ss-studio-text-node-font-size, inherit\);/
     );
+  });
+
+  it("keeps the live-editor-only rule down to its unique declarations", () => {
+    const css = readStudioCss();
+    // (?<!,\n) skips the shared rule, whose selector list ends with this
+    // same class on a comma-continued line.
+    const liveEditorRule = readRuleBody(
+      css,
+      /(?<!,\n)\.ss-studio-text-node-live-editor\s*\{(?<body>[^}]*)\}/s
+    );
+
+    expect(liveEditorRule).toMatch(/cursor:\s*text;/);
+    // The box contract lives in the shared rule; a duplicate here would
+    // silently drift from it.
+    expect(liveEditorRule).not.toMatch(/box-sizing/);
+    expect(liveEditorRule).not.toMatch(/max-width/);
   });
 
   it("lets rendered markdown flow as normal blocks instead of pre-wrap source", () => {

--- a/src/views/studio/graph-v3/__tests__/studio-graph-text-node-live-preview.test.ts
+++ b/src/views/studio/graph-v3/__tests__/studio-graph-text-node-live-preview.test.ts
@@ -1,0 +1,315 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { StudioNodeInstance } from "../../../../studio/types";
+import {
+  renderTextNodeCard,
+  type StudioTextNodeMarkdownEditorFactory,
+  type StudioTextNodeMarkdownEditorHandle,
+} from "../StudioGraphTextNodeCard";
+
+function createTextNode(value: string): StudioNodeInstance {
+  return {
+    id: "text_node",
+    kind: "studio.text",
+    version: "1.0.0",
+    title: "Text",
+    position: { x: 10, y: 20 },
+    config: { value },
+    continueOnError: false,
+    disabled: false,
+  };
+}
+
+function createGraphInteractionStub() {
+  return {
+    isNodeSelected: jest.fn(() => false),
+    registerNodeElement: jest.fn(),
+    startNodeDrag: jest.fn(),
+    getGraphZoom: jest.fn(() => 1),
+    toggleNodeSelection: jest.fn(),
+    ensureSingleSelection: jest.fn(),
+    resolveNodeResizeSnap: jest.fn(() => null),
+    clearResizeSnapGuides: jest.fn(),
+  };
+}
+
+type HarnessOptions = {
+  value?: string;
+  isEditing?: boolean;
+  busy?: boolean;
+  shouldAutoFocus?: boolean;
+  renderMarkdownPreview?: jest.Mock;
+  createMarkdownEditor?: StudioTextNodeMarkdownEditorFactory;
+  registerEditorTeardown?: jest.Mock;
+};
+
+function renderHarness(options: HarnessOptions = {}) {
+  const node = createTextNode(options.value ?? "");
+  const nodeEl = document.body.createDiv({ cls: "ss-studio-node-card" });
+  const graphInteraction = createGraphInteractionStub();
+  const onNodeConfigMutated = jest.fn();
+  const onNodeConfigValueChange = jest.fn();
+  const onRequestTextNodeEdit = jest.fn();
+  const onStopTextNodeEdit = jest.fn();
+
+  renderTextNodeCard({
+    nodeEl,
+    node,
+    busy: options.busy ?? false,
+    graphInteraction: graphInteraction as never,
+    onNodeConfigMutated,
+    onNodeConfigValueChange,
+    onNodeGeometryMutated: jest.fn(),
+    isEditing: options.isEditing ?? false,
+    shouldAutoFocus: options.shouldAutoFocus ?? false,
+    onRequestTextNodeEdit,
+    onStopTextNodeEdit,
+    renderMarkdownPreview: options.renderMarkdownPreview,
+    createMarkdownEditor: options.createMarkdownEditor,
+    registerEditorTeardown: options.registerEditorTeardown,
+  });
+
+  return {
+    node,
+    nodeEl,
+    graphInteraction,
+    onNodeConfigMutated,
+    onNodeConfigValueChange,
+    onRequestTextNodeEdit,
+    onStopTextNodeEdit,
+  };
+}
+
+type EditorFactoryCapture = {
+  factory: StudioTextNodeMarkdownEditorFactory;
+  calls: Array<{
+    containerEl: HTMLElement;
+    options: Parameters<StudioTextNodeMarkdownEditorFactory>[1];
+  }>;
+  handle: StudioTextNodeMarkdownEditorHandle & {
+    destroy: jest.Mock;
+    focus: jest.Mock;
+    selectAll: jest.Mock;
+  };
+};
+
+function createEditorFactory(result: "handle" | "null" = "handle"): EditorFactoryCapture {
+  const handle = {
+    value: "",
+    set: jest.fn(),
+    destroy: jest.fn(),
+    focus: jest.fn(),
+    selectAll: jest.fn(),
+    editorEl: null,
+    editor: null,
+  };
+  const calls: EditorFactoryCapture["calls"] = [];
+  const factory: StudioTextNodeMarkdownEditorFactory = (containerEl, options) => {
+    calls.push({ containerEl, options });
+    if (result === "null") {
+      return null;
+    }
+    return handle;
+  };
+  return { factory, calls, handle };
+}
+
+describe("studio.text live-preview card", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.restoreAllMocks();
+  });
+
+  describe("display mode", () => {
+    it("renders the value as markdown through renderMarkdownPreview", () => {
+      const renderMarkdownPreview = jest.fn();
+      const { node, nodeEl } = renderHarness({
+        value: "# Heading\n\n| a | b |\n| - | - |",
+        renderMarkdownPreview,
+      });
+
+      const displayEl = nodeEl.querySelector<HTMLElement>(".ss-studio-text-node-display");
+      expect(displayEl).not.toBeNull();
+      expect(displayEl?.classList.contains("is-markdown")).toBe(true);
+      expect(renderMarkdownPreview).toHaveBeenCalledTimes(1);
+      expect(renderMarkdownPreview).toHaveBeenCalledWith(
+        node,
+        "# Heading\n\n| a | b |\n| - | - |",
+        displayEl
+      );
+    });
+
+    it("keeps the faint placeholder for empty values without invoking markdown", () => {
+      const renderMarkdownPreview = jest.fn();
+      const { nodeEl } = renderHarness({ value: "   ", renderMarkdownPreview });
+
+      const displayEl = nodeEl.querySelector<HTMLElement>(".ss-studio-text-node-display");
+      expect(displayEl?.textContent).toBe("Text");
+      expect(displayEl?.classList.contains("is-placeholder")).toBe(true);
+      expect(displayEl?.classList.contains("is-markdown")).toBe(false);
+      expect(renderMarkdownPreview).not.toHaveBeenCalled();
+    });
+
+    it("falls back to plain text when markdown rendering rejects", async () => {
+      const renderMarkdownPreview = jest.fn(() => Promise.reject(new Error("boom")));
+      const { nodeEl } = renderHarness({
+        value: "plain body",
+        renderMarkdownPreview,
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const displayEl = nodeEl.querySelector<HTMLElement>(".ss-studio-text-node-display");
+      expect(displayEl?.textContent).toBe("plain body");
+    });
+
+    it("still opens edit mode on double click over rendered markdown", () => {
+      const renderMarkdownPreview = jest.fn();
+      const { node, nodeEl, onRequestTextNodeEdit, graphInteraction } = renderHarness({
+        value: "**bold**",
+        renderMarkdownPreview,
+      });
+
+      const displayEl = nodeEl.querySelector<HTMLElement>(".ss-studio-text-node-display");
+      displayEl?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
+
+      expect(graphInteraction.ensureSingleSelection).toHaveBeenCalledWith(node.id);
+      expect(onRequestTextNodeEdit).toHaveBeenCalledWith(node.id);
+    });
+  });
+
+  describe("edit mode with the embedded markdown editor", () => {
+    it("mounts the live editor host and hands it the current value and placeholder", () => {
+      const capture = createEditorFactory();
+      const { nodeEl } = renderHarness({
+        value: "existing text",
+        isEditing: true,
+        createMarkdownEditor: capture.factory,
+      });
+
+      const hostEl = nodeEl.querySelector<HTMLElement>(".ss-studio-text-node-live-editor");
+      expect(hostEl).not.toBeNull();
+      expect(nodeEl.querySelector("textarea.ss-studio-text-node-editor")).toBeNull();
+      expect(capture.calls).toHaveLength(1);
+      expect(capture.calls[0].containerEl).toBe(hostEl);
+      expect(capture.calls[0].options.value).toBe("existing text");
+      expect(capture.calls[0].options.placeholder).toBe("Text");
+    });
+
+    it("marks the live editor host interactive so pointer gestures stay in the editor", () => {
+      const capture = createEditorFactory();
+      const { nodeEl, graphInteraction } = renderHarness({
+        value: "text",
+        isEditing: true,
+        createMarkdownEditor: capture.factory,
+      });
+
+      const hostEl = nodeEl.querySelector<HTMLElement>(".ss-studio-text-node-live-editor");
+      expect(hostEl?.hasAttribute("data-studio-interactive")).toBe(true);
+      expect(graphInteraction.startNodeDrag).not.toHaveBeenCalled();
+    });
+
+    it("commits editor changes as continuous config mutations", () => {
+      const capture = createEditorFactory();
+      const { node, onNodeConfigValueChange } = renderHarness({
+        value: "start",
+        isEditing: true,
+        createMarkdownEditor: capture.factory,
+      });
+
+      capture.calls[0].options.onChange?.("start plus more");
+
+      expect(onNodeConfigValueChange).toHaveBeenCalledWith(
+        node.id,
+        "value",
+        "start plus more",
+        { mode: "continuous" }
+      );
+    });
+
+    it("ends the edit session on escape and on blur", () => {
+      const capture = createEditorFactory();
+      const { node, onStopTextNodeEdit } = renderHarness({
+        value: "x",
+        isEditing: true,
+        createMarkdownEditor: capture.factory,
+      });
+
+      capture.calls[0].options.onEscape?.();
+      expect(onStopTextNodeEdit).toHaveBeenCalledWith(node.id);
+
+      capture.calls[0].options.onBlur?.();
+      expect(onStopTextNodeEdit).toHaveBeenCalledTimes(2);
+    });
+
+    it("registers a teardown that destroys the editor", () => {
+      const capture = createEditorFactory();
+      const registerEditorTeardown = jest.fn();
+      const { node } = renderHarness({
+        value: "x",
+        isEditing: true,
+        createMarkdownEditor: capture.factory,
+        registerEditorTeardown,
+      });
+
+      expect(registerEditorTeardown).toHaveBeenCalledWith(node.id, expect.any(Function));
+      const teardown = registerEditorTeardown.mock.calls[0][1] as () => void;
+      teardown();
+      expect(capture.handle.destroy).toHaveBeenCalled();
+    });
+
+    it("autofocuses and selects the editor content when requested", () => {
+      jest
+        .spyOn(window, "requestAnimationFrame")
+        .mockImplementation((callback: FrameRequestCallback) => {
+          callback(0);
+          return 1;
+        });
+      const capture = createEditorFactory();
+      renderHarness({
+        value: "x",
+        isEditing: true,
+        shouldAutoFocus: true,
+        createMarkdownEditor: capture.factory,
+      });
+
+      expect(capture.handle.focus).toHaveBeenCalled();
+      expect(capture.handle.selectAll).toHaveBeenCalled();
+    });
+
+    it("falls back to the plain textarea when the factory yields no editor", () => {
+      const capture = createEditorFactory("null");
+      const { nodeEl } = renderHarness({
+        value: "fallback text",
+        isEditing: true,
+        createMarkdownEditor: capture.factory,
+      });
+
+      const textareaEl = nodeEl.querySelector<HTMLTextAreaElement>(
+        "textarea.ss-studio-text-node-editor"
+      );
+      expect(textareaEl).not.toBeNull();
+      expect(textareaEl?.value).toBe("fallback text");
+      expect(nodeEl.querySelector(".ss-studio-text-node-live-editor")).toBeNull();
+    });
+
+    it("does not mount the live editor while the view is busy", () => {
+      const capture = createEditorFactory();
+      const { nodeEl } = renderHarness({
+        value: "busy text",
+        isEditing: true,
+        busy: true,
+        createMarkdownEditor: capture.factory,
+      });
+
+      expect(capture.calls).toHaveLength(0);
+      const textareaEl = nodeEl.querySelector<HTMLTextAreaElement>(
+        "textarea.ss-studio-text-node-editor"
+      );
+      expect(textareaEl).not.toBeNull();
+      expect(textareaEl?.disabled).toBe(true);
+    });
+  });
+});

--- a/src/views/studio/graph-v3/__tests__/studio-graph-text-node-live-preview.test.ts
+++ b/src/views/studio/graph-v3/__tests__/studio-graph-text-node-live-preview.test.ts
@@ -308,6 +308,34 @@ describe("studio.text live-preview card", () => {
       expect(capture.handle.selectAll).toHaveBeenCalled();
     });
 
+    it("skips the deferred autofocus when the editor is torn down before the frame fires", () => {
+      const pendingFrames: FrameRequestCallback[] = [];
+      jest
+        .spyOn(window, "requestAnimationFrame")
+        .mockImplementation((callback: FrameRequestCallback) => {
+          pendingFrames.push(callback);
+          return pendingFrames.length;
+        });
+      const capture = createEditorFactory();
+      const registerEditorTeardown = jest.fn();
+      renderHarness({
+        value: "x",
+        isEditing: true,
+        shouldAutoFocus: true,
+        createMarkdownEditor: capture.factory,
+        registerEditorTeardown,
+      });
+
+      const teardown = registerEditorTeardown.mock.calls[0][1] as () => void;
+      teardown();
+      for (const frame of pendingFrames) {
+        frame(0);
+      }
+
+      expect(capture.handle.focus).not.toHaveBeenCalled();
+      expect(capture.handle.selectAll).not.toHaveBeenCalled();
+    });
+
     it("falls back to the plain textarea when the factory yields no editor", () => {
       const capture = createEditorFactory("null");
       const { nodeEl } = renderHarness({

--- a/src/views/studio/graph-v3/__tests__/studio-graph-text-node-live-preview.test.ts
+++ b/src/views/studio/graph-v3/__tests__/studio-graph-text-node-live-preview.test.ts
@@ -163,6 +163,9 @@ describe("studio.text live-preview card", () => {
 
       const displayEl = nodeEl.querySelector<HTMLElement>(".ss-studio-text-node-display");
       expect(displayEl?.textContent).toBe("plain body");
+      // The fallback shows raw text, so the markdown block-flow styling
+      // must come off with it.
+      expect(displayEl?.classList.contains("is-markdown")).toBe(false);
     });
 
     it("leaves rendered links and checkboxes to their own pointer handling instead of dragging", () => {

--- a/src/views/studio/graph-v3/__tests__/studio-graph-text-node-live-preview.test.ts
+++ b/src/views/studio/graph-v3/__tests__/studio-graph-text-node-live-preview.test.ts
@@ -165,6 +165,32 @@ describe("studio.text live-preview card", () => {
       expect(displayEl?.textContent).toBe("plain body");
     });
 
+    it("leaves rendered links and checkboxes to their own pointer handling instead of dragging", () => {
+      const renderMarkdownPreview = jest.fn((_node, _markdown, containerEl: HTMLElement) => {
+        containerEl.createEl("a", { text: "a link", attr: { href: "https://example.com" } });
+        const checkboxEl = containerEl.createEl("input");
+        checkboxEl.type = "checkbox";
+      });
+      const { nodeEl, graphInteraction } = renderHarness({
+        value: "[a link](https://example.com)\n\n- [ ] task",
+        renderMarkdownPreview,
+      });
+
+      const displayEl = nodeEl.querySelector<HTMLElement>(".ss-studio-text-node-display");
+      const linkEl = displayEl?.querySelector<HTMLElement>("a");
+      const checkboxEl = displayEl?.querySelector<HTMLElement>("input");
+      expect(linkEl).not.toBeNull();
+      expect(checkboxEl).not.toBeNull();
+
+      for (const targetEl of [linkEl, checkboxEl]) {
+        const event = new MouseEvent("pointerdown", { bubbles: true, cancelable: true });
+        Object.defineProperty(event, "pointerId", { value: 41, configurable: true });
+        targetEl?.dispatchEvent(event);
+      }
+
+      expect(graphInteraction.startNodeDrag).not.toHaveBeenCalled();
+    });
+
     it("still opens edit mode on double click over rendered markdown", () => {
       const renderMarkdownPreview = jest.fn();
       const { node, nodeEl, onRequestTextNodeEdit, graphInteraction } = renderHarness({


### PR DESCRIPTION
- Studio text nodes now edit like an Obsidian note: double-clicking mounts Obsidian's own embedded live-preview CodeMirror editor (same editor as Canvas text cards), so markdown syntax, tables, and checklists render live while typing; Escape/blur still end the session and empty nodes still self-delete.
- The resting card renders its value as real markdown via `MarkdownRenderer` instead of raw source; plain-text fallback (textarea + raw display) remains for environments where the internal editor can't be resolved.
- New reusable `src/editor/embeddable-markdown-editor.ts` resolves the internal editor defensively (community `embedRegistry` technique) and is covered by unit tests; the view now owns editor lifecycles through a teardown registry disposed on each render and on close.

Follow-up candidate (not in this PR, one issue per PR): the inline Raw/Rendered editors on note/text-output/text-generation/transcription cards share the same "markdown on a card" capability and could adopt the embedded editor next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text cards now support a richer markdown editing experience with live preview when available.
  * Markdown content in text cards renders in normal block flow for cleaner display.
  * Embedded editors now behave more like the main canvas, including matching sizing and focus behavior.

* **Bug Fixes**
  * Improved handling so interactive markdown elements don’t accidentally start dragging cards.
  * Editors are cleaned up reliably when views close or rerender, reducing stale editor issues.
  * Fallback behavior keeps text editable if live preview can’t be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->