### PR TITLE
docs: align mobile QA with deterministic release gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,14 +120,14 @@ The watcher copies main.js, manifest.json, and styles.css after successful
 builds. Use the official Obsidian CLI or Computer Use for live reload, errors,
 DOM inspection, and visual verification.
 
-For a mobile-sensitive change, automated checks are necessary but not final
-proof. Sync the exact built main.js, manifest.json, and styles.css into a real
-Obsidian Mobile vault, verify their hashes, then exercise settings, Chat,
-Similar Notes, Studio portable and blocked nodes, commands, modals, and fixed
-transients. Cover portrait and landscape, keyboard open and closed, light and
-dark themes, enlarged interface text, and phone plus tablet or equivalent
-widths. Record which Android/iOS hosts were physically tested; desktop mobile
-emulation does not count as native-host proof.
+For mobile-sensitive changes, npm run check:mobile and npm run check:full are
+the release gates. They validate the exact built main.js, manifest.json, and
+styles.css across narrow-pane, touch, keyboard, accessibility, and Studio
+capability scenarios with desktop adapters unavailable. Simulator, emulator,
+browser-emulation, or physical-device runs may provide supplemental evidence
+when explicitly requested, but they are not release gates and must not replace
+or weaken the deterministic checks. Record the host and artifact hashes when
+manual mobile exploration is performed.
 
 ## Product contracts
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -63,19 +63,19 @@ CI is one secret-free Ubuntu/Node 22 job running npm run check:ci.
    surfaces are checked as the exact three-file plugin artifact.
 4. Full unit, managed API fixture, embeddings, integration, artifact, and
    release tests run through npm run check:ci on every PR.
-5. A mobile-sensitive release uses that exact artifact on real Obsidian Mobile
-   hardware. Record hashes, host OS and Obsidian versions, phone and tablet
-   coverage, orientation, software keyboard, themes, enlarged interface text,
-   and the exercised surfaces.
+5. When explicitly requested, the exact artifact may also be explored on real
+   Obsidian Mobile hardware. Record hashes, host OS and Obsidian versions, phone
+   and tablet coverage, orientation, software keyboard, themes, enlarged
+   interface text, and the exercised surfaces.
 
-The first four layers are deterministic compatibility and interaction
-evidence. They deliberately avoid Android emulators, iOS Simulator,
+The first four layers are the deterministic compatibility and interaction
+release gate. They deliberately avoid Android emulators, iOS Simulator,
 self-hosted device runners, and browser mobile emulation. This repository does
 not own an iOS app target for Simulator or an APK or IPA for a device farm.
 Android emulation adds a nonphysical host, boot, storage-sync, and WebView
 debugging lane that has not been reproducible in hosted CI. Browser emulation
-reproduces viewport and touch inputs, not the installed Obsidian host. None of
-these alternatives substitutes for the physical-device release gate.
+reproduces viewport and touch inputs, not the installed Obsidian host. These
+manual alternatives are supplemental evidence, not release requirements.
 
 ## Local API
 
@@ -103,12 +103,13 @@ npm run sync:local
 
 Successful builds copy main.js, manifest.json, and styles.css. Use the official
 Obsidian CLI or Computer Use to reload the plugin and verify real desktop UI.
-Mobile confidence comes from portable architecture, the exact built-bundle
-smoke, and real Obsidian Mobile verification. For mobile-sensitive changes,
-test the synced artifact in portrait and landscape, with the keyboard open and
-closed, light and dark themes, enlarged interface text, and phone plus tablet
-or equivalent widths. Verify the synced artifact hashes. No native-device CI
-harness is part of this repository.
+Mobile release confidence comes from portable architecture, focused
+interaction tests, and the exact built-bundle smoke. If manual mobile
+exploration is explicitly requested, test the synced artifact in portrait and
+landscape, with the keyboard open and closed, light and dark themes, enlarged
+interface text, and phone plus tablet or equivalent widths. Verify the synced
+artifact hashes. No native-device CI or mandatory manual-device gate is part of
+this repository.
 
 ## Release validation
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -57,12 +57,11 @@ then loads main.js from the exact production artifact with desktop adapters
 unavailable and checks that its compiled styles.css still contains the shared
 touch, safe-area, and narrow-surface rules.
 
-These deterministic layers are PR gates, but they are not a mobile device.
-Android emulators, iOS Simulator, browser viewport emulation, and synthetic DOM
-events do not count as proof of the installed Obsidian Mobile host. A
-mobile-sensitive release still requires the exact three built artifacts on
-physical Obsidian Mobile, with the hashes and scenarios recorded as described
-in AGENTS.md.
+These deterministic layers are the PR and release gates. They do not claim to
+be an installed Obsidian Mobile host. Android emulators, iOS Simulator, browser
+viewport emulation, synthetic DOM events, and physical-device exploration may
+provide supplemental evidence when explicitly requested, but they are not
+release requirements and must not replace or weaken the deterministic checks.
 
 ## Real-app verification
 


### PR DESCRIPTION
## What changed

- Make the deterministic Node 22 mobile artifact checks the explicit PR and release gate.
- Keep simulator, emulator, browser-emulation, and physical-device runs available as optional supplemental evidence when explicitly requested.
- Align `AGENTS.md`, development guidance, and the testing architecture so they no longer describe manual mobile-device work as mandatory.

## Why

The repository already enforces mobile compatibility through static policy, focused narrow-pane, touch, keyboard, accessibility, and Studio tests, plus compiled bundle loading with desktop adapters unavailable. The remaining prose still described physical-device QA as a required release gate, contradicting the approved deterministic contract.

## Verification

- `npm run check:full`
- 330 unit suites, 4,139 tests
- 27 embeddings suites, 234 tests
- 6 compiled integration suites, 33 tests
- 17 release artifact and build contract tests
