### PR TITLE
[codex] Preserve 6.2.7 release provenance through tag push

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -81,7 +81,9 @@ exact child Jest commands in
 structured provenance and artifact-inspection sidecars before uploading a
 failed gate. Successful release validation writes SHA-256, size, Git revision,
 dirty state, Node, platform, and architecture to
-`.cache/ci-evidence/release-provenance.json`.
+`.cache/ci-evidence/release-provenance-<version>.json`. The version-qualified
+release record is separate from the rolling CI build provenance, so the
+required pre-push gate cannot overwrite it while publishing the tag.
 
 Saved chat parsing fails closed. A malformed or truncated history is never
 reduced to a surviving prefix and sent as a new request. Direct loads show a

--- a/scripts/build-provenance.mjs
+++ b/scripts/build-provenance.mjs
@@ -144,16 +144,60 @@ export function writeJsonEvidence(filePath, value) {
   return resolvedPath;
 }
 
+function assertSafeRepositoryEvidencePath(root, outputPath) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(outputPath);
+  const relativePath = path.relative(resolvedRoot, resolvedPath);
+  if (
+    relativePath === ""
+    || relativePath === ".."
+    || relativePath.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new Error(`Evidence output must stay inside the repository: ${resolvedPath}`);
+  }
+
+  const segments = relativePath.split(path.sep);
+  let currentPath = resolvedRoot;
+  for (let index = 0; index < segments.length; index += 1) {
+    currentPath = path.join(currentPath, segments[index]);
+    let stats;
+    try {
+      stats = fs.lstatSync(currentPath);
+    } catch (error) {
+      if (error?.code === "ENOENT") return;
+      throw error;
+    }
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Evidence output path must not contain a symbolic link: ${currentPath}`);
+    }
+    const isDestination = index === segments.length - 1;
+    if (isDestination ? !stats.isFile() : !stats.isDirectory()) {
+      throw new Error(
+        `Evidence output path must contain only directories and a regular-file destination: ${currentPath}`,
+      );
+    }
+  }
+}
+
+function writeRepositoryJsonEvidence({ root, outputPath, value }) {
+  assertSafeRepositoryEvidencePath(root, outputPath);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  assertSafeRepositoryEvidencePath(root, outputPath);
+  replaceFileAtomically(outputPath, `${JSON.stringify(value, null, 2)}\n`);
+  return outputPath;
+}
+
 export function writeBuildProvenance(options = {}) {
   const root = path.resolve(options.root || process.cwd());
   const record = createBuildProvenance({ ...options, root });
-  const outputPath = options.outputPath || path.join(
+  const outputPath = path.resolve(options.outputPath || path.join(
     root,
     DEFAULT_CI_EVIDENCE_DIRECTORY,
     "release-provenance.json",
-  );
+  ));
   return Object.freeze({
-    path: writeJsonEvidence(outputPath, record),
+    path: writeRepositoryJsonEvidence({ root, outputPath, value: record }),
     record,
   });
 }
@@ -200,13 +244,17 @@ export function writeArtifactInspectionEvidence({
     inspection,
     recordedAt,
   });
-  const destination = outputPath || path.join(
+  const destination = path.resolve(outputPath || path.join(
     resolvedRoot,
     DEFAULT_CI_EVIDENCE_DIRECTORY,
     "plugin-artifact-inspection.json",
-  );
+  ));
   return Object.freeze({
-    path: writeJsonEvidence(destination, record),
+    path: writeRepositoryJsonEvidence({
+      root: resolvedRoot,
+      outputPath: destination,
+      value: record,
+    }),
     record,
   });
 }

--- a/scripts/build-provenance.test.mjs
+++ b/scripts/build-provenance.test.mjs
@@ -129,6 +129,76 @@ test("writes provenance and sanitized artifact inspection as atomic JSON sidecar
   });
 });
 
+test("repository evidence rejects traversal, symlinked parents, and nonregular destinations", (t) => {
+  const root = fixture(t);
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), "systemsculpt-evidence-outside-"));
+  t.after(() => fs.rmSync(outside, { recursive: true, force: true }));
+  const outsideSentinel = path.join(outside, "sentinel.txt");
+  fs.writeFileSync(outsideSentinel, "unchanged\n");
+
+  assert.throws(
+    () => writeBuildProvenance({
+      root,
+      outputPath: path.join(root, "..", "escaped.json"),
+      spawnSyncImpl: gitFixture,
+    }),
+    /must stay inside the repository/,
+  );
+
+  fs.symlinkSync(outside, path.join(root, ".cache"), "dir");
+  assert.throws(
+    () => writeBuildProvenance({
+      root,
+      version: "6.2.7",
+      outputPath: path.join(
+        root,
+        ".cache",
+        "ci-evidence",
+        "release-provenance-6.2.7.json",
+      ),
+      spawnSyncImpl: gitFixture,
+    }),
+    /must not contain a symbolic link/,
+  );
+  assert.equal(
+    fs.existsSync(path.join(outside, "ci-evidence", "release-provenance-6.2.7.json")),
+    false,
+  );
+  assert.equal(fs.readFileSync(outsideSentinel, "utf8"), "unchanged\n");
+
+  fs.rmSync(path.join(root, ".cache"));
+  fs.mkdirSync(path.join(root, ".cache", "ci-evidence"), { recursive: true });
+  const destination = path.join(
+    root,
+    ".cache",
+    "ci-evidence",
+    "release-provenance-6.2.7.json",
+  );
+  fs.symlinkSync(outsideSentinel, destination);
+  assert.throws(
+    () => writeBuildProvenance({
+      root,
+      version: "6.2.7",
+      outputPath: destination,
+      spawnSyncImpl: gitFixture,
+    }),
+    /must not contain a symbolic link/,
+  );
+  assert.equal(fs.readFileSync(outsideSentinel, "utf8"), "unchanged\n");
+
+  fs.rmSync(destination);
+  fs.mkdirSync(destination);
+  assert.throws(
+    () => writeBuildProvenance({
+      root,
+      version: "6.2.7",
+      outputPath: destination,
+      spawnSyncImpl: gitFixture,
+    }),
+    /regular-file destination/,
+  );
+});
+
 test("missing artifacts stay explicit in provenance instead of disappearing", (t) => {
   const root = fixture(t);
   fs.rmSync(path.join(root, "styles.css"));

--- a/scripts/release-plugin.mjs
+++ b/scripts/release-plugin.mjs
@@ -10,6 +10,7 @@ import {
 } from "./plugin-artifacts.mjs";
 import {
   createRepositoryScopedGitEnvironment,
+  DEFAULT_CI_EVIDENCE_DIRECTORY,
   writeBuildProvenance,
 } from "./build-provenance.mjs";
 
@@ -87,6 +88,11 @@ export function validateReleasePackage({
     root: resolvedRoot,
     version,
     kind: "release",
+    outputPath: path.join(
+      resolvedRoot,
+      DEFAULT_CI_EVIDENCE_DIRECTORY,
+      `release-provenance-${version}.json`,
+    ),
   });
   const releaseRevision = provenance?.record?.git?.revision;
   const releaseDirty = provenance?.record?.git?.dirty;

--- a/scripts/release-plugin.test.mjs
+++ b/scripts/release-plugin.test.mjs
@@ -10,6 +10,7 @@ import {
 } from "./release-plugin.mjs";
 import { CANONICAL_API_BASE_URL } from "./plugin-build-options.mjs";
 import { assertProductionPluginArtifacts } from "./plugin-artifacts.mjs";
+import { writeBuildProvenance } from "./build-provenance.mjs";
 
 function fixture(t, overrides = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "systemsculpt-release-"));
@@ -97,7 +98,44 @@ test("records provenance only after artifact validation succeeds", (t) => {
     },
   });
 
-  assert.deepEqual(calls, [{ root, version: "5.11.0", kind: "release" }]);
+  assert.deepEqual(calls, [{
+    root,
+    version: "5.11.0",
+    kind: "release",
+    outputPath: path.join(
+      root,
+      ".cache",
+      "ci-evidence",
+      "release-provenance-5.11.0.json",
+    ),
+  }]);
+});
+
+test("later CI evidence cannot overwrite versioned release provenance", (t) => {
+  const root = fixture(t);
+  const release = validateFixtureRelease({ root });
+  const before = fs.readFileSync(release.provenance.path, "utf8");
+
+  const ci = writeBuildProvenance({
+    root,
+    version: "5.11.0",
+    kind: "ci-build",
+    spawnSyncImpl: () => ({ status: 1, stdout: "" }),
+  });
+
+  assert.equal(
+    release.provenance.path,
+    path.join(
+      root,
+      ".cache",
+      "ci-evidence",
+      "release-provenance-5.11.0.json",
+    ),
+  );
+  assert.notEqual(ci.path, release.provenance.path);
+  assert.equal(JSON.parse(fs.readFileSync(ci.path, "utf8")).kind, "ci-build");
+  assert.equal(fs.readFileSync(release.provenance.path, "utf8"), before);
+  assert.equal(JSON.parse(before).kind, "release");
 });
 
 test("release identity can require one clean full revision and matching tag", (t) => {

--- a/testing/README.md
+++ b/testing/README.md
@@ -81,7 +81,9 @@ Before a failed hosted gate uploads artifacts, CI validates that build
 provenance and artifact-inspection sidecars exist and are valid JSON.
 Release validation records SHA-256 and size for every shipped byte plus source
 revision and build-environment identity without changing the three-file plugin
-artifact contract.
+artifact contract. It writes a version-qualified release record alongside the
+rolling CI provenance so the tag-push gate cannot overwrite the release
+evidence.
 
 The installed pre-push hook runs check:ci. The workflow and package-script
 policy tests prevent local and hosted gate definitions from silently drifting.


### PR DESCRIPTION
## Summary

Preserve authoritative, version-specific release provenance through the tag-push gate before publishing plugin 6.2.7.

The strict release command correctly produced a `kind: release` record, but the subsequent tag push reran `check:ci` and replaced the same generic path with `kind: ci-build`. Artifact bytes stayed deterministic, but the authoritative release evidence no longer survived the workflow that was supposed to protect it.

## Fix

- Write release evidence to `.cache/ci-evidence/release-provenance-<version>.json`.
- Keep rolling CI and failure evidence at the existing generic path expected by hosted verification.
- Require repository evidence outputs to remain inside the repository.
- Reject traversal, symlinked parent components, symlink destinations, and nonregular destinations.
- Revalidate the destination after directory creation before atomic replacement.
- Document the separate CI and release evidence lifecycles.

## Regression proof

- Release provenance is written to the exact semantic-version-qualified path.
- A later `ci-build` write updates only the generic CI sidecar.
- The versioned release record remains byte-for-byte unchanged.
- An ignored `.cache` symlink cannot redirect evidence outside the repository.
- Traversal, destination symlinks, and directory destinations fail closed.
- Outside sentinel bytes remain unchanged.

## Local verification for head `6c0c6eac`

- Full authorized pre-push `npm run check:ci`: passed.
- Mobile interaction lane: 135 tests passed.
- Critical ChatView lane: 322 tests passed.
- Curated mutation lane: 14 of 14 mutants killed.
- Unit remainder: 3,880 tests passed.
- Embeddings: 234 tests passed.
- Integration: 36 tests passed.
- Release, artifact, CSS, and provenance contract: 47 tests passed.
- Independent adversarial review: one symlink-parent escape reproduced and fixed, then no remaining finding.
- `git diff --check`: passed.

## Completed release safety

PR #311 merged as exact plugin `main` revision
`ab034d63462f99af1852a949bee6bd84d42a2c46`. Merged-main CI run
`30409680508` completed successfully across the exhaustive plugin job, Ubuntu
Node 20.10, Ubuntu Node 24, macOS Node 22, Windows Node 22, and the protected
aggregate `required` job.

The corrected lightweight tag `6.2.7` points directly to that exact commit.
The strict Node 22 release gate completed from clean merged `main`, and the
version-specific provenance record retained SHA-256
`9dd0d2a8078ac6d88123f42cb39400c2e48bce5ca015e9c9672283232afd8221`
through the full tag-push CI rerun.

Release 6.2.7 is published as GitHub's latest non-prerelease release with
exactly `main.js`, `manifest.json`, and `styles.css`. The draft assets, public
assets, and an independent third download all matched the authoritative
provenance hashes and sizes.

The live SystemSculpt latest-version endpoint reports 6.2.7. The exact public
assets were installed into the QA vault, and the real Obsidian fresh
server-search, disk save, full reload, replay-only follow-up, second reload,
network, all-level console, and saved-transcript acceptance passed without
HTTP 400, gateway warning, circuit update, historical search reexecution, or
persistence loss.

## Required gates

- [x] Hosted Linux, macOS, Windows, Node 20, Node 22, and Node 24 jobs pass
- [x] Aggregate protected `required` check passes
- [x] Comments, reviews, and inline threads are empty or resolved
- [x] Merged-main workflow passes before retagging
- [x] Corrected exact tag, strict release, publication, public re-download, live distribution, and target Obsidian acceptance pass
