### PR TITLE
[codex] Fix managed image downloads without Content-Length

### DIFF
--- a/src/services/PlatformRequestClient.ts
+++ b/src/services/PlatformRequestClient.ts
@@ -16,6 +16,7 @@ export type PlatformRequestInput = {
   transport?: PlatformTransport;
   bodyEncoding?: "json" | "raw";
   responseEncoding?: "text" | "arrayBuffer";
+  maxResponseBytes?: number;
   /**
    * Replay-safe endpoint used to prove that direct browser fetch can read the
    * first-party origin before a state-changing streaming request is sent.
@@ -39,6 +40,12 @@ export class PlatformRequestClient {
     const rawBody = input.bodyEncoding === "raw";
     if (rawBody && input.body !== undefined && !(input.body instanceof ArrayBuffer)) {
       throw new TypeError("Raw platform request bodies must be an ArrayBuffer.");
+    }
+    if (
+      input.maxResponseBytes !== undefined
+      && (!Number.isInteger(input.maxResponseBytes) || input.maxResponseBytes < 1)
+    ) {
+      throw new TypeError("Maximum platform response size must be a positive integer.");
     }
     let transport = input.transport
       ?? PlatformContext.get().preferredTransport({
@@ -115,6 +122,13 @@ export class PlatformRequestClient {
       : typeof result.text === "string"
         ? result.text
         : JSON.stringify(result.json || {});
+    if (
+      input.maxResponseBytes !== undefined
+      && input.responseEncoding === "arrayBuffer"
+      && result.arrayBuffer.byteLength > input.maxResponseBytes
+    ) {
+      throw new TypeError("Native response exceeded the configured maximum size.");
+    }
     const responseHeaders = new Headers();
     const nativeHeaders = (result as typeof result & { headers?: Record<string, string> }).headers;
     if (nativeHeaders) {

--- a/src/services/__tests__/PlatformRequestClient.test.ts
+++ b/src/services/__tests__/PlatformRequestClient.test.ts
@@ -278,4 +278,37 @@ describe("PlatformRequestClient", () => {
     expect(response.headers.get("x-systemsculpt-contract")).toBe("managed-capabilities-v2");
     expect(response.headers.get("x-systemsculpt-image-output-contract")).toBe("managed-image-output-v1");
   });
+
+  it("rejects an oversized native binary response before reconstructing another body", async () => {
+    const client = new PlatformRequestClient();
+    (requestUrl as jest.Mock).mockResolvedValue({
+      status: 200,
+      headers: { "Content-Type": "image/png" },
+      arrayBuffer: new Uint8Array([1, 2, 3]).buffer,
+      text: "\u0001\u0002\u0003",
+      json: null,
+    });
+
+    await expect(client.request({
+      url: "https://systemsculpt.com/api/plugin/images/generations/jobs/job/outputs/0",
+      method: "GET",
+      transport: "requestUrl",
+      responseEncoding: "arrayBuffer",
+      maxResponseBytes: 2,
+    })).rejects.toThrow("Native response exceeded the configured maximum size");
+  });
+
+  it.each([0, -1, 1.5, Number.NaN])("rejects invalid maximum native response size %p before transport", async (maxResponseBytes) => {
+    const client = new PlatformRequestClient();
+
+    await expect(client.request({
+      url: "https://systemsculpt.com/api/plugin/images/generations/jobs/job/outputs/0",
+      method: "GET",
+      transport: "requestUrl",
+      responseEncoding: "arrayBuffer",
+      maxResponseBytes,
+    })).rejects.toThrow("Maximum platform response size must be a positive integer");
+
+    expect(requestUrl).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/managed/ManagedJobClient.ts
+++ b/src/services/managed/ManagedJobClient.ts
@@ -1,5 +1,5 @@
 import { HostedTransportAdapter } from "./adapters/HostedTransportAdapter";
-import { MANAGED_CAPABILITY_CONTRACT, ManagedImageOutputBytes, ManagedImageOutputMetadata, ManagedJobCapability, ManagedJobStatus, ManagedTransportResult } from "./ManagedTypes";
+import { MANAGED_CAPABILITY_CONTRACT, MANAGED_IMAGE_OUTPUT_MAX_BYTES, ManagedImageOutputBytes, ManagedImageOutputMetadata, ManagedJobCapability, ManagedJobStatus, ManagedTransportResult } from "./ManagedTypes";
 
 export const MANAGED_JOB_PROTOCOL = "managed-job-protocol-v1" as const;
 const MANAGED_IMAGE_OUTPUT_PROTOCOL = "managed-image-output-v1" as const;
@@ -84,21 +84,68 @@ export class ManagedJobClient {
     const result = await this.transport.managedImageOutput(path, headers, signal);
     if (!result.response.ok) await this.imageOutputError(result, requestId);
     const response = result.response, responseRequestId = response.headers.get("x-request-id");
-    const required: Record<string, string> = { "x-systemsculpt-contract": MANAGED_CAPABILITY_CONTRACT, "x-systemsculpt-job-contract": MANAGED_JOB_PROTOCOL, "x-systemsculpt-image-output-contract": MANAGED_IMAGE_OUTPUT_PROTOCOL, "x-systemsculpt-capability": "image_generation", "x-systemsculpt-output-index": String(outputIndex), "x-systemsculpt-content-sha256": expected.sha256, "content-type": expected.mime_type, "content-length": String(expected.size_bytes), "cache-control": "no-store, max-age=0", "x-content-type-options": "nosniff" };
+    const required: Record<string, string> = { "x-systemsculpt-contract": MANAGED_CAPABILITY_CONTRACT, "x-systemsculpt-job-contract": MANAGED_JOB_PROTOCOL, "x-systemsculpt-image-output-contract": MANAGED_IMAGE_OUTPUT_PROTOCOL, "x-systemsculpt-capability": "image_generation", "x-systemsculpt-output-index": String(outputIndex), "x-systemsculpt-content-sha256": expected.sha256, "content-type": expected.mime_type, "cache-control": "no-store, max-age=0", "x-content-type-options": "nosniff" };
+    const declaredLength = response.headers.get("content-length");
+    // A proxy may legitimately frame the fixed server body as chunked. When
+    // length is present it must agree with metadata; either way the reader
+    // below enforces the exact metadata size before hashing.
+    const validDeclaredLength = declaredLength === null
+      || (/^(0|[1-9]\d*)$/.test(declaredLength) && Number(declaredLength) === expected.size_bytes);
     const mismatchedHeaders = [
       ...(responseRequestId === requestId ? [] : ["x-request-id"]),
       ...Object.entries(required).filter(([name, value]) => response.headers.get(name) !== value).map(([name]) => name),
+      ...(validDeclaredLength ? [] : ["content-length"]),
     ];
     if (mismatchedHeaders.length > 0) malformed(`Invalid managed image output headers: ${mismatchedHeaders.join(", ")}.`);
     const extension = expected.mime_type === "image/png" ? "png" : expected.mime_type === "image/jpeg" ? "jpg" : "webp";
     if (response.headers.get("content-disposition") !== `attachment; filename="systemsculpt-image-${outputIndex}.${extension}"`) malformed("Invalid managed image output disposition.");
-    let bytes: ArrayBuffer; try { bytes = await response.arrayBuffer(); } catch (error) { if (signal?.aborted) { try { await response.body?.cancel(); } catch {} throw new DOMException("Aborted", "AbortError"); } throw error; }
-    if (signal?.aborted) { try { await response.body?.cancel(); } catch {} throw new DOMException("Aborted", "AbortError"); }
-    if (bytes.byteLength !== expected.size_bytes || await this.sha256(bytes) !== expected.sha256) malformed("Managed image output integrity mismatch.");
+    const bytes = await this.readImageOutputBytes(response, expected.size_bytes, signal);
+    if (await this.sha256(bytes) !== expected.sha256) malformed("Managed image output integrity mismatch.");
     return { metadata: expected, bytes };
   }
 
-  private validateImageOutputMetadata(value: ManagedImageOutputMetadata, response = false): void { if (!value || Object.keys(value).sort().join() !== "height,index,mime_type,sha256,size_bytes,width" || !Number.isInteger(value.index) || value.index < 0 || value.index > 3 || !["image/png", "image/jpeg", "image/webp"].includes(value.mime_type) || !Number.isInteger(value.size_bytes) || value.size_bytes < 1 || value.size_bytes > 31457280 || !/^[a-f0-9]{64}$/.test(value.sha256) || [value.width, value.height].some(v => v !== null && (!Number.isInteger(v) || v < 0))) { if (response) malformed("Malformed image output metadata."); this.invalid("Invalid expected image output metadata."); } }
+  private async readImageOutputBytes(response: Response, expectedBytes: number, signal?: AbortSignal): Promise<ArrayBuffer> {
+    const body = response.body;
+    if (!body) malformed("Managed image output integrity mismatch.");
+    const reader = body.getReader();
+    const bytes = new Uint8Array(expectedBytes);
+    let offset = 0;
+    let completed = false;
+    const abortError = () => new DOMException("Aborted", "AbortError");
+    const abortReader = () => { void reader.cancel(abortError()).catch(() => undefined); };
+    signal?.addEventListener("abort", abortReader, { once: true });
+    try {
+      while (true) {
+        if (signal?.aborted) throw abortError();
+        let chunk: ReadableStreamReadResult<Uint8Array>;
+        try {
+          chunk = await reader.read();
+        } catch (error) {
+          if (signal?.aborted) throw abortError();
+          throw error;
+        }
+        if (signal?.aborted) throw abortError();
+        if (chunk.done) {
+          completed = true;
+          break;
+        }
+        if (!(chunk.value instanceof Uint8Array)) malformed("Managed image output body was malformed.");
+        if (chunk.value.byteLength > expectedBytes - offset) malformed("Managed image output exceeded expected size.");
+        bytes.set(chunk.value, offset);
+        offset += chunk.value.byteLength;
+      }
+    } finally {
+      signal?.removeEventListener("abort", abortReader);
+      if (!completed) {
+        try { await reader.cancel(); } catch {}
+      }
+      reader.releaseLock();
+    }
+    if (offset !== expectedBytes) malformed("Managed image output integrity mismatch.");
+    return bytes.buffer;
+  }
+
+  private validateImageOutputMetadata(value: ManagedImageOutputMetadata, response = false): void { if (!value || Object.keys(value).sort().join() !== "height,index,mime_type,sha256,size_bytes,width" || !Number.isInteger(value.index) || value.index < 0 || value.index > 3 || !["image/png", "image/jpeg", "image/webp"].includes(value.mime_type) || !Number.isInteger(value.size_bytes) || value.size_bytes < 1 || value.size_bytes > MANAGED_IMAGE_OUTPUT_MAX_BYTES || !/^[a-f0-9]{64}$/.test(value.sha256) || [value.width, value.height].some(v => v !== null && (!Number.isInteger(v) || v < 0))) { if (response) malformed("Malformed image output metadata."); this.invalid("Invalid expected image output metadata."); } }
   private imageOutputHeaders(requestId: string): Record<string, string> { return { "x-systemsculpt-contract": MANAGED_CAPABILITY_CONTRACT, "x-systemsculpt-job-contract": MANAGED_JOB_PROTOCOL, "x-systemsculpt-capability": "image_generation", "x-systemsculpt-image-output-contract": MANAGED_IMAGE_OUTPUT_PROTOCOL, "x-request-id": requestId }; }
   private requestId(): string { const requestId = this.createRequestId(); if (!/^[A-Za-z0-9._:-]{1,128}$/.test(requestId)) throw new Error("Invalid generated request ID."); return requestId; }
   private async sha256(bytes: ArrayBuffer): Promise<string> { const digest = await window.crypto.subtle.digest("SHA-256", bytes); return Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, "0")).join(""); }

--- a/src/services/managed/ManagedTypes.ts
+++ b/src/services/managed/ManagedTypes.ts
@@ -2,6 +2,7 @@ import type { ChatMessage } from "../../types";
 import type { AgentTranscriptSnapshot as ChatTranscriptSnapshot } from "../../views/chatview/AgentTranscriptRepository";
 
 export const MANAGED_CAPABILITY_CONTRACT = "managed-capabilities-v2" as const;
+export const MANAGED_IMAGE_OUTPUT_MAX_BYTES = 30 * 1024 * 1024;
 export const MANAGED_ADMISSION_CONTRACT = "admission-v1" as const;
 
 export type ManagedCapabilityAlias =

--- a/src/services/managed/__tests__/HostedTransportAdapter.test.ts
+++ b/src/services/managed/__tests__/HostedTransportAdapter.test.ts
@@ -196,7 +196,7 @@ describe("HostedTransportAdapter", () => {
     expect(request).toHaveBeenCalledWith(expect.objectContaining({
       url: "https://api.test/api/plugin/images/generations/jobs/123e4567-e89b-42d3-a456-426614174000/outputs/0",
       method: "GET", headers: expect.objectContaining(headers), preserveResponseHeaders: true, licenseKey: "secret",
-      transport: "requestUrl", responseEncoding: "arrayBuffer",
+      transport: "requestUrl", responseEncoding: "arrayBuffer", maxResponseBytes: 30 * 1024 * 1024,
     }));
     await expect(adapter.managedImageOutput("https://signed.test/output", headers)).rejects.toThrow("Invalid managed image output path");
     await expect(adapter.managedImageOutput("/api/plugin/documents/id/download", headers)).rejects.toThrow("Invalid managed image output path");

--- a/src/services/managed/__tests__/ManagedJobClient.test.ts
+++ b/src/services/managed/__tests__/ManagedJobClient.test.ts
@@ -245,6 +245,79 @@ describe("ManagedJobClient exact wire contract", () => {
     expect(JSON.stringify(request.mock.calls[0][0])).not.toContain("signed");
   });
 
+  it("downloads a valid chunked image output when content-length is absent", async () => {
+    const bytes = new Uint8Array([1, 2]);
+    const metadata = { index: 0, mime_type: "image/png" as const, size_bytes: 2, sha256: "a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222", width: 10, height: 20 };
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes.subarray(0, 1));
+        controller.enqueue(bytes.subarray(1));
+        controller.close();
+      },
+    });
+    request.mockResolvedValue(new Response(body, { status: 200, headers: { "x-request-id": "req-1", "x-systemsculpt-contract": "managed-capabilities-v2", "x-systemsculpt-job-contract": MANAGED_JOB_PROTOCOL, "x-systemsculpt-image-output-contract": "managed-image-output-v1", "x-systemsculpt-capability": "image_generation", "x-systemsculpt-output-index": "0", "x-systemsculpt-content-sha256": metadata.sha256, "content-type": "image/png", "cache-control": "no-store, max-age=0", "x-content-type-options": "nosniff", "content-disposition": "attachment; filename=\"systemsculpt-image-0.png\"" } }));
+
+    const result = await client.images.downloadOutput("123e4567-e89b-42d3-a456-426614174000", 0, metadata);
+
+    expect([...new Uint8Array(result.bytes)]).toEqual([1, 2]);
+  });
+
+  it.each([
+    ["malformed", "invalid"],
+    ["conflicting", "2, 3"],
+    ["leading zero", "02"],
+    ["negative", "-1"],
+    ["declared oversize", "31457281"],
+  ])("rejects a %s managed image content-length before reading bytes", async (_label, contentLength) => {
+    const metadata = { index: 0, mime_type: "image/png" as const, size_bytes: 2, sha256: "a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222", width: 1, height: 1 };
+    request.mockResolvedValue(new Response(new Uint8Array([1, 2]), { status: 200, headers: { ...imageContractHeaders(), "x-systemsculpt-output-index": "0", "x-systemsculpt-content-sha256": metadata.sha256, "content-type": "image/png", "content-length": contentLength, "cache-control": "no-store, max-age=0", "x-content-type-options": "nosniff", "content-disposition": "attachment; filename=\"systemsculpt-image-0.png\"" } }));
+
+    await expect(client.images.downloadOutput("123e4567-e89b-42d3-a456-426614174000", 0, metadata)).rejects.toMatchObject({
+      code: "malformed_response",
+      message: "Invalid managed image output headers: content-length.",
+    });
+  });
+
+  it("rejects and cancels an actual oversized chunked managed image body", async () => {
+    const cancel = jest.fn();
+    const metadata = { index: 0, mime_type: "image/png" as const, size_bytes: 2, sha256: "a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222", width: 1, height: 1 };
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+      },
+      cancel,
+    });
+    request.mockResolvedValue(new Response(body, { status: 200, headers: { ...imageContractHeaders(), "x-systemsculpt-output-index": "0", "x-systemsculpt-content-sha256": metadata.sha256, "content-type": "image/png", "cache-control": "no-store, max-age=0", "x-content-type-options": "nosniff", "content-disposition": "attachment; filename=\"systemsculpt-image-0.png\"" } }));
+
+    await expect(client.images.downloadOutput("123e4567-e89b-42d3-a456-426614174000", 0, metadata)).rejects.toMatchObject({
+      code: "malformed_response",
+      message: "Managed image output exceeded expected size.",
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["truncated", new Uint8Array([1])],
+    ["empty", null],
+  ])("rejects a %s managed image body after bounded reading", async (_label, body) => {
+    const metadata = { index: 0, mime_type: "image/png" as const, size_bytes: 2, sha256: "a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222", width: 1, height: 1 };
+    request.mockResolvedValue(new Response(body, { status: 200, headers: { ...imageContractHeaders(), "x-systemsculpt-output-index": "0", "x-systemsculpt-content-sha256": metadata.sha256, "content-type": "image/png", "cache-control": "no-store, max-age=0", "x-content-type-options": "nosniff", "content-disposition": "attachment; filename=\"systemsculpt-image-0.png\"" } }));
+
+    await expect(client.images.downloadOutput("123e4567-e89b-42d3-a456-426614174000", 0, metadata)).rejects.toMatchObject({
+      code: "malformed_response",
+      message: "Managed image output integrity mismatch.",
+    });
+  });
+
+  it("rejects a redirect response instead of interpreting it as image bytes", async () => {
+    const metadata = { index: 0, mime_type: "image/png" as const, size_bytes: 2, sha256: "a".repeat(64), width: 1, height: 1 };
+    request.mockResolvedValue(new Response(null, { status: 302, headers: { ...imageContractHeaders() } }));
+
+    await expect(client.images.downloadOutput("123e4567-e89b-42d3-a456-426614174000", 0, metadata)).rejects.toMatchObject({
+      code: "malformed_response",
+    });
+  });
+
   it.each([
     ["content length", { "content-length": "1" }, "content-length"], ["content type", { "content-type": "image/jpeg" }, "content-type"],
     ["index", { "x-systemsculpt-output-index": "1" }, "x-systemsculpt-output-index"], ["hash header", { "x-systemsculpt-content-sha256": "b".repeat(64) }, "x-systemsculpt-content-sha256"],

--- a/src/services/managed/adapters/HostedTransportAdapter.ts
+++ b/src/services/managed/adapters/HostedTransportAdapter.ts
@@ -1,6 +1,6 @@
 import { PlatformRequestClient, type PlatformRequestInput } from "../../PlatformRequestClient";
 import {
-  MANAGED_ADMISSION_CONTRACT, MANAGED_CAPABILITY_CONTRACT,
+  MANAGED_ADMISSION_CONTRACT, MANAGED_CAPABILITY_CONTRACT, MANAGED_IMAGE_OUTPUT_MAX_BYTES,
   ManagedServerOutcome, ManagedTransportOperation, ManagedTransportResult,
 } from "../ManagedTypes";
 import { ManagedCapabilityCatalog } from "../ManagedCapabilityCatalog";
@@ -80,11 +80,11 @@ export class HostedTransportAdapter {
     return this.send(
       { path, method: "GET", headers, signal },
       headers, false, true, undefined, false,
-      { transport: "requestUrl", responseEncoding: "arrayBuffer" },
+      { transport: "requestUrl", responseEncoding: "arrayBuffer", maxResponseBytes: MANAGED_IMAGE_OUTPUT_MAX_BYTES },
     );
   }
 
-  private async send(operation: ManagedTransportOperation, extra: Record<string, string> = {}, stream = false, scopedHeaders = false, managedChatConfiguration?: ManagedChatConfiguration, readErrorBody = true, requestOverrides: Pick<PlatformRequestInput, "transport" | "responseEncoding"> = {}): Promise<ManagedTransportResult> {
+  private async send(operation: ManagedTransportOperation, extra: Record<string, string> = {}, stream = false, scopedHeaders = false, managedChatConfiguration?: ManagedChatConfiguration, readErrorBody = true, requestOverrides: Pick<PlatformRequestInput, "transport" | "responseEncoding" | "maxResponseBytes"> = {}): Promise<ManagedTransportResult> {
     const pluginVersion = managedChatConfiguration?.pluginVersion ?? this.options.pluginVersion;
     const headers: Record<string, string> = scopedHeaders ? { ...extra } : { "x-plugin-version": pluginVersion, ...extra };
     if (!extra["x-systemsculpt-admission-contract"]) headers["x-systemsculpt-contract"] = MANAGED_CAPABILITY_CONTRACT;

--- a/src/studio/__tests__/studio-systemsculpt-api-adapter.test.ts
+++ b/src/studio/__tests__/studio-systemsculpt-api-adapter.test.ts
@@ -1,3 +1,7 @@
+import { createHash } from "node:crypto";
+import { ManagedJobClient, MANAGED_JOB_PROTOCOL } from "../../services/managed/ManagedJobClient";
+import { HostedTransportAdapter } from "../../services/managed/adapters/HostedTransportAdapter";
+import { StudioAssetStore } from "../StudioAssetStore";
 import { StudioApiExecutionAdapter } from "../StudioApiExecutionAdapter";
 
 function createPlugin() {
@@ -111,6 +115,82 @@ describe("StudioApiExecutionAdapter managed cutover", () => {
       text: "transcript",
       operation: { capability: "transcription", operationId: "studio-transcription-run-1-transcription-a" },
     });
+  });
+
+  it("downloads a chunked managed image and saves the verified bytes through Studio output storage", async () => {
+    const png = Uint8Array.from(Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9slt4d8AAAAASUVORK5CYII=", "base64"));
+    const sha256 = createHash("sha256").update(png).digest("hex");
+    const metadata = { index: 0, mime_type: "image/png" as const, size_bytes: png.byteLength, sha256, width: 1, height: 1 };
+    const request = jest.fn(async () => new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(png.subarray(0, 17));
+        controller.enqueue(png.subarray(17));
+        controller.close();
+      },
+    }), { headers: {
+      "x-request-id": "req-studio-image",
+      "x-systemsculpt-contract": "managed-capabilities-v2",
+      "x-systemsculpt-job-contract": MANAGED_JOB_PROTOCOL,
+      "x-systemsculpt-image-output-contract": "managed-image-output-v1",
+      "x-systemsculpt-capability": "image_generation",
+      "x-systemsculpt-output-index": "0",
+      "x-systemsculpt-content-sha256": sha256,
+      "content-type": "image/png",
+      "cache-control": "no-store, max-age=0",
+      "x-content-type-options": "nosniff",
+      "content-disposition": "attachment; filename=\"systemsculpt-image-0.png\"",
+    } }));
+    const jobs = new ManagedJobClient(
+      new HostedTransportAdapter({
+        baseUrl: "https://systemsculpt.test",
+        pluginVersion: "6.2.2",
+        licenseKey: () => "license",
+        requestClient: { request } as never,
+      }),
+      undefined,
+      () => "req-studio-image",
+    );
+    const downloaded = await jobs.images.downloadOutput("123e4567-e89b-42d3-a456-426614174000", 0, metadata);
+    const putAsset = jest.fn(async () => undefined);
+    const assetStore = new StudioAssetStore({
+      loadProject: jest.fn(async () => ({ projectId: "studio-project" })),
+      putAsset,
+    } as never);
+    const { plugin } = createPlugin();
+    const adapter = new StudioApiExecutionAdapter(plugin as never);
+    Object.assign(adapter as object, {
+      images: {
+        generate: jest.fn(async () => ({
+          operationId: "studio-image-run-1-image-a",
+          jobId: "123e4567-e89b-42d3-a456-426614174000",
+          outputs: [downloaded],
+        })),
+      },
+    });
+
+    const result = await adapter.generateImage({
+      runId: "run-1",
+      nodeId: "image-a",
+      projectPath: "SystemSculpt/Studio/New Studio Project.systemsculpt",
+      signal: new AbortController().signal,
+      buildPayload: async () => ({ prompt: "Draw" }),
+      storeOutput: (bytes, mimeType) => assetStore.storeArrayBuffer(
+        "SystemSculpt/Studio/New Studio Project.systemsculpt",
+        bytes,
+        mimeType,
+      ),
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0]).toMatchObject({ hash: sha256, mimeType: "image/png", sizeBytes: png.byteLength });
+    expect(putAsset).toHaveBeenCalledWith(
+      "SystemSculpt/Studio/New Studio Project.systemsculpt",
+      "studio-project",
+      expect.objectContaining({
+        contentAddressedPath: `${sha256.slice(0, 2)}/${sha256}.png`,
+        bytes: png,
+      }),
+    );
   });
 
   it("finalizes published transcription records while preserving image cleanup", async () => {


### PR DESCRIPTION
## What changed

- Accept a missing `Content-Length` on managed image output responses when every other managed contract header is valid.
- Read the body through an exact-size bounded reader, then verify SHA-256 before Studio stores the image.
- Reject malformed or conflicting declared lengths, actual oversize, truncation, empty bodies, wrong hashes, redirects, and aborts.
- Apply the existing 30 MiB maximum to the native Obsidian binary transport before reconstructing another response body.
- Add an end-to-end Studio regression that downloads a chunked PNG and stores the verified bytes at the expected content-addressed path.

## Root cause

Cloudflare can legitimately deliver a streamed response using chunked transfer encoding without exposing `Content-Length`. The plugin rejected that response before reading it, even though managed job metadata already carried the exact byte count and SHA-256 digest.

This keeps strict status, MIME, size, disposition, contract-header, and hash validation. It does not trust arbitrary bytes or switch to an unbounded read.

## Compatibility

The companion server PR restores a fixed `Content-Length` for released clients. This client change also handles current chunked responses safely, so old-client/new-server and new-client/old-server combinations remain compatible.

## Verification

- `mise exec node@22 -- npm run check:full`
- 329 unit suites, 4,060 tests
- 27 embeddings suites, 234 tests
- 6 compiled integration suites, 32 tests
- 17 release-artifact tests
- Production desktop and mobile bundle loading
- Studio chunked PNG download and content-addressed output persistence
