### PR TITLE
ci: run the full regression gate on PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   plugin:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -21,4 +22,7 @@ jobs:
           node-version: "22.x"
           cache: npm
       - run: npm ci --no-audit --no-fund
-      - run: npm run check
+      # check:full = check:plugin + unit, embeddings, compiled-integration,
+      # and release-script suites, so a merge cannot land without the full
+      # regression pass.
+      - run: npm run check:full

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ npm run check:full
   release guards.
 - check:full adds unit, embeddings, compiled integration, and release-script
   suites.
-- CI has one secret-free Ubuntu/Node job and runs npm run check. There is no
+- CI has one secret-free Ubuntu/Node job and runs npm run check:full. There is no
   Windows, Android, iOS, provider, or native-device matrix.
 
 ## Local Obsidian loop


### PR DESCRIPTION
## What

CI now runs `npm run check:full` (check:plugin + unit + embeddings + compiled-integration + release-script suites) instead of the fast `check` gate, with a 30-minute job timeout. AGENTS.md CI line updated.

## Why

Merges to main only proved the fast gate; the full regression suites (chat/agent workspace, audio transcription, embeddings, Studio, compiled-bundle integration) never ran in CI. Now a merge cannot land without the complete pass.

## Verification

- `npm run check:full` green locally on current main (this exact suite).
- This PR's own CI run executes the new workflow from the head ref — green here is the end-to-end proof.
- Remains secret-free; no matrix change.