### PR TITLE
Wait for the development watcher to stop before reloading

### DIFF
--- a/scripts/dev-watcher-service.mjs
+++ b/scripts/dev-watcher-service.mjs
@@ -116,6 +116,30 @@ function requireMac(platform) {
   }
 }
 
+function sleepSync(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function waitForServiceToUnload(options) {
+  const {
+    serviceTarget,
+    runCommand,
+    sleep = sleepSync,
+    timeoutMs = 5_000,
+    pollIntervalMs = 50,
+  } = options;
+  const attempts = Math.max(1, Math.ceil(timeoutMs / pollIntervalMs));
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const result = runCommand("launchctl", ["print", serviceTarget], {
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    if (result?.error || result?.status !== 0) return;
+    sleep(pollIntervalMs);
+  }
+  throw new Error(`launchctl did not unload ${serviceTarget} within ${timeoutMs}ms.`);
+}
+
 export function installDevWatcherService(options = {}) {
   const root = path.resolve(String(options.root || process.cwd()));
   const configPath = resolveSyncConfigPath(options.configPath);
@@ -123,6 +147,7 @@ export function installDevWatcherService(options = {}) {
   const platform = options.platform || process.platform;
   const uid = options.uid ?? process.getuid?.();
   const runCommand = options.runCommand || spawnSync;
+  const sleep = options.sleep || sleepSync;
   requireMac(platform);
   if (!Number.isInteger(uid) || uid < 0) throw new Error("Unable to resolve the current macOS user.");
   if (!fs.existsSync(path.join(root, "run.sh"))) throw new Error(`run.sh is missing from ${root}.`);
@@ -140,12 +165,20 @@ export function installDevWatcherService(options = {}) {
   }));
 
   const domain = `gui/${uid}`;
-  runCommand("launchctl", ["bootout", `${domain}/${DEV_WATCHER_SERVICE_LABEL}`], {
+  const serviceTarget = `${domain}/${DEV_WATCHER_SERVICE_LABEL}`;
+  runCommand("launchctl", ["bootout", serviceTarget], {
     encoding: "utf8",
     stdio: "pipe",
   });
+  waitForServiceToUnload({
+    serviceTarget,
+    runCommand,
+    sleep,
+    timeoutMs: options.unloadTimeoutMs,
+    pollIntervalMs: options.unloadPollIntervalMs,
+  });
   checked("launchctl", ["bootstrap", domain, paths.plistPath], runCommand);
-  checked("launchctl", ["kickstart", "-k", `${domain}/${DEV_WATCHER_SERVICE_LABEL}`], runCommand);
+  checked("launchctl", ["kickstart", "-k", serviceTarget], runCommand);
   return { ...paths, root, configPath, domain };
 }
 

--- a/scripts/dev-watcher-service.test.mjs
+++ b/scripts/dev-watcher-service.test.mjs
@@ -44,6 +44,7 @@ test("install writes and bootstraps a per-user persistent watcher", (t) => {
   const calls = [];
   const runCommand = (command, args) => {
     calls.push([command, args]);
+    if (args[0] === "print") return { status: 113, stdout: "", stderr: "not found" };
     return { status: 0, stdout: "ok", stderr: "" };
   };
 
@@ -59,11 +60,86 @@ test("install writes and bootstraps a per-user persistent watcher", (t) => {
   assert.equal(fs.existsSync(result.plistPath), true);
   assert.deepEqual(calls.map(([, args]) => args[0]), [
     "bootout",
+    "print",
     "bootstrap",
     "kickstart",
   ]);
   assert.match(fs.readFileSync(result.plistPath, "utf8"), /--headless/);
   assert.match(fs.readFileSync(result.plistPath, "utf8"), /--sync-config/);
+});
+
+test("install waits for an asynchronous launchd bootout before bootstrapping", (t) => {
+  const root = tempRoot(t);
+  const home = path.join(root, "home");
+  const configPath = path.join(root, "systemsculpt-sync.config.json");
+  fs.writeFileSync(path.join(root, "run.sh"), "#!/usr/bin/env bash\n");
+  fs.writeFileSync(configPath, JSON.stringify({
+    pluginTargets: [{ path: path.join(root, "vault", ".obsidian", "plugins", "systemsculpt-ai") }],
+  }));
+  const calls = [];
+  let printCount = 0;
+  let sleepCount = 0;
+  const runCommand = (command, args) => {
+    calls.push([command, args]);
+    if (args[0] === "print") {
+      printCount += 1;
+      return printCount < 3
+        ? { status: 0, stdout: "still unloading", stderr: "" }
+        : { status: 113, stdout: "", stderr: "not found" };
+    }
+    return { status: 0, stdout: "ok", stderr: "" };
+  };
+
+  installDevWatcherService({
+    root,
+    home,
+    configPath,
+    platform: "darwin",
+    uid: 501,
+    runCommand,
+    sleep: () => {
+      sleepCount += 1;
+    },
+  });
+
+  assert.equal(printCount, 3);
+  assert.equal(sleepCount, 2);
+  assert.deepEqual(calls.map(([, args]) => args[0]), [
+    "bootout",
+    "print",
+    "print",
+    "print",
+    "bootstrap",
+    "kickstart",
+  ]);
+});
+
+test("install fails safely when launchd never completes the bootout", (t) => {
+  const root = tempRoot(t);
+  const home = path.join(root, "home");
+  const configPath = path.join(root, "systemsculpt-sync.config.json");
+  fs.writeFileSync(path.join(root, "run.sh"), "#!/usr/bin/env bash\n");
+  fs.writeFileSync(configPath, JSON.stringify({
+    pluginTargets: [{ path: path.join(root, "vault", ".obsidian", "plugins", "systemsculpt-ai") }],
+  }));
+  const calls = [];
+  const runCommand = (command, args) => {
+    calls.push([command, args]);
+    return { status: 0, stdout: "still unloading", stderr: "" };
+  };
+
+  assert.throws(() => installDevWatcherService({
+    root,
+    home,
+    configPath,
+    platform: "darwin",
+    uid: 501,
+    runCommand,
+    sleep: () => {},
+    unloadTimeoutMs: 3,
+    unloadPollIntervalMs: 1,
+  }), /did not unload.*within 3ms/);
+  assert.equal(calls.some(([, args]) => args[0] === "bootstrap"), false);
 });
 
 test("install refuses to run without an explicit local vault target", (t) => {

--- a/src/services/__tests__/EmbeddingsManager.emptyLifecycle.test.ts
+++ b/src/services/__tests__/EmbeddingsManager.emptyLifecycle.test.ts
@@ -144,6 +144,15 @@ function harness(initialContent: string) {
   };
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for embeddings lifecycle state.`);
+}
+
 describe("EmbeddingsManager local empty-note lifecycle", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -180,10 +189,7 @@ describe("EmbeddingsManager local empty-note lifecycle", () => {
     expect(state.manager.getStats()).toMatchObject({ processed: 0, needsProcessing: 1 });
     releaseLock();
     await heldLock;
-    await new Promise((resolve) => setTimeout(resolve, 450));
-    for (let attempt = 0; attempt < 20 && (state.request.mock.calls.length === 0 || state.manager.isCurrentlyProcessing()); attempt += 1) {
-      await Promise.resolve();
-    }
+    await waitFor(() => state.request.mock.calls.length > 0 && !state.manager.isCurrentlyProcessing());
 
     expect(state.request).toHaveBeenCalledTimes(1);
     expect(state.manager.getStats()).toMatchObject({ processed: 1, present: 1, needsProcessing: 0 });


### PR DESCRIPTION
Fixes the macOS launchd race reproduced while rebinding the persistent dev watcher after PR #304. The installer now polls the exact service target until bootout is complete, fails with a bounded timeout if launchd never unloads it, and only then bootstraps the replacement. Also replaces a timing-fragile embeddings lifecycle assertion that failed under the additional watcher load with a bounded state wait.\n\nVerified locally:\n- two consecutive real launchd reinstalls succeeded\n- node --test scripts/dev-watcher-service.test.mjs\n- npm run check:ci\n- 331 core suites / 4,144 tests\n- 27 embeddings suites / 234 tests\n- 6 compiled integration suites / 33 tests\n- 17 release-script tests